### PR TITLE
Complete Phase 3: Ancestry module migration with ML fit/predict inter…

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1672,8 +1672,8 @@ Migrate GWAS module and remove deprecated code.
 |-------|--------|-----------------|
 | 0: Regression Testing | ✅ Complete | (enables validation) |
 | 1: Core Foundation | ✅ Complete | A1, P1, R1, R2, R3, D1, D2, D3 |
-| 2: QC Migration | Not Started | A1, A2, M1, M2, D1 |
-| 3: Ancestry Migration | Not Started | A2, M1, D1 |
+| 2: QC Migration | ✅ Complete | A1, A2, M1, M2, D1 |
+| 3: Ancestry Migration | ✅ Complete | A2, M1, D1 |
 | 4: CLI Migration | Not Started | A3, M3, C1 |
 | 5: GWAS & Cleanup | Not Started | - |
 
@@ -1708,3 +1708,82 @@ Migrate GWAS module and remove deprecated code.
 2. **Immutability**: GenotypeData is a frozen dataclass - transformations return new instances
 3. **Type hints**: Full type annotations with mypy --strict compliance
 4. **Backward compatibility**: Calls to existing untyped code use `# type: ignore[no-untyped-call]`
+
+---
+
+## Phase 3 Completion Notes
+
+**Completed:** 2026-01-22
+
+### Deliverables
+
+| File | Status | Description |
+|------|--------|-------------|
+| `ancestry/__init__.py` | ✅ | Public exports for all ancestry components |
+| `ancestry/config.py` | ✅ | Configuration dataclasses (PCAConfig, UMAPConfig, ClassifierConfig, AncestryConfig, etc.) |
+| `ancestry/results.py` | ✅ | Result dataclasses (AncestryPredictions, TrainingMetrics, PCAResult, etc.) |
+| `ancestry/reference.py` | ✅ | ReferencePanel management for loading reference data |
+| `ancestry/model.py` | ✅ | AncestryModel with fit/predict interface |
+| `ancestry/reducers/__init__.py` | ✅ | Reducer exports |
+| `ancestry/reducers/pca.py` | ✅ | PCAReducer with flashPCA-style scaling |
+| `ancestry/reducers/umap_reducer.py` | ✅ | UMAPReducer wrapper |
+
+### Success Criteria Met
+
+- [x] `AncestryModel` with `fit()` and `predict()` methods implemented
+- [x] All ancestry parameters documented in config.py (PCAConfig, UMAPConfig, ClassifierConfig, GridSearchConfig, etc.)
+- [x] Model can be saved/loaded with pickle
+- [x] InferenceMode enum for container/cloud support (LOCAL, CONTAINER, SINGULARITY, CLOUD)
+- [x] `mypy genotools/ancestry/ --ignore-missing-imports` passes
+- [x] Unit tests: 85 tests passing for config, results, and reducers
+
+### Key Design Decisions
+
+1. **Fit/predict interface**: Unlike QC's step composition, ancestry uses ML-style fit/predict pattern matching scikit-learn conventions
+2. **Frozen configurations**: All config dataclasses are immutable (frozen=True) with validation in `__post_init__`
+3. **FlashPCA scaling**: Preserved flashPCA-style scaling formula for backward compatibility with trained models
+4. **Separate reducers**: PCA and UMAP are separate reducer classes that can be used independently
+5. **Admixed detection**: CAH (Complex Admixture History) detection preserved from original implementation
+6. **Backward compatibility**: `to_dict()` methods on result classes return legacy dictionary format
+
+### New Module Structure
+
+```
+genotools/ancestry/
+├── __init__.py           # Public API exports
+├── config.py             # Configuration dataclasses (frozen, validated)
+├── model.py              # AncestryModel with fit/predict
+├── reference.py          # ReferencePanel loading
+├── results.py            # Result dataclasses
+└── reducers/
+    ├── __init__.py
+    ├── pca.py            # PCAReducer with flashPCA scaling
+    └── umap_reducer.py   # UMAPReducer wrapper
+```
+
+### Usage Example
+
+```python
+from genotools.ancestry import AncestryModel, AncestryConfig, PCAConfig
+
+# Custom configuration
+config = AncestryConfig(
+    pca=PCAConfig(n_components=30),
+    min_samples_per_ancestry=50
+)
+
+# Create model
+model = AncestryModel(config=config)
+
+# Fit on reference data
+model.fit(raw_ref_data, labels)
+
+# Predict ancestry
+predictions = model.predict(new_sample_data, sample_ids)
+print(predictions.ancestry_counts)
+# {'EUR': 100, 'AFR': 50, ...}
+
+# Save/load model
+model.save(Path("model.pkl"))
+loaded = AncestryModel.load(Path("model.pkl"))
+```

--- a/genotools/ancestry/__init__.py
+++ b/genotools/ancestry/__init__.py
@@ -1,0 +1,149 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Ancestry prediction module for GenoTools.
+
+This module provides a clean ML-pattern interface for ancestry prediction
+using PCA, UMAP, and XGBoost classification.
+
+Basic Usage:
+    >>> from genotools.ancestry import AncestryModel, ReferencePanel, AncestryConfig
+    >>>
+    >>> # Load reference panel
+    >>> ref = ReferencePanel.load(
+    ...     geno_path=Path("/path/to/ref_panel"),
+    ...     labels_path=Path("/path/to/labels.txt")
+    ... )
+    >>>
+    >>> # Create and train model
+    >>> model = AncestryModel()
+    >>> model.fit(ref)
+    >>>
+    >>> # Predict ancestry
+    >>> predictions = model.predict(test_data)
+    >>> print(predictions.ancestry_counts)
+    {'EUR': 100, 'AFR': 50, ...}
+    >>>
+    >>> # Save model for later use
+    >>> model.save(Path("model.pkl"))
+
+Configuration:
+    >>> from genotools.ancestry import AncestryConfig, PCAConfig
+    >>>
+    >>> # Custom configuration
+    >>> config = AncestryConfig(
+    ...     pca=PCAConfig(n_components=30),
+    ...     min_samples_per_ancestry=50
+    ... )
+    >>> model = AncestryModel(config=config)
+
+Inference Modes:
+    The module supports multiple inference modes for different environments:
+    - LOCAL: In-process Python execution (default)
+    - CONTAINER: Docker container with bundled model
+    - SINGULARITY: Singularity container for HPC environments
+    - CLOUD: Google Cloud AI Platform
+
+    >>> from genotools.ancestry import InferenceMode, InferenceConfig
+    >>> config = AncestryConfig(
+    ...     inference=InferenceConfig(mode=InferenceMode.CONTAINER)
+    ... )
+
+UMAP Version Note:
+    CRITICAL: This module requires umap-learn==0.5.3 for compatibility with
+    existing trained models. Models trained with different UMAP versions may
+    fail to load or produce incorrect predictions.
+"""
+
+# Configuration classes
+from genotools.ancestry.config import (
+    AncestryConfig,
+    PCAConfig,
+    UMAPConfig,
+    ClassifierConfig,
+    GridSearchConfig,
+    AdmixedConfig,
+    InferenceConfig,
+    TrainingConfig,
+    InferenceMode,
+    DEFAULT_ANCESTRY_LABELS,
+)
+
+# Result classes
+from genotools.ancestry.results import (
+    AncestryPredictions,
+    AncestryResult,
+    TrainingMetrics,
+    PCAResult,
+    UMAPResult,
+    SplitResult,
+)
+
+# Reference panel management
+from genotools.ancestry.reference import (
+    ReferencePanel,
+    get_default_model_path,
+    validate_model_files,
+)
+
+# Main model class
+from genotools.ancestry.model import (
+    AncestryModel,
+    load_trained_pipeline,
+)
+
+# Reducers (for advanced usage)
+from genotools.ancestry.reducers import (
+    PCAReducer,
+    UMAPReducer,
+    flashpca_scale,
+    run_pca,
+    run_umap,
+)
+
+
+__all__ = [
+    # Main classes
+    "AncestryModel",
+    "ReferencePanel",
+    # Configuration
+    "AncestryConfig",
+    "PCAConfig",
+    "UMAPConfig",
+    "ClassifierConfig",
+    "GridSearchConfig",
+    "AdmixedConfig",
+    "InferenceConfig",
+    "TrainingConfig",
+    "InferenceMode",
+    "DEFAULT_ANCESTRY_LABELS",
+    # Results
+    "AncestryPredictions",
+    "AncestryResult",
+    "TrainingMetrics",
+    "PCAResult",
+    "UMAPResult",
+    "SplitResult",
+    # Utilities
+    "get_default_model_path",
+    "validate_model_files",
+    "load_trained_pipeline",
+    # Reducers
+    "PCAReducer",
+    "UMAPReducer",
+    "flashpca_scale",
+    "run_pca",
+    "run_umap",
+]

--- a/genotools/ancestry/config.py
+++ b/genotools/ancestry/config.py
@@ -1,0 +1,412 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Ancestry prediction configuration dataclasses.
+
+This module provides typed configuration for the ancestry prediction pipeline,
+including PCA, UMAP dimensionality reduction, and XGBoost classification.
+
+CRITICAL: umap-learn must be pinned to version 0.5.3 for model compatibility.
+Old pickled models may fail with newer UMAP versions.
+See requirements.txt: umap-learn==0.5.3
+
+Example:
+    >>> from genotools.ancestry.config import AncestryConfig
+    >>> config = AncestryConfig()
+    >>> config.pca.n_components
+    50
+    >>> # Custom configuration
+    >>> custom_config = AncestryConfig(
+    ...     pca=PCAConfig(n_components=20),
+    ...     classifier=ClassifierConfig(n_estimators=200)
+    ... )
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Tuple
+
+from genotools.core.config import BaseConfig, ThresholdConfig
+
+
+class InferenceMode(Enum):
+    """Ancestry inference execution modes.
+
+    Determines where the prediction computation runs:
+    - LOCAL: In-process Python execution (default)
+    - CONTAINER: Docker container with bundled model
+    - SINGULARITY: Singularity container for HPC environments
+    - CLOUD: Google Cloud AI Platform prediction
+    """
+
+    LOCAL = "local"
+    CONTAINER = "container"
+    SINGULARITY = "singularity"
+    CLOUD = "cloud"
+
+
+# Default ancestry labels supported by GenoTools
+# These are the 10 labels from the current implementation
+DEFAULT_ANCESTRY_LABELS: Tuple[str, ...] = (
+    "AFR",  # African
+    "SAS",  # South Asian
+    "EAS",  # East Asian
+    "EUR",  # European
+    "AMR",  # American/Latino (admixed)
+    "AJ",   # Ashkenazi Jewish
+    "CAS",  # Central Asian
+    "MDE",  # Middle Eastern
+    "FIN",  # Finnish
+    "AAC",  # African American (admixed)
+)
+
+
+@dataclass(frozen=True)
+class PCAConfig(ThresholdConfig):
+    """Configuration for PCA dimensionality reduction.
+
+    PCA is the first step in the ancestry prediction pipeline. It reduces
+    the high-dimensional genotype data to a smaller set of principal
+    components that capture population structure.
+
+    The default of 50 components provides sufficient resolution for
+    distinguishing 10 ancestry groups while maintaining computational
+    efficiency.
+
+    Attributes:
+        n_components: Number of principal components to compute.
+            More components capture more variance but increase computation
+            time. Default is 50 (matching current implementation).
+        maf: Minor allele frequency threshold for variant filtering before PCA.
+            Variants with MAF < threshold are excluded. Default is 0.01.
+        geno: Variant missingness threshold. Variants with missing rate
+            > threshold are excluded before PCA. Default is 0.1.
+        hwe: Hardy-Weinberg equilibrium p-value threshold. Variants with
+            HWE p < threshold are excluded. Default is 5e-6.
+        random_state: Random seed for reproducibility. Default is 123.
+    """
+
+    n_components: int = 50
+    maf: float = 0.01
+    geno: float = 0.1
+    hwe: float = 5e-6
+    random_state: int = 123
+
+    def __post_init__(self) -> None:
+        """Validate PCA configuration."""
+        if self.n_components < 2:
+            raise ValueError(
+                f"n_components must be >= 2, got {self.n_components}"
+            )
+        if self.n_components > 1000:
+            raise ValueError(
+                f"n_components must be <= 1000, got {self.n_components}"
+            )
+        self._validate_proportion(self.maf, "maf")
+        self._validate_proportion(self.geno, "geno")
+        # HWE can be very small, so allow scientific notation range
+        if self.hwe <= 0 or self.hwe > 1:
+            raise ValueError(
+                f"hwe must be in (0, 1], got {self.hwe}"
+            )
+
+
+@dataclass(frozen=True)
+class UMAPConfig(ThresholdConfig):
+    """Configuration for UMAP dimensionality reduction.
+
+    UMAP (Uniform Manifold Approximation and Projection) is used to further
+    reduce the PCA components while preserving local structure. This makes
+    the ancestry clusters more separable for classification.
+
+    CRITICAL: Requires umap-learn==0.5.3 for model compatibility. Models
+    trained with one UMAP version may not load correctly with another.
+
+    The parameters below are the GridSearchCV hyperparameter ranges from
+    the current implementation. Final values are determined during training.
+
+    Attributes:
+        n_neighbors: Number of neighbors for local structure. Higher values
+            capture more global structure. Default is 15 (UMAP default).
+        n_components: Output dimensionality. Default is 2 for visualization,
+            but grid search may select higher values.
+        min_dist: Minimum distance between points in embedding. Lower values
+            allow tighter clusters. Default is 0.1.
+        metric: Distance metric. Default is "euclidean".
+        a: UMAP curve parameter controlling how tight clusters form.
+            Default is None (UMAP calculates from spread).
+        b: UMAP curve parameter controlling cluster density.
+            Default is None (UMAP calculates from min_dist).
+        random_state: Random seed for reproducibility. Default is 123.
+    """
+
+    n_neighbors: int = 15
+    n_components: int = 2
+    min_dist: float = 0.1
+    metric: str = "euclidean"
+    a: Optional[float] = None
+    b: Optional[float] = None
+    random_state: int = 123
+
+    def __post_init__(self) -> None:
+        """Validate UMAP configuration."""
+        if self.n_neighbors < 2:
+            raise ValueError(
+                f"n_neighbors must be >= 2, got {self.n_neighbors}"
+            )
+        if self.n_components < 1:
+            raise ValueError(
+                f"n_components must be >= 1, got {self.n_components}"
+            )
+        self._validate_proportion(self.min_dist, "min_dist", 0.0, 1.0)
+        if self.a is not None and self.a <= 0:
+            raise ValueError(f"a must be positive, got {self.a}")
+        if self.b is not None and self.b <= 0:
+            raise ValueError(f"b must be positive, got {self.b}")
+
+
+@dataclass(frozen=True)
+class ClassifierConfig(ThresholdConfig):
+    """Configuration for XGBoost classifier.
+
+    The classifier predicts ancestry labels from the UMAP embedding.
+    Uses XGBoost with linear booster (gblinear) for efficiency and
+    interpretability.
+
+    Hyperparameter ranges from current implementation's GridSearchCV:
+    - lambda: [10^-3, 10^-2, 10^-1, 1, 10, 100]
+    - n_neighbors (UMAP): [5, 20]
+    - n_components (UMAP): [15, 25]
+    - a (UMAP): [0.75, 1.0, 1.5]
+    - b (UMAP): [0.25, 0.5, 0.75]
+
+    Attributes:
+        n_estimators: Number of boosting rounds. Default is 100.
+        max_depth: Maximum tree depth. Not used with gblinear booster.
+            Default is 6 for tree boosters.
+        learning_rate: Step size shrinkage. Default is 0.1.
+        booster: Boosting algorithm. Default is "gblinear" for linear
+            booster matching current implementation.
+        reg_lambda: L2 regularization term. Default is 1.0.
+        random_state: Random seed for reproducibility. Default is 123.
+    """
+
+    n_estimators: int = 100
+    max_depth: int = 6
+    learning_rate: float = 0.1
+    booster: str = "gblinear"
+    reg_lambda: float = 1.0
+    random_state: int = 123
+
+    def __post_init__(self) -> None:
+        """Validate classifier configuration."""
+        if self.n_estimators < 1:
+            raise ValueError(
+                f"n_estimators must be >= 1, got {self.n_estimators}"
+            )
+        if self.max_depth < 1:
+            raise ValueError(
+                f"max_depth must be >= 1, got {self.max_depth}"
+            )
+        self._validate_positive(self.learning_rate, "learning_rate")
+        if self.booster not in ("gbtree", "gblinear", "dart"):
+            raise ValueError(
+                f"booster must be 'gbtree', 'gblinear', or 'dart', "
+                f"got '{self.booster}'"
+            )
+
+
+@dataclass(frozen=True)
+class GridSearchConfig(BaseConfig):
+    """Configuration for hyperparameter grid search.
+
+    Controls the grid search parameters used during model training.
+    These are the exact parameter ranges from the current implementation.
+
+    Attributes:
+        umap_n_neighbors: Grid values for UMAP n_neighbors. Default is (5, 20).
+        umap_n_components: Grid values for UMAP n_components. Default is (15, 25).
+        umap_a: Grid values for UMAP a parameter. Default is (0.75, 1.0, 1.5).
+        umap_b: Grid values for UMAP b parameter. Default is (0.25, 0.5, 0.75).
+        xgb_lambda: Grid values for XGBoost L2 regularization.
+            Default is powers of 10 from 10^-3 to 10^2.
+        cv_folds: Number of cross-validation folds. Default is 5.
+        scoring: Scoring metric for grid search. Default is "balanced_accuracy".
+    """
+
+    umap_n_neighbors: Tuple[int, ...] = (5, 20)
+    umap_n_components: Tuple[int, ...] = (15, 25)
+    umap_a: Tuple[float, ...] = (0.75, 1.0, 1.5)
+    umap_b: Tuple[float, ...] = (0.25, 0.5, 0.75)
+    xgb_lambda: Tuple[float, ...] = (0.001, 0.01, 0.1, 1.0, 10.0, 100.0)
+    cv_folds: int = 5
+    scoring: str = "balanced_accuracy"
+
+    def __post_init__(self) -> None:
+        """Validate grid search configuration."""
+        if self.cv_folds < 2:
+            raise ValueError(
+                f"cv_folds must be >= 2, got {self.cv_folds}"
+            )
+        if not self.umap_n_neighbors:
+            raise ValueError("umap_n_neighbors cannot be empty")
+        if not self.umap_n_components:
+            raise ValueError("umap_n_components cannot be empty")
+
+
+@dataclass(frozen=True)
+class AdmixedConfig(ThresholdConfig):
+    """Configuration for admixed sample detection.
+
+    Samples that don't clearly belong to a single ancestry group are
+    classified as "Complex Admixture History" (CAH). This is determined
+    by measuring the distance to each ancestry's centroid in PC space.
+
+    Samples closest to the global centroid (ALL) rather than any specific
+    ancestry centroid are classified as CAH.
+
+    Attributes:
+        n_clusters_cas: Number of Birch clusters for CAS (Central Asian)
+            splitting. CAS shows bimodal distribution, so it's split into
+            CAS and CAS2 subclusters. Default is 2.
+        birch_threshold: Birch clustering threshold. Default is None
+            (use sklearn default).
+    """
+
+    n_clusters_cas: int = 2
+    birch_threshold: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        """Validate admixed detection configuration."""
+        if self.n_clusters_cas < 1:
+            raise ValueError(
+                f"n_clusters_cas must be >= 1, got {self.n_clusters_cas}"
+            )
+
+
+@dataclass(frozen=True)
+class InferenceConfig(BaseConfig):
+    """Configuration for ancestry inference execution.
+
+    Controls where and how the prediction computation runs. Supports
+    local execution, Docker containers, Singularity containers (for HPC),
+    and Google Cloud AI Platform.
+
+    Attributes:
+        mode: Execution mode (local, container, singularity, cloud).
+            Default is LOCAL.
+        container_image: Docker/Singularity image name for container modes.
+            Default is the official GenoTools ancestry image.
+        cloud_project: Google Cloud project ID for cloud mode.
+        cloud_region: Google Cloud region for cloud mode.
+            Default is "us-central1".
+        cloud_endpoint: Cloud AI Platform endpoint ID for cloud mode.
+    """
+
+    mode: InferenceMode = InferenceMode.LOCAL
+    container_image: str = "mkoretsky1/genotools_ancestry:python3.11"
+    cloud_project: Optional[str] = None
+    cloud_region: str = "us-central1"
+    cloud_endpoint: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Validate inference configuration."""
+        if self.mode == InferenceMode.CLOUD:
+            if not self.cloud_project:
+                raise ValueError(
+                    "cloud_project is required when mode is CLOUD"
+                )
+
+
+@dataclass(frozen=True)
+class TrainingConfig(BaseConfig):
+    """Configuration for model training.
+
+    Controls the training process including train/test split and
+    resource allocation.
+
+    Attributes:
+        test_size: Proportion of reference samples for testing.
+            Default is 0.2 (20% test, 80% train).
+        random_state: Random seed for train/test split. Default is 123.
+        n_jobs: Number of parallel jobs for grid search. None means
+            auto-detect based on available resources. Default is None.
+        gb_per_worker: Memory per worker for job calculation.
+            Default is 3 GB.
+    """
+
+    test_size: float = 0.2
+    random_state: int = 123
+    n_jobs: Optional[int] = None
+    gb_per_worker: float = 3.0
+
+    def __post_init__(self) -> None:
+        """Validate training configuration."""
+        if self.test_size <= 0 or self.test_size >= 1:
+            raise ValueError(
+                f"test_size must be in (0, 1), got {self.test_size}"
+            )
+
+
+@dataclass(frozen=True)
+class AncestryConfig(BaseConfig):
+    """Full ancestry prediction configuration.
+
+    This is the top-level configuration class that combines all
+    sub-configurations for the ancestry prediction pipeline.
+
+    Example:
+        >>> config = AncestryConfig()
+        >>> config.pca.n_components
+        50
+        >>> # With custom settings
+        >>> config = AncestryConfig(
+        ...     pca=PCAConfig(n_components=20),
+        ...     inference=InferenceConfig(mode=InferenceMode.CONTAINER)
+        ... )
+
+    Attributes:
+        pca: PCA dimensionality reduction configuration.
+        umap: UMAP configuration (defaults used if grid searching).
+        classifier: XGBoost classifier configuration.
+        grid_search: Hyperparameter grid search configuration.
+        admixed: Admixed sample detection configuration.
+        inference: Inference execution configuration.
+        training: Model training configuration.
+        labels: Supported ancestry labels. Default includes all 10 labels.
+        min_samples_per_ancestry: Minimum samples required per ancestry
+            to include in output. Groups below this are pruned.
+            Default is 0 (include all).
+    """
+
+    pca: PCAConfig = field(default_factory=PCAConfig)
+    umap: UMAPConfig = field(default_factory=UMAPConfig)
+    classifier: ClassifierConfig = field(default_factory=ClassifierConfig)
+    grid_search: GridSearchConfig = field(default_factory=GridSearchConfig)
+    admixed: AdmixedConfig = field(default_factory=AdmixedConfig)
+    inference: InferenceConfig = field(default_factory=InferenceConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+    labels: Tuple[str, ...] = DEFAULT_ANCESTRY_LABELS
+    min_samples_per_ancestry: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate ancestry configuration."""
+        if not self.labels:
+            raise ValueError("labels cannot be empty")
+        if self.min_samples_per_ancestry < 0:
+            raise ValueError(
+                f"min_samples_per_ancestry must be >= 0, "
+                f"got {self.min_samples_per_ancestry}"
+            )

--- a/genotools/ancestry/model.py
+++ b/genotools/ancestry/model.py
@@ -1,0 +1,644 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Ancestry prediction model with fit/predict interface.
+
+This module provides the AncestryModel class which implements a scikit-learn
+style fit/predict interface for ancestry prediction. The model uses:
+
+1. PCA for initial dimensionality reduction
+2. UMAP for manifold learning
+3. XGBoost for classification
+
+Example:
+    >>> from genotools.ancestry.model import AncestryModel
+    >>> from genotools.ancestry.reference import ReferencePanel
+    >>>
+    >>> # Load reference panel
+    >>> ref = ReferencePanel.load(ref_path, labels_path)
+    >>>
+    >>> # Create and train model
+    >>> model = AncestryModel()
+    >>> model.fit(ref)
+    >>>
+    >>> # Predict ancestry
+    >>> predictions = model.predict(test_data)
+    >>> predictions.ancestry_counts
+    {'EUR': 100, 'AFR': 50, ...}
+    >>>
+    >>> # Save and load model
+    >>> model.save(Path("model.pkl"))
+    >>> loaded = AncestryModel.load(Path("model.pkl"))
+"""
+
+import logging
+import os
+import pickle
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+import psutil
+from sklearn import preprocessing
+from sklearn.cluster import Birch
+from sklearn.model_selection import GridSearchCV, StratifiedKFold, train_test_split
+from sklearn.pipeline import Pipeline
+from umap import UMAP
+from xgboost import XGBClassifier
+
+from genotools.ancestry.config import (
+    AncestryConfig,
+    InferenceMode,
+    PCAConfig,
+)
+from genotools.ancestry.reducers.pca import PCAReducer
+from genotools.ancestry.reducers.umap_reducer import UMAPReducer
+from genotools.ancestry.results import (
+    AncestryPredictions,
+    AncestryResult,
+    PCAResult,
+    SplitResult,
+    TrainingMetrics,
+    UMAPResult,
+)
+from genotools.core.exceptions import AncestryError
+from genotools.core.genotypes import GenotypeData
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AncestryModel:
+    """Ancestry prediction model with fit/predict interface.
+
+    This class provides a scikit-learn style interface for ancestry prediction.
+    The model combines PCA, UMAP, and XGBoost into a prediction pipeline.
+
+    The typical workflow is:
+    1. Load reference panel with ReferencePanel.load()
+    2. Create model: AncestryModel(config)
+    3. Fit on reference: model.fit(reference)
+    4. Predict on new samples: model.predict(new_data)
+    5. Optionally save: model.save(path)
+
+    Attributes:
+        config: Full ancestry configuration.
+        pca_reducer: Fitted PCA reducer (set after fit).
+        pipeline: Fitted sklearn Pipeline with UMAP + XGBoost (set after fit).
+        label_encoder: Fitted LabelEncoder (set after fit).
+        best_params: Best hyperparameters from grid search (set after fit).
+        training_metrics: Metrics from training (set after fit).
+    """
+
+    config: AncestryConfig = field(default_factory=AncestryConfig)
+    pca_reducer: Optional[PCAReducer] = field(default=None, repr=False)
+    pipeline: Optional[Pipeline] = field(default=None, repr=False)
+    label_encoder: Optional[preprocessing.LabelEncoder] = field(
+        default=None, repr=False
+    )
+    best_params: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    training_metrics: Optional[TrainingMetrics] = field(default=None, repr=False)
+    _is_fitted: bool = field(default=False, repr=False)
+    _train_pca: Optional[pd.DataFrame] = field(default=None, repr=False)
+
+    @property
+    def is_fitted(self) -> bool:
+        """Whether the model has been fitted."""
+        return self._is_fitted
+
+    def _prepare_training_data(
+        self,
+        raw_data: pd.DataFrame,
+        labels: pd.Series,  # type: ignore[type-arg]
+    ) -> Dict[str, Any]:
+        """Prepare data for training with train/test split.
+
+        Args:
+            raw_data: DataFrame with FID, IID, and SNP columns.
+            labels: Series mapping IID to ancestry label.
+
+        Returns:
+            Dictionary with train/test split data.
+        """
+        # Separate IDs and SNPs
+        ids = raw_data[["FID", "IID"]]
+        snps = raw_data.drop(columns=["FID", "IID"], errors="ignore")
+
+        # Get labels for samples in order
+        y = ids["IID"].map(labels)
+
+        # Encode labels
+        self.label_encoder = preprocessing.LabelEncoder()
+        y_encoded = self.label_encoder.fit_transform(y)
+
+        # Train/test split
+        X_train, X_test, y_train, y_test, idx_train, idx_test = train_test_split(
+            snps.values,
+            y_encoded,
+            np.arange(len(snps)),
+            test_size=self.config.training.test_size,
+            random_state=self.config.training.random_state,
+            stratify=y_encoded,
+        )
+
+        return {
+            "X_train": X_train,
+            "X_test": X_test,
+            "y_train": y_train,
+            "y_test": y_test,
+            "train_ids": ids.iloc[idx_train].reset_index(drop=True),
+            "test_ids": ids.iloc[idx_test].reset_index(drop=True),
+            "train_labels": self.label_encoder.inverse_transform(y_train),
+            "test_labels": self.label_encoder.inverse_transform(y_test),
+            "label_encoder": self.label_encoder,
+        }
+
+    def _run_pca(
+        self,
+        X_train: np.ndarray,  # type: ignore[type-arg]
+        X_test: np.ndarray,  # type: ignore[type-arg]
+        train_ids: pd.DataFrame,
+        test_ids: pd.DataFrame,
+        train_labels: np.ndarray,  # type: ignore[type-arg]
+        test_labels: np.ndarray,  # type: ignore[type-arg]
+    ) -> Dict[str, Any]:
+        """Run PCA on training data and transform test data.
+
+        Args:
+            X_train: Training genotype matrix.
+            X_test: Test genotype matrix.
+            train_ids: DataFrame with FID, IID for training samples.
+            test_ids: DataFrame with FID, IID for test samples.
+            train_labels: Labels for training samples.
+            test_labels: Labels for test samples.
+
+        Returns:
+            Dictionary with PCA results.
+        """
+        # Create and fit PCA reducer
+        self.pca_reducer = PCAReducer(config=self.config.pca)
+        self.pca_reducer.fit(X_train)
+
+        # Transform data
+        X_train_pca = self.pca_reducer.transform(X_train, return_dataframe=True)
+        X_test_pca = self.pca_reducer.transform(X_test, return_dataframe=True)
+
+        assert isinstance(X_train_pca, pd.DataFrame)
+        assert isinstance(X_test_pca, pd.DataFrame)
+
+        # Build labeled DataFrames
+        train_pca = pd.concat(
+            [train_ids.reset_index(drop=True), X_train_pca], axis=1
+        )
+        train_pca["label"] = train_labels
+
+        test_pca = pd.concat([test_ids.reset_index(drop=True), X_test_pca], axis=1)
+        test_pca["label"] = test_labels
+
+        ref_pca = pd.concat([train_pca, test_pca], ignore_index=True)
+
+        self._train_pca = train_pca
+
+        return {
+            "X_train": X_train_pca.values,
+            "X_test": X_test_pca.values,
+            "train_pca": train_pca,
+            "test_pca": test_pca,
+            "ref_pca": ref_pca,
+        }
+
+    def _train_classifier(
+        self,
+        X_train: np.ndarray,  # type: ignore[type-arg]
+        X_test: np.ndarray,  # type: ignore[type-arg]
+        y_train: np.ndarray,  # type: ignore[type-arg]
+        y_test: np.ndarray,  # type: ignore[type-arg]
+    ) -> Dict[str, Any]:
+        """Train UMAP + XGBoost classifier with grid search.
+
+        Args:
+            X_train: Training PCA components.
+            X_test: Test PCA components.
+            y_train: Training labels (encoded).
+            y_test: Test labels (encoded).
+
+        Returns:
+            Dictionary with trained classifier and metrics.
+        """
+        # Build parameter grid from config
+        param_grid = {
+            "umap__n_neighbors": list(self.config.grid_search.umap_n_neighbors),
+            "umap__n_components": list(self.config.grid_search.umap_n_components),
+            "umap__a": list(self.config.grid_search.umap_a),
+            "umap__b": list(self.config.grid_search.umap_b),
+            "xgb__lambda": list(self.config.grid_search.xgb_lambda),
+        }
+
+        # Calculate optimal number of parallel jobs
+        n_jobs = self.config.training.n_jobs
+        if n_jobs is None:
+            available_ram_gb = psutil.virtual_memory().total / (1024**3)
+            gb_per_worker = self.config.training.gb_per_worker
+            max_workers_by_ram = max(1, int((available_ram_gb * 0.8) / gb_per_worker))
+            cpu_count = os.cpu_count() or 1
+            n_jobs = min(cpu_count, max_workers_by_ram)
+
+        logger.info(
+            f"Using {n_jobs} parallel workers for GridSearchCV "
+            f"(RAM: {psutil.virtual_memory().total / (1024**3):.1f}GB)"
+        )
+
+        # Build pipeline
+        umap = UMAP(random_state=self.config.umap.random_state)
+        xgb = XGBClassifier(
+            booster=self.config.classifier.booster,
+            random_state=self.config.classifier.random_state,
+        )
+        pipeline = Pipeline([("umap", umap), ("xgb", xgb)])
+
+        # Grid search with cross-validation
+        cv = StratifiedKFold(
+            n_splits=self.config.grid_search.cv_folds,
+            shuffle=True,
+            random_state=self.config.training.random_state,
+        )
+        grid_search = GridSearchCV(
+            pipeline,
+            param_grid,
+            cv=cv,
+            scoring=self.config.grid_search.scoring,
+            n_jobs=n_jobs,
+            verbose=1,
+        )
+        grid_search.fit(X_train, y_train)
+
+        # Get results
+        results_df = pd.DataFrame(grid_search.cv_results_)
+        top_results = results_df[results_df["rank_test_score"] == 1]
+
+        train_acc = grid_search.best_score_
+        train_ci_interval = 1.96 * float(top_results["std_test_score"].iloc[0])
+
+        self.pipeline = grid_search.best_estimator_
+        self.best_params = grid_search.best_params_
+
+        # Evaluate on test set
+        test_acc = float(self.pipeline.score(X_test, y_test))
+        test_margin = 1.96 * np.sqrt((test_acc * (1 - test_acc)) / len(y_test))
+
+        # Confusion matrix
+        y_pred = self.pipeline.predict(X_test)
+        from sklearn import metrics
+
+        confusion_matrix = metrics.confusion_matrix(y_test, y_pred)
+
+        logger.info(f"Training Balanced Accuracy: {train_acc:.4f}")
+        logger.info(f"Test Balanced Accuracy: {test_acc:.4f}")
+        logger.info(f"Best Parameters: {grid_search.best_params_}")
+
+        # Store training metrics
+        self.training_metrics = TrainingMetrics(
+            train_accuracy=train_acc,
+            test_accuracy=test_acc,
+            train_accuracy_ci=(train_acc - train_ci_interval, train_acc + train_ci_interval),
+            test_accuracy_ci=(test_acc - test_margin, test_acc + test_margin),
+            confusion_matrix=confusion_matrix,
+            best_params=grid_search.best_params_,
+            label_encoder_classes=list(self.label_encoder.classes_)
+            if self.label_encoder
+            else [],
+        )
+
+        return {
+            "pipeline": self.pipeline,
+            "best_params": grid_search.best_params_,
+            "train_accuracy": train_acc,
+            "test_accuracy": test_acc,
+            "confusion_matrix": confusion_matrix,
+        }
+
+    def _predict_admixed(
+        self,
+        projected: pd.DataFrame,
+        train_pca: pd.DataFrame,
+    ) -> pd.DataFrame:
+        """Identify samples with complex admixture history.
+
+        Samples closest to the global centroid rather than any specific
+        ancestry centroid are classified as CAH (Complex Admixture History).
+
+        Args:
+            projected: DataFrame with projected samples (PCs + predicted label).
+            train_pca: DataFrame with training PCA data and labels.
+
+        Returns:
+            Updated projected DataFrame with CAH labels.
+        """
+        # Copy training data for admixture calculation
+        train_pca_admix = train_pca.copy()
+
+        # Handle CAS (Central Asian) bimodal distribution
+        cas_train = train_pca_admix[train_pca_admix["label"] == "CAS"]
+        other_train = train_pca_admix[train_pca_admix["label"] != "CAS"]
+
+        if len(cas_train) > 0:
+            cas_ids = cas_train[["FID", "IID"]].reset_index(drop=True)
+            cas_labels = cas_train["label"].reset_index(drop=True)
+            cas_pcs = cas_train.drop(
+                columns=["FID", "IID", "label"], errors="ignore"
+            ).reset_index(drop=True)
+
+            # Cluster CAS into two groups based on first 3 PCs
+            birch = Birch(n_clusters=self.config.admixed.n_clusters_cas)
+            birch.fit(cas_pcs[["PC1", "PC2", "PC3"]])
+            cas_clusters = birch.predict(cas_pcs[["PC1", "PC2", "PC3"]])
+
+            # Reconstruct CAS training data with subclusters
+            cas_train_new = pd.concat([cas_ids, cas_pcs, cas_labels], axis=1)
+            cas_train_new["label"] = np.where(cas_clusters == 0, "CAS", "CAS2")
+            train_pca_admix = pd.concat(
+                [other_train, cas_train_new], axis=0, ignore_index=True
+            )
+
+        # Calculate centroids for each ancestry
+        pc_cols = [c for c in train_pca_admix.columns if c.startswith("PC")]
+        pc_centroids = pd.DataFrame()
+
+        train_pcs = train_pca_admix[pc_cols]
+        pc_centroids["ALL"] = train_pcs.mean(axis=0)
+
+        for ancestry in train_pca_admix["label"].unique():
+            ancestry_data = train_pca_admix[train_pca_admix["label"] == ancestry]
+            ancestry_pcs = ancestry_data[pc_cols]
+            pc_centroids[ancestry] = ancestry_pcs.mean(axis=0)
+
+        # Calculate distance to each centroid for projected samples
+        projected_copy = projected.copy()
+        projected_ids = projected_copy[["FID", "IID", "label"]]
+        projected_pcs = projected_copy[pc_cols].copy()
+
+        for ancestry in pc_centroids.columns:
+            centroid = pc_centroids[ancestry]
+            distances = projected_pcs.apply(
+                lambda row: np.sqrt(np.sum((row - centroid) ** 2)), axis=1
+            )
+            projected_pcs[ancestry] = distances
+
+        # Find minimum distance and corresponding ancestry
+        distance_cols = list(pc_centroids.columns)
+        projected_pcs["min_distance"] = projected_pcs[distance_cols].min(axis=1)
+        projected_pcs["min_distance_ancestry"] = (
+            projected_pcs[distance_cols]
+            .eq(projected_pcs["min_distance"], axis=0)
+            .idxmax(axis=1)
+        )
+
+        # Update labels - samples closest to ALL centroid become CAH
+        result = pd.concat([projected_ids, projected_pcs[pc_cols]], axis=1)
+        result["label"] = np.where(
+            projected_pcs["min_distance_ancestry"] == "ALL",
+            "CAH",
+            projected_ids["label"],
+        )
+
+        return result
+
+    def fit(
+        self,
+        raw_ref_data: pd.DataFrame,
+        labels: pd.Series,  # type: ignore[type-arg]
+        out_path: Optional[Path] = None,
+    ) -> "AncestryModel":
+        """Fit the ancestry model on reference data.
+
+        Args:
+            raw_ref_data: DataFrame with reference genotype data.
+                Must have FID, IID columns followed by SNP columns.
+            labels: Series mapping IID to ancestry label.
+            out_path: Optional path for saving intermediate files.
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            AncestryError: If training fails.
+        """
+        logger.info("Fitting ancestry model on reference data")
+
+        # Prepare training data
+        split_data = self._prepare_training_data(raw_ref_data, labels)
+
+        # Run PCA
+        pca_result = self._run_pca(
+            X_train=split_data["X_train"],
+            X_test=split_data["X_test"],
+            train_ids=split_data["train_ids"],
+            test_ids=split_data["test_ids"],
+            train_labels=split_data["train_labels"],
+            test_labels=split_data["test_labels"],
+        )
+
+        # Save PCA outputs if path provided
+        if out_path:
+            pca_result["train_pca"].to_csv(
+                f"{out_path}_labeled_train_pca.txt", sep="\t", index=False
+            )
+            pca_result["ref_pca"].to_csv(
+                f"{out_path}_labeled_ref_pca.txt", sep="\t", index=False
+            )
+            if self.pca_reducer:
+                self.pca_reducer.save_eigenvalues(
+                    Path(f"{out_path}_pca_eigenvalues.txt")
+                )
+
+        # Train classifier
+        classifier_result = self._train_classifier(
+            X_train=pca_result["X_train"],
+            X_test=pca_result["X_test"],
+            y_train=split_data["y_train"],
+            y_test=split_data["y_test"],
+        )
+
+        self._is_fitted = True
+        logger.info("Ancestry model fitted successfully")
+
+        return self
+
+    def predict(
+        self,
+        raw_geno_data: pd.DataFrame,
+        geno_ids: pd.DataFrame,
+        out_path: Optional[Path] = None,
+        detect_admixed: bool = True,
+    ) -> AncestryPredictions:
+        """Predict ancestry for new samples.
+
+        Args:
+            raw_geno_data: DataFrame with genotype data (samples x SNPs).
+            geno_ids: DataFrame with FID, IID columns.
+            out_path: Optional path for saving outputs.
+            detect_admixed: Whether to detect admixed samples. Default True.
+
+        Returns:
+            AncestryPredictions with predicted ancestries.
+
+        Raises:
+            AncestryError: If model not fitted or prediction fails.
+        """
+        if not self._is_fitted:
+            raise AncestryError("Model must be fitted before prediction")
+
+        if self.pca_reducer is None or self.pipeline is None:
+            raise AncestryError("Model is in invalid state")
+
+        if self.label_encoder is None:
+            raise AncestryError("Label encoder not set")
+
+        logger.info(f"Predicting ancestry for {len(raw_geno_data)} samples")
+
+        # Get SNP columns (exclude ID columns)
+        snp_cols = [c for c in raw_geno_data.columns if c not in ("FID", "IID", "label")]
+        X_new = raw_geno_data[snp_cols].values
+
+        # Project through PCA
+        X_new_pca = self.pca_reducer.transform(X_new, return_dataframe=True)
+        assert isinstance(X_new_pca, pd.DataFrame)
+
+        # Predict with pipeline
+        y_pred_encoded = self.pipeline.predict(X_new_pca.values)
+        y_pred = self.label_encoder.inverse_transform(y_pred_encoded)
+
+        # Build projected DataFrame for admixture detection
+        projected = pd.concat(
+            [geno_ids.reset_index(drop=True), X_new_pca], axis=1
+        )
+        projected["label"] = y_pred
+
+        # Detect admixed samples if requested
+        if detect_admixed and self._train_pca is not None:
+            projected = self._predict_admixed(projected, self._train_pca)
+            y_pred = projected["label"].values
+
+        # Save outputs if path provided
+        output_path = None
+        if out_path:
+            output_path = Path(f"{out_path}_umap_linearsvc_predicted_labels.txt")
+            projected[["FID", "IID", "label"]].to_csv(
+                output_path, sep="\t", index=False
+            )
+            projected.to_csv(
+                f"{out_path}_projected_new_pca.txt", sep="\t", index=False
+            )
+
+        # Create predictions result
+        predictions_df = geno_ids.copy()
+        predictions_df["predicted_ancestry"] = y_pred
+
+        logger.info(f"Predicted ancestry counts: {pd.Series(y_pred).value_counts().to_dict()}")
+
+        return AncestryPredictions(
+            predictions=predictions_df,
+            output_path=output_path,
+        )
+
+    def save(self, path: Path) -> Path:
+        """Save fitted model to file.
+
+        Args:
+            path: Output file path (should end in .pkl).
+
+        Returns:
+            Path to saved file.
+
+        Raises:
+            AncestryError: If model not fitted.
+        """
+        if not self._is_fitted:
+            raise AncestryError("Cannot save unfitted model")
+
+        with open(path, "wb") as f:
+            pickle.dump(self, f)
+
+        logger.info(f"Model saved to: {path}")
+        return path
+
+    @classmethod
+    def load(cls, path: Path) -> "AncestryModel":
+        """Load fitted model from file.
+
+        Args:
+            path: Path to saved model file.
+
+        Returns:
+            Loaded AncestryModel.
+
+        Raises:
+            FileNotFoundError: If file doesn't exist.
+            AncestryError: If file contains invalid model.
+        """
+        if not path.exists():
+            raise FileNotFoundError(f"Model file not found: {path}")
+
+        with open(path, "rb") as f:
+            model = pickle.load(f)
+
+        if not isinstance(model, cls):
+            raise AncestryError(
+                f"Invalid model file: expected AncestryModel, got {type(model)}"
+            )
+
+        logger.info(f"Model loaded from: {path}")
+        return model
+
+
+def load_trained_pipeline(
+    model_path: Path,
+    X_test: np.ndarray,  # type: ignore[type-arg]
+    y_test: np.ndarray,  # type: ignore[type-arg]
+) -> Dict[str, Any]:
+    """Load a trained sklearn Pipeline from pickle.
+
+    This is a compatibility function for loading old-style models
+    that only contain the UMAP+XGBoost pipeline.
+
+    Args:
+        model_path: Path to pickled pipeline.
+        X_test: Test features for evaluation.
+        y_test: Test labels for evaluation.
+
+    Returns:
+        Dictionary with pipeline, accuracy, and parameters.
+    """
+    from sklearn import metrics
+
+    with open(model_path, "rb") as f:
+        pipeline = pickle.load(f)
+
+    test_acc = float(pipeline.score(X_test, y_test))
+    y_pred = pipeline.predict(X_test)
+    confusion_matrix = metrics.confusion_matrix(y_test, y_pred)
+    params = pipeline.get_params()
+
+    logger.info(f"Loaded pipeline with test accuracy: {test_acc:.4f}")
+
+    return {
+        "pipeline": pipeline,
+        "test_accuracy": test_acc,
+        "confusion_matrix": confusion_matrix,
+        "params": params,
+    }

--- a/genotools/ancestry/reducers/__init__.py
+++ b/genotools/ancestry/reducers/__init__.py
@@ -1,0 +1,44 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Dimensionality reduction modules for ancestry prediction.
+
+This package provides PCA and UMAP transformations used in the ancestry
+prediction pipeline.
+
+Example:
+    >>> from genotools.ancestry.reducers import PCAReducer, UMAPReducer
+    >>> pca = PCAReducer(n_components=50)
+    >>> pca.fit(training_data)
+    >>> projected = pca.transform(new_data)
+"""
+
+from genotools.ancestry.reducers.pca import (
+    PCAReducer,
+    flashpca_scale,
+    run_pca,
+)
+from genotools.ancestry.reducers.umap_reducer import (
+    UMAPReducer,
+    run_umap,
+)
+
+__all__ = [
+    "PCAReducer",
+    "flashpca_scale",
+    "run_pca",
+    "UMAPReducer",
+    "run_umap",
+]

--- a/genotools/ancestry/reducers/pca.py
+++ b/genotools/ancestry/reducers/pca.py
@@ -1,0 +1,413 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""PCA dimensionality reduction for ancestry prediction.
+
+This module provides PCA computation and transformation for the ancestry
+prediction pipeline. It uses flashPCA-style scaling for compatibility with
+the existing implementation and reference panels.
+
+The flashPCA scaling computes standard deviation as sqrt(p/2 * (1 - p/2))
+where p is the mean allele frequency. This differs from standard scaling
+and is important for reproducibility with existing trained models.
+
+Reference: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0093766
+
+Example:
+    >>> from genotools.ancestry.reducers.pca import PCAReducer
+    >>> pca = PCAReducer(n_components=50)
+    >>> pca.fit(X_train)
+    >>> X_train_pca = pca.transform(X_train)
+    >>> X_new_pca = pca.transform(X_new)
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Tuple, Any
+
+import numpy as np
+import pandas as pd
+from sklearn.decomposition import PCA
+from sklearn.impute import SimpleImputer
+
+from genotools.ancestry.config import PCAConfig
+from genotools.core.exceptions import AncestryError
+
+
+def flashpca_scale(
+    data: np.ndarray,  # type: ignore[type-arg]
+    mean: Optional[np.ndarray] = None,  # type: ignore[type-arg]
+    sd: Optional[np.ndarray] = None,  # type: ignore[type-arg]
+    compute_stats: bool = False,
+    eps: float = 1e-12,
+) -> Tuple[
+    np.ndarray,  # type: ignore[type-arg]
+    np.ndarray,  # type: ignore[type-arg]
+    np.ndarray,  # type: ignore[type-arg]
+    np.ndarray,  # type: ignore[type-arg]
+]:
+    """Apply flashPCA-style scaling to genotype data.
+
+    FlashPCA uses a specific scaling formula where the standard deviation
+    is computed as sqrt(mean/2 * (1 - mean/2)), which is appropriate for
+    genotype data where values represent allele counts (0, 1, 2).
+
+    Reference: Abraham & Inouye, 2014, PLOS ONE
+    https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0093766
+
+    Args:
+        data: Genotype matrix (samples x variants) with values 0, 1, 2.
+        mean: Pre-computed means. If None and compute_stats=True, computed.
+        sd: Pre-computed standard deviations. If None and compute_stats=True,
+            computed using flashPCA formula.
+        compute_stats: If True, compute mean and sd from data.
+        eps: Small value to avoid division by zero. Default is 1e-12.
+
+    Returns:
+        Tuple of:
+            - scaled_data: Scaled genotype matrix
+            - mean: Mean values per variant
+            - sd: Standard deviation values per variant
+            - keep_mask: Boolean mask of variants to keep (sd > eps)
+
+    Raises:
+        ValueError: If mean/sd not provided and compute_stats is False.
+    """
+    if compute_stats:
+        mean = data.mean(axis=0)
+        # flashPCA-style standard deviation
+        sd = np.sqrt((mean / 2) * (1 - mean / 2))
+    elif mean is None or sd is None:
+        raise ValueError(
+            "mean and sd must be provided if compute_stats is False"
+        )
+
+    # Create mask for non-zero SD variants
+    keep_mask = sd > eps
+
+    # Filter data and stats to kept variants
+    data_filtered = data[:, keep_mask]
+    mean_filtered = mean[keep_mask]
+    sd_filtered = sd[keep_mask]
+
+    # Scale data
+    scaled_data = (data_filtered - mean_filtered) / sd_filtered
+
+    return scaled_data, mean, sd, keep_mask
+
+
+@dataclass
+class PCAReducer:
+    """PCA dimensionality reducer for ancestry prediction.
+
+    This class wraps sklearn's PCA with flashPCA-style scaling and
+    provides a fit/transform interface for use in the ancestry pipeline.
+
+    Attributes:
+        config: PCA configuration parameters.
+        pca: Fitted sklearn PCA object.
+        mean: Training data mean for scaling.
+        sd: Training data standard deviation for scaling.
+        keep_mask: Boolean mask of variants kept after SD filtering.
+        imputer: SimpleImputer for handling missing values.
+    """
+
+    config: PCAConfig = field(default_factory=PCAConfig)
+    pca: Optional[PCA] = field(default=None, repr=False)
+    mean: Optional[np.ndarray] = field(default=None, repr=False)  # type: ignore[type-arg]
+    sd: Optional[np.ndarray] = field(default=None, repr=False)  # type: ignore[type-arg]
+    keep_mask: Optional[np.ndarray] = field(default=None, repr=False)  # type: ignore[type-arg]
+    imputer: Optional[SimpleImputer] = field(default=None, repr=False)
+    _is_fitted: bool = field(default=False, repr=False)
+
+    @property
+    def n_components(self) -> int:
+        """Number of PCA components."""
+        return self.config.n_components
+
+    @property
+    def is_fitted(self) -> bool:
+        """Whether the reducer has been fitted."""
+        return self._is_fitted
+
+    @property
+    def n_variants_used(self) -> int:
+        """Number of variants used after SD filtering."""
+        if self.keep_mask is None:
+            return 0
+        return int(self.keep_mask.sum())
+
+    @property
+    def n_variants_dropped(self) -> int:
+        """Number of variants dropped due to zero SD."""
+        if self.keep_mask is None:
+            return 0
+        return int((~self.keep_mask).sum())
+
+    @property
+    def eigenvalues(self) -> Optional[np.ndarray]:  # type: ignore[type-arg]
+        """Eigenvalues (explained variance) for each component."""
+        if self.pca is None:
+            return None
+        return self.pca.explained_variance_
+
+    @property
+    def explained_variance_ratio(self) -> Optional[np.ndarray]:  # type: ignore[type-arg]
+        """Proportion of variance explained by each component."""
+        if self.pca is None:
+            return None
+        return self.pca.explained_variance_ratio_
+
+    def _get_pc_names(self) -> list[str]:
+        """Get column names for PC output."""
+        return [f"PC{i+1}" for i in range(self.config.n_components)]
+
+    def fit(self, X: np.ndarray) -> "PCAReducer":  # type: ignore[type-arg]
+        """Fit PCA on training data.
+
+        Args:
+            X: Genotype matrix (samples x variants) with values 0, 1, 2.
+                Missing values (NaN) are imputed with mean.
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            AncestryError: If insufficient samples or variants for PCA.
+        """
+        # Validate input dimensions
+        if X.shape[0] < 50:
+            raise AncestryError(
+                f"Training data has only {X.shape[0]} samples, "
+                f"which is insufficient for PCA. Need at least 50."
+            )
+        if X.shape[1] < 50:
+            raise AncestryError(
+                f"Training data has only {X.shape[1]} SNPs, "
+                f"which is insufficient for PCA. Need at least 50."
+            )
+
+        # Impute missing values
+        self.imputer = SimpleImputer(missing_values=np.nan, strategy="mean")
+        X_imputed = self.imputer.fit_transform(X)
+
+        # Apply flashPCA scaling
+        X_scaled, self.mean, self.sd, self.keep_mask = flashpca_scale(
+            X_imputed, compute_stats=True
+        )
+
+        # Check we still have enough variants after filtering
+        if X_scaled.shape[1] < 50:
+            raise AncestryError(
+                f"After removing {self.n_variants_dropped} zero-SD SNPs, "
+                f"only {self.n_variants_used} SNPs remain. "
+                f"Insufficient for PCA. Consider relaxing filters."
+            )
+
+        # Fit PCA
+        self.pca = PCA(
+            n_components=self.config.n_components,
+            svd_solver="full",
+            random_state=self.config.random_state,
+        )
+        self.pca.fit(X_scaled)
+
+        self._is_fitted = True
+        return self
+
+    def transform(
+        self,
+        X: np.ndarray,  # type: ignore[type-arg]
+        return_dataframe: bool = False,
+    ) -> np.ndarray | pd.DataFrame:  # type: ignore[type-arg]
+        """Transform data using fitted PCA.
+
+        Args:
+            X: Genotype matrix (samples x variants) to transform.
+            return_dataframe: If True, return DataFrame with PC column names.
+
+        Returns:
+            PCA-transformed data (samples x n_components).
+
+        Raises:
+            AncestryError: If PCA not fitted.
+        """
+        if not self._is_fitted:
+            raise AncestryError("PCAReducer must be fitted before transform")
+
+        if self.imputer is None or self.pca is None:
+            raise AncestryError("PCAReducer is in invalid state")
+
+        if self.mean is None or self.sd is None or self.keep_mask is None:
+            raise AncestryError("PCAReducer scaling parameters not set")
+
+        # Impute missing values
+        X_imputed = self.imputer.transform(X)
+
+        # Apply flashPCA scaling using fitted parameters
+        X_scaled, _, _, _ = flashpca_scale(
+            X_imputed,
+            mean=self.mean,
+            sd=self.sd,
+            compute_stats=False,
+        )
+
+        # Apply keep_mask (filter to same variants as training)
+        X_filtered = X_scaled
+
+        # Transform with PCA
+        X_pca = self.pca.transform(X_filtered)
+
+        if return_dataframe:
+            return pd.DataFrame(X_pca, columns=self._get_pc_names())
+        return X_pca
+
+    def fit_transform(
+        self,
+        X: np.ndarray,  # type: ignore[type-arg]
+        return_dataframe: bool = False,
+    ) -> np.ndarray | pd.DataFrame:  # type: ignore[type-arg]
+        """Fit PCA and transform data in one step.
+
+        Args:
+            X: Genotype matrix (samples x variants).
+            return_dataframe: If True, return DataFrame with PC column names.
+
+        Returns:
+            PCA-transformed data (samples x n_components).
+        """
+        self.fit(X)
+        return self.transform(X, return_dataframe=return_dataframe)
+
+    def save_eigenvalues(self, path: Path) -> Path:
+        """Save eigenvalues and explained variance to file.
+
+        Args:
+            path: Output file path.
+
+        Returns:
+            Path to saved file.
+
+        Raises:
+            AncestryError: If PCA not fitted.
+        """
+        if not self._is_fitted or self.pca is None:
+            raise AncestryError("PCAReducer must be fitted before saving")
+
+        ev_df = pd.DataFrame({
+            "PC": self._get_pc_names(),
+            "eigenvalue": self.pca.explained_variance_,
+            "explained_variance_ratio": self.pca.explained_variance_ratio_,
+        })
+        ev_df.to_csv(path, sep="\t", index=False)
+        return path
+
+
+def run_pca(
+    X_train: np.ndarray,  # type: ignore[type-arg]
+    X_test: np.ndarray,  # type: ignore[type-arg]
+    X_new: np.ndarray,  # type: ignore[type-arg]
+    train_ids: pd.DataFrame,
+    test_ids: pd.DataFrame,
+    new_ids: pd.DataFrame,
+    train_labels: np.ndarray,  # type: ignore[type-arg]
+    test_labels: np.ndarray,  # type: ignore[type-arg]
+    config: Optional[PCAConfig] = None,
+    out_path: Optional[Path] = None,
+) -> dict[str, Any]:
+    """Run PCA on training data and project test/new samples.
+
+    This is a convenience function that wraps PCAReducer to match the
+    interface of the original calculate_pcs method.
+
+    Args:
+        X_train: Training genotype matrix (samples x variants).
+        X_test: Test genotype matrix.
+        X_new: New samples genotype matrix.
+        train_ids: DataFrame with FID, IID for training samples.
+        test_ids: DataFrame with FID, IID for test samples.
+        new_ids: DataFrame with FID, IID for new samples.
+        train_labels: Ancestry labels for training samples.
+        test_labels: Ancestry labels for test samples.
+        config: PCA configuration. Default is PCAConfig().
+        out_path: Optional path prefix for saving outputs.
+
+    Returns:
+        Dictionary with:
+            - reducer: Fitted PCAReducer
+            - X_train: Transformed training data
+            - X_test: Transformed test data
+            - train_pca: DataFrame with train IDs, PCs, and labels
+            - test_pca: DataFrame with test IDs, PCs, and labels
+            - ref_pca: DataFrame with combined train+test (full reference)
+            - projected_pca: DataFrame with new samples IDs and PCs
+            - eigenvalues: Eigenvalues array
+            - explained_variance_ratio: Explained variance ratio array
+    """
+    if config is None:
+        config = PCAConfig()
+
+    # Create and fit reducer
+    reducer = PCAReducer(config=config)
+    reducer.fit(X_train)
+
+    # Transform all datasets
+    X_train_pca = reducer.transform(X_train, return_dataframe=True)
+    X_test_pca = reducer.transform(X_test, return_dataframe=True)
+    X_new_pca = reducer.transform(X_new, return_dataframe=True)
+
+    # Build output DataFrames with IDs and labels
+    train_ids_reset = train_ids.reset_index(drop=True)
+    test_ids_reset = test_ids.reset_index(drop=True)
+    new_ids_reset = new_ids.reset_index(drop=True)
+
+    # Ensure PCA DataFrames are properly typed
+    assert isinstance(X_train_pca, pd.DataFrame)
+    assert isinstance(X_test_pca, pd.DataFrame)
+    assert isinstance(X_new_pca, pd.DataFrame)
+
+    train_pca = pd.concat([train_ids_reset, X_train_pca], axis=1)
+    train_pca["label"] = train_labels
+
+    test_pca = pd.concat([test_ids_reset, X_test_pca], axis=1)
+    test_pca["label"] = test_labels
+
+    ref_pca = pd.concat([train_pca, test_pca], ignore_index=True)
+
+    projected_pca = pd.concat([new_ids_reset, X_new_pca], axis=1)
+    projected_pca["label"] = "new"
+
+    # Save outputs if path provided
+    if out_path:
+        train_pca.to_csv(
+            f"{out_path}_labeled_train_pca.txt", sep="\t", index=False
+        )
+        ref_pca.to_csv(f"{out_path}_labeled_ref_pca.txt", sep="\t", index=False)
+        projected_pca.to_csv(
+            f"{out_path}_projected_new_pca.txt", sep="\t", index=False
+        )
+        reducer.save_eigenvalues(Path(f"{out_path}_pca_eigenvalues.txt"))
+
+    return {
+        "reducer": reducer,
+        "X_train": X_train_pca.values,
+        "X_test": X_test_pca.values,
+        "train_pca": train_pca,
+        "test_pca": test_pca,
+        "ref_pca": ref_pca,
+        "projected_pca": projected_pca,
+        "eigenvalues": reducer.eigenvalues,
+        "explained_variance_ratio": reducer.explained_variance_ratio,
+    }

--- a/genotools/ancestry/reducers/umap_reducer.py
+++ b/genotools/ancestry/reducers/umap_reducer.py
@@ -1,0 +1,281 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""UMAP dimensionality reduction for ancestry prediction.
+
+This module provides UMAP (Uniform Manifold Approximation and Projection)
+transformation for the ancestry prediction pipeline. UMAP is used to
+reduce PCA components to a lower-dimensional space that preserves local
+structure, making ancestry clusters more separable.
+
+CRITICAL: Requires umap-learn==0.5.3 for model compatibility.
+Models trained with one UMAP version may not load correctly with another.
+
+Example:
+    >>> from genotools.ancestry.reducers.umap_reducer import UMAPReducer
+    >>> reducer = UMAPReducer(n_neighbors=15, n_components=2)
+    >>> reducer.fit(X_train_pca)
+    >>> X_train_umap = reducer.transform(X_train_pca)
+    >>> X_new_umap = reducer.transform(X_new_pca)
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import numpy as np
+import pandas as pd
+from umap import UMAP
+
+from genotools.ancestry.config import UMAPConfig
+from genotools.core.exceptions import AncestryError
+
+
+@dataclass
+class UMAPReducer:
+    """UMAP dimensionality reducer for ancestry prediction.
+
+    This class wraps the UMAP library with a fit/transform interface
+    for use in the ancestry pipeline. It can be used standalone or
+    as part of a sklearn Pipeline with XGBoost classifier.
+
+    CRITICAL: Requires umap-learn==0.5.3 for compatibility with
+    existing trained models.
+
+    Attributes:
+        config: UMAP configuration parameters.
+        umap: Fitted UMAP object.
+    """
+
+    config: UMAPConfig = field(default_factory=UMAPConfig)
+    umap: Optional[UMAP] = field(default=None, repr=False)
+    _is_fitted: bool = field(default=False, repr=False)
+
+    @property
+    def is_fitted(self) -> bool:
+        """Whether the reducer has been fitted."""
+        return self._is_fitted
+
+    @property
+    def n_components(self) -> int:
+        """Output dimensionality."""
+        return self.config.n_components
+
+    def _create_umap(self) -> UMAP:
+        """Create UMAP instance from config.
+
+        Returns:
+            Configured UMAP instance.
+        """
+        kwargs: Dict[str, Any] = {
+            "n_neighbors": self.config.n_neighbors,
+            "n_components": self.config.n_components,
+            "min_dist": self.config.min_dist,
+            "metric": self.config.metric,
+            "random_state": self.config.random_state,
+        }
+
+        # Only add a/b parameters if explicitly set
+        if self.config.a is not None:
+            kwargs["a"] = self.config.a
+        if self.config.b is not None:
+            kwargs["b"] = self.config.b
+
+        return UMAP(**kwargs)
+
+    def fit(self, X: np.ndarray) -> "UMAPReducer":  # type: ignore[type-arg]
+        """Fit UMAP on input data.
+
+        Args:
+            X: Input data (samples x features), typically PCA components.
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            AncestryError: If input data is too small.
+        """
+        if X.shape[0] < self.config.n_neighbors:
+            raise AncestryError(
+                f"Input has {X.shape[0]} samples but UMAP requires at least "
+                f"{self.config.n_neighbors} samples (n_neighbors). "
+                f"Reduce n_neighbors or use more samples."
+            )
+
+        self.umap = self._create_umap()
+        self.umap.fit(X)
+        self._is_fitted = True
+        return self
+
+    def transform(
+        self,
+        X: np.ndarray,  # type: ignore[type-arg]
+        return_dataframe: bool = False,
+    ) -> np.ndarray | pd.DataFrame:  # type: ignore[type-arg]
+        """Transform data using fitted UMAP.
+
+        Args:
+            X: Input data (samples x features) to transform.
+            return_dataframe: If True, return DataFrame with UMAP column names.
+
+        Returns:
+            UMAP-transformed data (samples x n_components).
+
+        Raises:
+            AncestryError: If UMAP not fitted.
+        """
+        if not self._is_fitted or self.umap is None:
+            raise AncestryError("UMAPReducer must be fitted before transform")
+
+        X_umap = self.umap.transform(X)
+
+        if return_dataframe:
+            columns = [f"UMAP{i+1}" for i in range(self.config.n_components)]
+            return pd.DataFrame(X_umap, columns=columns)
+        return X_umap
+
+    def fit_transform(
+        self,
+        X: np.ndarray,  # type: ignore[type-arg]
+        return_dataframe: bool = False,
+    ) -> np.ndarray | pd.DataFrame:  # type: ignore[type-arg]
+        """Fit UMAP and transform data in one step.
+
+        Args:
+            X: Input data (samples x features).
+            return_dataframe: If True, return DataFrame with UMAP column names.
+
+        Returns:
+            UMAP-transformed data (samples x n_components).
+        """
+        self.fit(X)
+        return self.transform(X, return_dataframe=return_dataframe)
+
+    @classmethod
+    def from_params(
+        cls,
+        params: Dict[str, Any],
+        random_state: int = 123,
+    ) -> "UMAPReducer":
+        """Create UMAPReducer from parameter dictionary.
+
+        This is useful for creating a reducer with parameters from
+        a grid search result (e.g., best_params_ from GridSearchCV).
+
+        Args:
+            params: Dictionary with UMAP parameters. Keys should be
+                prefixed with "umap__" (sklearn Pipeline convention)
+                or be plain parameter names.
+            random_state: Random seed for reproducibility.
+
+        Returns:
+            Configured UMAPReducer.
+        """
+        # Handle sklearn Pipeline parameter naming convention
+        clean_params: Dict[str, Any] = {}
+        for key, value in params.items():
+            if key.startswith("umap__"):
+                clean_key = key[6:]  # Remove "umap__" prefix
+                clean_params[clean_key] = value
+            elif key in ("n_neighbors", "n_components", "min_dist", "metric", "a", "b"):
+                clean_params[key] = value
+
+        # Build config
+        config = UMAPConfig(
+            n_neighbors=clean_params.get("n_neighbors", 15),
+            n_components=clean_params.get("n_components", 2),
+            min_dist=clean_params.get("min_dist", 0.1),
+            metric=clean_params.get("metric", "euclidean"),
+            a=clean_params.get("a"),
+            b=clean_params.get("b"),
+            random_state=random_state,
+        )
+
+        return cls(config=config)
+
+
+def run_umap(
+    ref_pca: pd.DataFrame,
+    new_pca: pd.DataFrame,
+    new_labels: pd.Series,  # type: ignore[type-arg]
+    params: Optional[Dict[str, Any]] = None,
+    config: Optional[UMAPConfig] = None,
+) -> Dict[str, Any]:
+    """Run UMAP on reference PCA and project new samples.
+
+    This is a convenience function that matches the interface of the
+    original umap_transform_with_fitted method.
+
+    Args:
+        ref_pca: DataFrame with reference sample PCA components.
+            Should have columns: FID, IID, PC1...PCn, label
+        new_pca: DataFrame with new sample PCA components.
+            Should have columns: FID, IID, PC1...PCn
+        new_labels: Series with predicted labels for new samples.
+        params: Optional dictionary with UMAP parameters from grid search.
+            If provided, overrides config.
+        config: Optional UMAP configuration. Default is UMAPConfig().
+
+    Returns:
+        Dictionary with:
+            - reducer: Fitted UMAPReducer
+            - ref_umap: DataFrame with reference UMAP + labels + dataset='ref'
+            - new_umap: DataFrame with new samples UMAP + labels + dataset='predicted'
+            - total_umap: DataFrame with combined ref + new UMAP
+    """
+    # Get reference data without IDs and labels
+    ref_labels = ref_pca["label"].values
+    ref_ids = ref_pca[["FID", "IID"]]
+    X_ref = ref_pca.drop(columns=["FID", "IID", "label"]).values
+
+    # Get new sample data without IDs
+    new_ids = new_pca[["FID", "IID"]]
+    X_new = new_pca.drop(columns=["FID", "IID", "label"], errors="ignore").values
+
+    # Create reducer
+    if params is not None:
+        reducer = UMAPReducer.from_params(params)
+    elif config is not None:
+        reducer = UMAPReducer(config=config)
+    else:
+        reducer = UMAPReducer()
+
+    # Fit on reference data
+    reducer.fit(X_ref)
+
+    # Transform both datasets
+    ref_umap_arr = reducer.transform(X_ref, return_dataframe=True)
+    new_umap_arr = reducer.transform(X_new, return_dataframe=True)
+
+    assert isinstance(ref_umap_arr, pd.DataFrame)
+    assert isinstance(new_umap_arr, pd.DataFrame)
+
+    # Build output DataFrames
+    ref_umap = ref_umap_arr.reset_index(drop=True)
+    ref_umap["label"] = ref_labels
+    ref_umap["dataset"] = "ref"
+
+    new_umap = new_umap_arr.reset_index(drop=True)
+    new_umap["label"] = new_labels.values if hasattr(new_labels, "values") else new_labels
+    new_umap["dataset"] = "predicted"
+
+    # Combine
+    total_umap = pd.concat([ref_umap, new_umap], ignore_index=True)
+
+    return {
+        "reducer": reducer,
+        "ref_umap": ref_umap,
+        "new_umap": new_umap,
+        "total_umap": total_umap,
+    }

--- a/genotools/ancestry/reference.py
+++ b/genotools/ancestry/reference.py
@@ -1,0 +1,351 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Reference panel management for ancestry prediction.
+
+This module provides the ReferencePanel class for loading and managing
+reference population data used in ancestry prediction. Reference panels
+contain genotype data from individuals with known ancestry labels.
+
+Example:
+    >>> from genotools.ancestry.reference import ReferencePanel
+    >>> ref = ReferencePanel.load(
+    ...     geno_path=Path("/path/to/ref_panel"),
+    ...     labels_path=Path("/path/to/labels.txt")
+    ... )
+    >>> ref.sample_count
+    3000
+    >>> ref.ancestry_counts
+    {'EUR': 500, 'AFR': 500, ...}
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import pandas as pd
+
+from genotools.core.genotypes import GenotypeData
+from genotools.core.exceptions import AncestryError
+
+
+@dataclass
+class ReferencePanel:
+    """Reference panel for ancestry prediction.
+
+    A reference panel contains genotype data from individuals with known
+    ancestry labels. This data is used to train the ancestry prediction
+    model and provide a basis for projecting new samples.
+
+    The reference panel expects:
+    - Genotype files in PLINK bfile format (.bed/.bim/.fam)
+    - A labels file with tab-separated FID, IID, label columns
+      (no header, or header with these column names)
+
+    Attributes:
+        genotypes: GenotypeData pointing to the reference genotype files.
+        labels: Series mapping sample IID to ancestry label.
+        labels_path: Path to the labels file that was loaded.
+    """
+
+    genotypes: GenotypeData
+    labels: pd.Series  # type: ignore[type-arg]
+    labels_path: Path
+
+    def __post_init__(self) -> None:
+        """Validate reference panel data."""
+        if len(self.labels) == 0:
+            raise AncestryError("Reference panel has no labeled samples")
+
+        # Check that labels index matches sample IDs in genotype data
+        # This is validated at load time, but we double-check here
+
+    @classmethod
+    def load(
+        cls,
+        geno_path: Path,
+        labels_path: Path,
+        require_all_labeled: bool = True,
+    ) -> "ReferencePanel":
+        """Load reference panel from files.
+
+        Args:
+            geno_path: Path prefix to genotype files (without extension).
+                Expects bfile format (.bed/.bim/.fam).
+            labels_path: Path to ancestry labels file. Tab-separated with
+                columns: FID, IID, label (or no header with same order).
+            require_all_labeled: If True, raise error if any samples in
+                the genotype files lack labels. Default is True.
+
+        Returns:
+            Loaded ReferencePanel instance.
+
+        Raises:
+            FileNotFoundError: If genotype or labels files don't exist.
+            AncestryError: If labels are invalid or don't match samples.
+        """
+        geno_path = Path(geno_path)
+        labels_path = Path(labels_path)
+
+        # Validate genotype files exist
+        if not geno_path.with_suffix(".bed").exists():
+            raise FileNotFoundError(
+                f"Reference panel bed file not found: {geno_path}.bed"
+            )
+        if not geno_path.with_suffix(".bim").exists():
+            raise FileNotFoundError(
+                f"Reference panel bim file not found: {geno_path}.bim"
+            )
+        if not geno_path.with_suffix(".fam").exists():
+            raise FileNotFoundError(
+                f"Reference panel fam file not found: {geno_path}.fam"
+            )
+
+        # Validate labels file exists
+        if not labels_path.exists():
+            raise FileNotFoundError(
+                f"Reference labels file not found: {labels_path}"
+            )
+
+        # Load genotype data
+        genotypes = GenotypeData.from_path(geno_path)
+
+        # Load labels
+        labels_df = cls._load_labels_file(labels_path)
+
+        # Load fam file to get sample IDs
+        fam_df = pd.read_csv(
+            geno_path.with_suffix(".fam"),
+            sep=r"\s+",
+            header=None,
+            names=["FID", "IID", "PAT", "MAT", "SEX", "PHENO"],
+            dtype=str,
+        )
+
+        # Merge labels with fam file
+        merged = fam_df.merge(
+            labels_df,
+            on=["FID", "IID"],
+            how="left",
+        )
+
+        # Check for missing labels
+        missing_labels = merged["label"].isna()
+        if missing_labels.any():
+            n_missing = missing_labels.sum()
+            if require_all_labeled:
+                raise AncestryError(
+                    f"{n_missing} samples in reference panel have no labels. "
+                    f"Set require_all_labeled=False to allow unlabeled samples."
+                )
+            # Filter to only labeled samples
+            merged = merged[~missing_labels]
+
+        # Create Series with IID as index
+        labels_series = pd.Series(
+            merged["label"].values,
+            index=merged["IID"].values,
+            name="label",
+        )
+
+        return cls(
+            genotypes=genotypes,
+            labels=labels_series,
+            labels_path=labels_path,
+        )
+
+    @staticmethod
+    def _load_labels_file(path: Path) -> pd.DataFrame:
+        """Load ancestry labels file.
+
+        Handles both headerless files and files with FID/IID/label header.
+
+        Args:
+            path: Path to labels file.
+
+        Returns:
+            DataFrame with FID, IID, label columns.
+        """
+        # Try reading with assumed columns
+        df = pd.read_csv(
+            path,
+            sep="\t",
+            header=None,
+            names=["FID", "IID", "label"],
+            dtype=str,
+        )
+
+        # Check if first row looks like a header
+        if df.iloc[0]["FID"] in ("FID", "#FID"):
+            # Re-read with header
+            df = pd.read_csv(path, sep="\t", dtype=str)
+            # Normalize column names
+            df.columns = [c.replace("#", "") for c in df.columns]
+            if "label" not in df.columns:
+                # Try common alternatives
+                for alt in ("LABEL", "ancestry", "ANCESTRY", "pop", "POP"):
+                    if alt in df.columns:
+                        df = df.rename(columns={alt: "label"})
+                        break
+
+        return df[["FID", "IID", "label"]]
+
+    @property
+    def sample_count(self) -> int:
+        """Number of labeled samples in reference panel."""
+        return len(self.labels)
+
+    @property
+    def variant_count(self) -> int:
+        """Number of variants in reference panel."""
+        return self.genotypes.variant_count
+
+    @property
+    def ancestry_counts(self) -> Dict[str, int]:
+        """Count of samples per ancestry label.
+
+        Returns:
+            Dictionary mapping ancestry labels to sample counts.
+        """
+        counts = self.labels.value_counts()
+        return dict(counts)
+
+    @property
+    def unique_ancestries(self) -> List[str]:
+        """List of unique ancestry labels in reference panel."""
+        return list(self.labels.unique())
+
+    def get_samples_by_ancestry(self, ancestry: str) -> List[str]:
+        """Get sample IDs for a specific ancestry.
+
+        Args:
+            ancestry: Ancestry label to filter by.
+
+        Returns:
+            List of sample IIDs with the specified ancestry.
+        """
+        return list(self.labels[self.labels == ancestry].index)
+
+    def validate_snp_overlap(
+        self,
+        other: GenotypeData,
+        min_overlap: int = 10000,
+    ) -> int:
+        """Check SNP overlap with another genotype dataset.
+
+        Ancestry prediction requires sufficient SNP overlap between
+        the reference panel and the target samples. This method
+        estimates the overlap (actual overlap is computed during
+        data preparation).
+
+        Args:
+            other: GenotypeData to check overlap with.
+            min_overlap: Minimum required SNP overlap. Default is 10000.
+
+        Returns:
+            Estimated number of overlapping SNPs.
+
+        Raises:
+            AncestryError: If overlap is below minimum threshold.
+        """
+        # This is a simplified check - actual overlap computation
+        # happens during data preparation when SNP IDs are compared
+        min_variants = min(self.variant_count, other.variant_count)
+
+        if min_variants < min_overlap:
+            raise AncestryError(
+                f"Insufficient variant count for ancestry prediction. "
+                f"Reference has {self.variant_count} variants, "
+                f"target has {other.variant_count} variants. "
+                f"Expected at least {min_overlap} overlapping SNPs."
+            )
+
+        return min_variants
+
+    def get_labeled_data(self) -> pd.DataFrame:
+        """Get labeled sample information.
+
+        Returns:
+            DataFrame with FID, IID, and label columns for all
+            labeled samples in the reference panel.
+        """
+        # Load fam file for FID/IID pairs
+        fam_df = pd.read_csv(
+            self.genotypes.path.with_suffix(".fam"),
+            sep=r"\s+",
+            header=None,
+            names=["FID", "IID", "PAT", "MAT", "SEX", "PHENO"],
+            dtype=str,
+        )
+
+        # Filter to labeled samples and add labels
+        labeled = fam_df[fam_df["IID"].isin(self.labels.index)].copy()
+        labeled["label"] = labeled["IID"].map(self.labels)
+
+        return labeled[["FID", "IID", "label"]]
+
+
+def get_default_model_path() -> Optional[Path]:
+    """Get path to bundled NBA model if available.
+
+    Returns the path to the pre-trained NBA v2 model if it has been
+    downloaded using genotools-download.
+
+    Returns:
+        Path to model directory, or None if not available.
+    """
+    import os
+
+    model_destination = os.path.expanduser("~/.genotools/ref")
+    nba_model_dir = Path(model_destination) / "models" / "nba_v2"
+
+    if nba_model_dir.exists():
+        return nba_model_dir
+
+    return None
+
+
+def validate_model_files(model_dir: Path) -> Dict[str, Path]:
+    """Validate that required model files exist.
+
+    Checks for the presence of all files needed to load a trained
+    ancestry model.
+
+    Args:
+        model_dir: Directory containing model files.
+
+    Returns:
+        Dictionary mapping file types to their paths.
+
+    Raises:
+        FileNotFoundError: If required files are missing.
+    """
+    required_files = {
+        "model": "*.pkl",
+        "common_snps": "*.common_snps",
+    }
+
+    found_files: Dict[str, Path] = {}
+
+    for file_type, pattern in required_files.items():
+        matches = list(model_dir.glob(pattern))
+        if not matches:
+            raise FileNotFoundError(
+                f"Required {file_type} file not found in {model_dir}. "
+                f"Expected file matching pattern: {pattern}"
+            )
+        found_files[file_type] = matches[0]
+
+    return found_files

--- a/genotools/ancestry/results.py
+++ b/genotools/ancestry/results.py
@@ -1,0 +1,397 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Ancestry prediction result dataclasses.
+
+This module provides typed result classes for ancestry prediction outputs,
+including predictions, model training metrics, and pipeline results.
+
+Example:
+    >>> from genotools.ancestry.results import AncestryPredictions
+    >>> # Access predictions
+    >>> predictions.get_ancestry("SAMPLE001")
+    'EUR'
+    >>> predictions.filter_by_ancestry("EUR")
+    ['SAMPLE001', 'SAMPLE002', ...]
+    >>> predictions.ancestry_counts
+    {'EUR': 100, 'AFR': 50, ...}
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class AncestryPredictions:
+    """Ancestry prediction results for a set of samples.
+
+    This class holds the predicted ancestry labels and associated metadata
+    for all samples processed through the ancestry prediction pipeline.
+
+    The predictions DataFrame contains:
+    - FID: Family ID
+    - IID: Individual ID
+    - predicted_ancestry: Predicted ancestry label (e.g., "EUR", "AFR")
+    - Additional columns for per-class probabilities (if available)
+
+    Attributes:
+        predictions: DataFrame with sample IDs and predicted ancestries.
+            Must contain 'FID', 'IID', and 'predicted_ancestry' columns.
+        probabilities: Optional DataFrame with per-class prediction
+            probabilities. Columns are ancestry labels, rows are samples.
+        output_path: Path where predictions were saved, if any.
+    """
+
+    predictions: pd.DataFrame
+    probabilities: Optional[pd.DataFrame] = None
+    output_path: Optional[Path] = None
+
+    def __post_init__(self) -> None:
+        """Validate predictions DataFrame."""
+        required_cols = {"FID", "IID", "predicted_ancestry"}
+        missing = required_cols - set(self.predictions.columns)
+        if missing:
+            raise ValueError(
+                f"predictions DataFrame missing required columns: {missing}"
+            )
+
+    def get_ancestry(self, sample_id: str) -> Optional[str]:
+        """Get predicted ancestry for a specific sample.
+
+        Args:
+            sample_id: Individual ID (IID) to look up.
+
+        Returns:
+            Predicted ancestry label, or None if sample not found.
+        """
+        mask = self.predictions["IID"] == sample_id
+        if not mask.any():
+            return None
+        return str(self.predictions.loc[mask, "predicted_ancestry"].iloc[0])
+
+    def filter_by_ancestry(self, ancestry: str) -> List[str]:
+        """Get all sample IDs for a given ancestry.
+
+        Args:
+            ancestry: Ancestry label to filter by (e.g., "EUR").
+
+        Returns:
+            List of individual IDs (IID) with the specified ancestry.
+        """
+        mask = self.predictions["predicted_ancestry"] == ancestry
+        return list(self.predictions.loc[mask, "IID"])
+
+    @property
+    def ancestry_counts(self) -> Dict[str, int]:
+        """Count of samples per predicted ancestry.
+
+        Returns:
+            Dictionary mapping ancestry labels to sample counts.
+        """
+        counts = self.predictions["predicted_ancestry"].value_counts()
+        return dict(counts)
+
+    @property
+    def sample_count(self) -> int:
+        """Total number of samples with predictions."""
+        return len(self.predictions)
+
+    @property
+    def unique_ancestries(self) -> List[str]:
+        """List of unique ancestry labels in predictions."""
+        return list(self.predictions["predicted_ancestry"].unique())
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return predictions as DataFrame.
+
+        Returns:
+            Copy of the predictions DataFrame.
+        """
+        return self.predictions.copy()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to legacy dictionary format for backward compatibility.
+
+        Returns the format expected by existing pipeline code:
+        {
+            'data': {'ids': DataFrame, 'y_pred': array, ...},
+            'metrics': {'predicted_counts': Series, ...},
+            'output': {'labels_outpath': str}
+        }
+
+        Returns:
+            Dictionary in legacy format.
+        """
+        return {
+            "data": {
+                "ids": self.predictions[["FID", "IID", "predicted_ancestry"]],
+                "y_pred": self.predictions["predicted_ancestry"].values,
+            },
+            "metrics": {
+                "predicted_counts": self.predictions[
+                    "predicted_ancestry"
+                ].value_counts()
+            },
+            "output": {
+                "labels_outpath": (
+                    str(self.output_path) if self.output_path else None
+                )
+            },
+        }
+
+    def save(self, path: Path) -> Path:
+        """Save predictions to a tab-separated file.
+
+        Args:
+            path: Output file path.
+
+        Returns:
+            Path to the saved file.
+        """
+        self.predictions[["FID", "IID", "predicted_ancestry"]].rename(
+            columns={"predicted_ancestry": "label"}
+        ).to_csv(path, sep="\t", index=False)
+        return path
+
+
+@dataclass
+class TrainingMetrics:
+    """Metrics from model training.
+
+    Captures accuracy, confusion matrix, and hyperparameters from
+    the training process for model evaluation and diagnostics.
+
+    Attributes:
+        train_accuracy: Cross-validated training accuracy.
+        test_accuracy: Accuracy on held-out test set.
+        train_accuracy_ci: 95% confidence interval for train accuracy.
+        test_accuracy_ci: 95% confidence interval for test accuracy.
+        confusion_matrix: Confusion matrix as numpy array.
+        best_params: Best hyperparameters from grid search.
+        label_encoder_classes: Ordered list of class labels.
+    """
+
+    train_accuracy: float
+    test_accuracy: float
+    train_accuracy_ci: Tuple[float, float]
+    test_accuracy_ci: Tuple[float, float]
+    confusion_matrix: np.ndarray  # type: ignore[type-arg]
+    best_params: Dict[str, Any]
+    label_encoder_classes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization.
+
+        Returns:
+            Dictionary with all metrics.
+        """
+        return {
+            "train_accuracy": self.train_accuracy,
+            "test_accuracy": self.test_accuracy,
+            "train_accuracy_ci": self.train_accuracy_ci,
+            "test_accuracy_ci": self.test_accuracy_ci,
+            "confusion_matrix": self.confusion_matrix.tolist(),
+            "best_params": self.best_params,
+            "label_encoder_classes": self.label_encoder_classes,
+        }
+
+
+@dataclass
+class PCAResult:
+    """Results from PCA transformation.
+
+    Contains the transformed data and metadata from PCA computation,
+    including eigenvalues for variance analysis.
+
+    Attributes:
+        train_pca: PCA-transformed training data with labels.
+        test_pca: PCA-transformed test data with labels.
+        ref_pca: Full reference panel PCA (train + test combined).
+        projected_pca: PCA-projected new samples.
+        eigenvalues: Eigenvalues for each principal component.
+        explained_variance_ratio: Proportion of variance explained.
+        n_components: Number of PCA components.
+        n_snps_used: Number of SNPs used in PCA (after filtering).
+        train_mean: Training data mean (for projection).
+        train_sd: Training data standard deviation (for projection).
+    """
+
+    train_pca: pd.DataFrame
+    test_pca: pd.DataFrame
+    ref_pca: pd.DataFrame
+    projected_pca: pd.DataFrame
+    eigenvalues: np.ndarray  # type: ignore[type-arg]
+    explained_variance_ratio: np.ndarray  # type: ignore[type-arg]
+    n_components: int
+    n_snps_used: int
+    train_mean: np.ndarray  # type: ignore[type-arg]
+    train_sd: np.ndarray  # type: ignore[type-arg]
+
+    def save_eigenvalues(self, path: Path) -> Path:
+        """Save eigenvalues to a file.
+
+        Args:
+            path: Output file path.
+
+        Returns:
+            Path to the saved file.
+        """
+        col_names = [f"PC{i+1}" for i in range(self.n_components)]
+        ev_df = pd.DataFrame({
+            "PC": col_names,
+            "eigenvalue": self.eigenvalues,
+            "explained_variance_ratio": self.explained_variance_ratio,
+        })
+        ev_df.to_csv(path, sep="\t", index=False)
+        return path
+
+
+@dataclass
+class UMAPResult:
+    """Results from UMAP transformation.
+
+    Contains the UMAP embeddings for visualization and the fitted
+    UMAP model parameters.
+
+    Attributes:
+        ref_umap: UMAP embedding of reference samples with labels.
+        new_umap: UMAP embedding of new samples with predicted labels.
+        total_umap: Combined UMAP embedding (ref + new) with dataset labels.
+        params: UMAP parameters used (may be from grid search).
+    """
+
+    ref_umap: pd.DataFrame
+    new_umap: pd.DataFrame
+    total_umap: pd.DataFrame
+    params: Dict[str, Any]
+
+
+@dataclass
+class SplitResult:
+    """Results from splitting cohort by ancestry.
+
+    Contains the paths to ancestry-specific genotype files and
+    information about samples that were pruned due to small group sizes.
+
+    Attributes:
+        ancestry_paths: Dictionary mapping ancestry labels to output paths.
+        ancestry_labels: List of ancestries that met minimum sample threshold.
+        pruned_samples: DataFrame of samples pruned due to small ancestry
+            group size. Contains FID, IID, step, label columns.
+    """
+
+    ancestry_paths: Dict[str, Path]
+    ancestry_labels: List[str]
+    pruned_samples: pd.DataFrame
+
+    @property
+    def n_ancestries(self) -> int:
+        """Number of ancestry groups in output."""
+        return len(self.ancestry_labels)
+
+    @property
+    def n_pruned(self) -> int:
+        """Number of samples pruned due to small group size."""
+        return len(self.pruned_samples)
+
+
+@dataclass
+class AncestryResult:
+    """Complete result of ancestry prediction pipeline.
+
+    This is the top-level result class that combines all outputs from
+    running ancestry prediction, including predictions, training metrics,
+    PCA/UMAP results, and split cohort information.
+
+    Attributes:
+        predictions: Ancestry predictions for all samples.
+        training_metrics: Model training metrics (if model was trained).
+        pca_result: PCA transformation results.
+        umap_result: UMAP transformation results (if computed).
+        split_result: Cohort splitting results.
+        model_path: Path to saved model file, if any.
+        common_snps_path: Path to common SNPs file used for prediction.
+    """
+
+    predictions: AncestryPredictions
+    training_metrics: Optional[TrainingMetrics] = None
+    pca_result: Optional[PCAResult] = None
+    umap_result: Optional[UMAPResult] = None
+    split_result: Optional[SplitResult] = None
+    model_path: Optional[Path] = None
+    common_snps_path: Optional[Path] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to legacy dictionary format for backward compatibility.
+
+        Returns the format expected by existing pipeline code:
+        {
+            'step': 'predict_ancestry',
+            'data': {...},
+            'metrics': {...},
+            'output': {...}
+        }
+
+        Returns:
+            Dictionary in legacy format.
+        """
+        data_dict: Dict[str, Any] = {
+            "predict_data": self.predictions.to_dict()["data"],
+        }
+
+        if self.training_metrics:
+            data_dict["confusion_matrix"] = self.training_metrics.confusion_matrix
+            data_dict["label_encoder"] = self.training_metrics.label_encoder_classes
+
+        if self.pca_result:
+            data_dict["train_pcs"] = self.pca_result.train_pca
+            data_dict["ref_pcs"] = self.pca_result.ref_pca
+            data_dict["projected_pcs"] = self.pca_result.projected_pca
+
+        if self.umap_result:
+            data_dict["total_umap"] = self.umap_result.total_umap
+            data_dict["ref_umap"] = self.umap_result.ref_umap
+            data_dict["new_samples_umap"] = self.umap_result.new_umap
+
+        if self.split_result:
+            data_dict["labels_list"] = self.split_result.ancestry_labels
+            data_dict["pruned_samples"] = self.split_result.pruned_samples
+
+        metrics_dict: Dict[str, Any] = {
+            "predicted_counts": self.predictions.ancestry_counts,
+        }
+
+        if self.training_metrics:
+            metrics_dict["test_accuracy"] = self.training_metrics.test_accuracy
+
+        outfiles_dict: Dict[str, Any] = {
+            "predicted_labels": self.predictions.to_dict()["output"],
+        }
+
+        if self.split_result:
+            outfiles_dict["split_paths"] = list(
+                self.split_result.ancestry_paths.values()
+            )
+
+        return {
+            "step": "predict_ancestry",
+            "data": data_dict,
+            "metrics": metrics_dict,
+            "output": outfiles_dict,
+        }

--- a/tests/unit/test_ancestry/__init__.py
+++ b/tests/unit/test_ancestry/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Unit tests for ancestry module."""

--- a/tests/unit/test_ancestry/test_config.py
+++ b/tests/unit/test_ancestry/test_config.py
@@ -1,0 +1,352 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for ancestry configuration classes."""
+
+import pytest
+
+from genotools.ancestry.config import (
+    AdmixedConfig,
+    AncestryConfig,
+    ClassifierConfig,
+    GridSearchConfig,
+    InferenceConfig,
+    InferenceMode,
+    PCAConfig,
+    TrainingConfig,
+    UMAPConfig,
+    DEFAULT_ANCESTRY_LABELS,
+)
+
+
+class TestPCAConfig:
+    """Tests for PCAConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = PCAConfig()
+        assert config.n_components == 50
+        assert config.maf == 0.01
+        assert config.geno == 0.1
+        assert config.hwe == 5e-6
+        assert config.random_state == 123
+
+    def test_custom_values(self) -> None:
+        """Custom values are accepted."""
+        config = PCAConfig(n_components=20, maf=0.05)
+        assert config.n_components == 20
+        assert config.maf == 0.05
+
+    def test_invalid_n_components_too_small(self) -> None:
+        """n_components < 2 raises ValueError."""
+        with pytest.raises(ValueError, match="n_components must be >= 2"):
+            PCAConfig(n_components=1)
+
+    def test_invalid_n_components_too_large(self) -> None:
+        """n_components > 1000 raises ValueError."""
+        with pytest.raises(ValueError, match="n_components must be <= 1000"):
+            PCAConfig(n_components=1500)
+
+    def test_invalid_maf_negative(self) -> None:
+        """Negative maf raises ValueError."""
+        with pytest.raises(ValueError, match="maf"):
+            PCAConfig(maf=-0.1)
+
+    def test_invalid_maf_too_large(self) -> None:
+        """maf > 1 raises ValueError."""
+        with pytest.raises(ValueError, match="maf"):
+            PCAConfig(maf=1.5)
+
+    def test_invalid_hwe_zero(self) -> None:
+        """hwe = 0 raises ValueError."""
+        with pytest.raises(ValueError, match="hwe must be in"):
+            PCAConfig(hwe=0)
+
+    def test_invalid_hwe_negative(self) -> None:
+        """Negative hwe raises ValueError."""
+        with pytest.raises(ValueError, match="hwe must be in"):
+            PCAConfig(hwe=-1e-6)
+
+    def test_frozen(self) -> None:
+        """Config is immutable."""
+        config = PCAConfig()
+        with pytest.raises(AttributeError):
+            config.n_components = 30  # type: ignore[misc]
+
+
+class TestUMAPConfig:
+    """Tests for UMAPConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = UMAPConfig()
+        assert config.n_neighbors == 15
+        assert config.n_components == 2
+        assert config.min_dist == 0.1
+        assert config.metric == "euclidean"
+        assert config.a is None
+        assert config.b is None
+        assert config.random_state == 123
+
+    def test_custom_values(self) -> None:
+        """Custom values are accepted."""
+        config = UMAPConfig(n_neighbors=10, n_components=3, a=1.0, b=0.5)
+        assert config.n_neighbors == 10
+        assert config.n_components == 3
+        assert config.a == 1.0
+        assert config.b == 0.5
+
+    def test_invalid_n_neighbors_too_small(self) -> None:
+        """n_neighbors < 2 raises ValueError."""
+        with pytest.raises(ValueError, match="n_neighbors must be >= 2"):
+            UMAPConfig(n_neighbors=1)
+
+    def test_invalid_n_components_too_small(self) -> None:
+        """n_components < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="n_components must be >= 1"):
+            UMAPConfig(n_components=0)
+
+    def test_invalid_a_not_positive(self) -> None:
+        """a <= 0 raises ValueError."""
+        with pytest.raises(ValueError, match="a must be positive"):
+            UMAPConfig(a=0)
+
+    def test_invalid_b_not_positive(self) -> None:
+        """b <= 0 raises ValueError."""
+        with pytest.raises(ValueError, match="b must be positive"):
+            UMAPConfig(b=-0.5)
+
+
+class TestClassifierConfig:
+    """Tests for ClassifierConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = ClassifierConfig()
+        assert config.n_estimators == 100
+        assert config.max_depth == 6
+        assert config.learning_rate == 0.1
+        assert config.booster == "gblinear"
+        assert config.reg_lambda == 1.0
+        assert config.random_state == 123
+
+    def test_custom_values(self) -> None:
+        """Custom values are accepted."""
+        config = ClassifierConfig(n_estimators=200, booster="gbtree")
+        assert config.n_estimators == 200
+        assert config.booster == "gbtree"
+
+    def test_invalid_n_estimators(self) -> None:
+        """n_estimators < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="n_estimators must be >= 1"):
+            ClassifierConfig(n_estimators=0)
+
+    def test_invalid_max_depth(self) -> None:
+        """max_depth < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="max_depth must be >= 1"):
+            ClassifierConfig(max_depth=0)
+
+    def test_invalid_learning_rate(self) -> None:
+        """Negative learning_rate raises ValueError."""
+        with pytest.raises(ValueError, match="learning_rate must be positive"):
+            ClassifierConfig(learning_rate=-0.1)
+
+    def test_invalid_booster(self) -> None:
+        """Invalid booster raises ValueError."""
+        with pytest.raises(ValueError, match="booster must be"):
+            ClassifierConfig(booster="invalid")
+
+    def test_valid_boosters(self) -> None:
+        """All valid boosters are accepted."""
+        for booster in ("gbtree", "gblinear", "dart"):
+            config = ClassifierConfig(booster=booster)
+            assert config.booster == booster
+
+
+class TestGridSearchConfig:
+    """Tests for GridSearchConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = GridSearchConfig()
+        assert config.umap_n_neighbors == (5, 20)
+        assert config.umap_n_components == (15, 25)
+        assert config.umap_a == (0.75, 1.0, 1.5)
+        assert config.umap_b == (0.25, 0.5, 0.75)
+        assert config.cv_folds == 5
+        assert config.scoring == "balanced_accuracy"
+
+    def test_invalid_cv_folds(self) -> None:
+        """cv_folds < 2 raises ValueError."""
+        with pytest.raises(ValueError, match="cv_folds must be >= 2"):
+            GridSearchConfig(cv_folds=1)
+
+    def test_empty_umap_n_neighbors(self) -> None:
+        """Empty umap_n_neighbors raises ValueError."""
+        with pytest.raises(ValueError, match="umap_n_neighbors cannot be empty"):
+            GridSearchConfig(umap_n_neighbors=())
+
+
+class TestAdmixedConfig:
+    """Tests for AdmixedConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = AdmixedConfig()
+        assert config.n_clusters_cas == 2
+        assert config.birch_threshold is None
+
+    def test_invalid_n_clusters(self) -> None:
+        """n_clusters_cas < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="n_clusters_cas must be >= 1"):
+            AdmixedConfig(n_clusters_cas=0)
+
+
+class TestInferenceConfig:
+    """Tests for InferenceConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = InferenceConfig()
+        assert config.mode == InferenceMode.LOCAL
+        assert config.container_image == "mkoretsky1/genotools_ancestry:python3.11"
+        assert config.cloud_project is None
+        assert config.cloud_region == "us-central1"
+
+    def test_all_modes(self) -> None:
+        """All inference modes are valid."""
+        for mode in InferenceMode:
+            if mode == InferenceMode.CLOUD:
+                config = InferenceConfig(mode=mode, cloud_project="test-project")
+            else:
+                config = InferenceConfig(mode=mode)
+            assert config.mode == mode
+
+    def test_cloud_mode_requires_project(self) -> None:
+        """Cloud mode without project raises ValueError."""
+        with pytest.raises(ValueError, match="cloud_project is required"):
+            InferenceConfig(mode=InferenceMode.CLOUD)
+
+    def test_cloud_mode_with_project(self) -> None:
+        """Cloud mode with project is valid."""
+        config = InferenceConfig(
+            mode=InferenceMode.CLOUD, cloud_project="my-project"
+        )
+        assert config.cloud_project == "my-project"
+
+
+class TestTrainingConfig:
+    """Tests for TrainingConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = TrainingConfig()
+        assert config.test_size == 0.2
+        assert config.random_state == 123
+        assert config.n_jobs is None
+        assert config.gb_per_worker == 3.0
+
+    def test_invalid_test_size_zero(self) -> None:
+        """test_size = 0 raises ValueError."""
+        with pytest.raises(ValueError, match="test_size must be in"):
+            TrainingConfig(test_size=0)
+
+    def test_invalid_test_size_one(self) -> None:
+        """test_size = 1 raises ValueError."""
+        with pytest.raises(ValueError, match="test_size must be in"):
+            TrainingConfig(test_size=1.0)
+
+    def test_invalid_test_size_negative(self) -> None:
+        """Negative test_size raises ValueError."""
+        with pytest.raises(ValueError, match="test_size must be in"):
+            TrainingConfig(test_size=-0.1)
+
+
+class TestAncestryConfig:
+    """Tests for AncestryConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = AncestryConfig()
+        assert isinstance(config.pca, PCAConfig)
+        assert isinstance(config.umap, UMAPConfig)
+        assert isinstance(config.classifier, ClassifierConfig)
+        assert isinstance(config.grid_search, GridSearchConfig)
+        assert isinstance(config.admixed, AdmixedConfig)
+        assert isinstance(config.inference, InferenceConfig)
+        assert isinstance(config.training, TrainingConfig)
+        assert config.labels == DEFAULT_ANCESTRY_LABELS
+        assert config.min_samples_per_ancestry == 0
+
+    def test_nested_config(self) -> None:
+        """Nested configs can be customized."""
+        config = AncestryConfig(
+            pca=PCAConfig(n_components=20),
+            umap=UMAPConfig(n_neighbors=10),
+        )
+        assert config.pca.n_components == 20
+        assert config.umap.n_neighbors == 10
+
+    def test_empty_labels(self) -> None:
+        """Empty labels raises ValueError."""
+        with pytest.raises(ValueError, match="labels cannot be empty"):
+            AncestryConfig(labels=())
+
+    def test_invalid_min_samples(self) -> None:
+        """Negative min_samples_per_ancestry raises ValueError."""
+        with pytest.raises(ValueError, match="min_samples_per_ancestry must be >= 0"):
+            AncestryConfig(min_samples_per_ancestry=-1)
+
+    def test_default_ancestry_labels(self) -> None:
+        """Default ancestry labels are correct."""
+        expected = (
+            "AFR", "SAS", "EAS", "EUR", "AMR",
+            "AJ", "CAS", "MDE", "FIN", "AAC",
+        )
+        assert DEFAULT_ANCESTRY_LABELS == expected
+
+
+class TestInferenceMode:
+    """Tests for InferenceMode enum."""
+
+    def test_all_modes_have_values(self) -> None:
+        """All modes have string values."""
+        assert InferenceMode.LOCAL.value == "local"
+        assert InferenceMode.CONTAINER.value == "container"
+        assert InferenceMode.SINGULARITY.value == "singularity"
+        assert InferenceMode.CLOUD.value == "cloud"
+
+
+class TestConfigImmutability:
+    """Tests that all configs are immutable (frozen)."""
+
+    def test_all_configs_frozen(self) -> None:
+        """All config classes are frozen dataclasses."""
+        configs = [
+            PCAConfig(),
+            UMAPConfig(),
+            ClassifierConfig(),
+            GridSearchConfig(),
+            AdmixedConfig(),
+            InferenceConfig(),
+            TrainingConfig(),
+            AncestryConfig(),
+        ]
+
+        for config in configs:
+            # Get first attribute
+            attr = list(config.__dataclass_fields__.keys())[0]
+            with pytest.raises(AttributeError):
+                setattr(config, attr, "new_value")

--- a/tests/unit/test_ancestry/test_reducers.py
+++ b/tests/unit/test_ancestry/test_reducers.py
@@ -1,0 +1,335 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for ancestry reducers (PCA, UMAP)."""
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from genotools.ancestry.config import PCAConfig, UMAPConfig
+from genotools.ancestry.reducers.pca import PCAReducer, flashpca_scale
+from genotools.ancestry.reducers.umap_reducer import UMAPReducer
+from genotools.core.exceptions import AncestryError
+
+
+class TestFlashPCAScale:
+    """Tests for flashpca_scale function."""
+
+    def test_compute_stats(self) -> None:
+        """flashpca_scale computes mean and sd correctly."""
+        # Create genotype-like data (0, 1, 2 values)
+        np.random.seed(42)
+        data = np.random.choice([0, 1, 2], size=(100, 50), p=[0.25, 0.5, 0.25])
+        data = data.astype(float)
+
+        scaled, mean, sd, keep_mask = flashpca_scale(data, compute_stats=True)
+
+        # Mean should be computed
+        assert mean is not None
+        assert len(mean) == 50
+
+        # SD should use flashPCA formula: sqrt(mean/2 * (1 - mean/2))
+        expected_sd = np.sqrt((mean / 2) * (1 - mean / 2))
+        np.testing.assert_array_almost_equal(sd, expected_sd)
+
+        # Most SNPs should be kept
+        assert keep_mask.sum() > 40
+
+    def test_apply_existing_stats(self) -> None:
+        """flashpca_scale applies provided mean and sd."""
+        np.random.seed(42)
+        data = np.random.choice([0, 1, 2], size=(50, 20), p=[0.25, 0.5, 0.25])
+        data = data.astype(float)
+
+        # First compute stats
+        _, mean, sd, keep_mask = flashpca_scale(data, compute_stats=True)
+
+        # Apply to new data
+        new_data = np.random.choice([0, 1, 2], size=(30, 20), p=[0.25, 0.5, 0.25])
+        new_data = new_data.astype(float)
+
+        scaled, _, _, _ = flashpca_scale(
+            new_data, mean=mean, sd=sd, compute_stats=False
+        )
+
+        # Output should be filtered to kept SNPs
+        assert scaled.shape[1] == keep_mask.sum()
+
+    def test_missing_stats_raises(self) -> None:
+        """flashpca_scale raises without stats when not computing."""
+        data = np.random.randn(10, 5)
+
+        with pytest.raises(ValueError, match="mean and sd must be provided"):
+            flashpca_scale(data, compute_stats=False)
+
+
+class TestPCAReducer:
+    """Tests for PCAReducer class."""
+
+    @pytest.fixture
+    def sample_data(self) -> np.ndarray:  # type: ignore[type-arg]
+        """Create sample genotype data."""
+        np.random.seed(42)
+        # 100 samples, 200 SNPs
+        data = np.random.choice([0, 1, 2], size=(100, 200), p=[0.25, 0.5, 0.25])
+        return data.astype(float)
+
+    def test_default_config(self) -> None:
+        """PCAReducer uses default config."""
+        reducer = PCAReducer()
+        assert reducer.n_components == 50
+        assert not reducer.is_fitted
+
+    def test_custom_config(self) -> None:
+        """PCAReducer accepts custom config."""
+        config = PCAConfig(n_components=20)
+        reducer = PCAReducer(config=config)
+        assert reducer.n_components == 20
+
+    def test_fit(self, sample_data: np.ndarray) -> None:  # type: ignore[type-arg]
+        """PCAReducer fits on data."""
+        reducer = PCAReducer(config=PCAConfig(n_components=10))
+        reducer.fit(sample_data)
+
+        assert reducer.is_fitted
+        assert reducer.n_variants_used > 0
+        assert reducer.pca is not None
+
+    def test_transform_before_fit_raises(
+        self, sample_data: np.ndarray  # type: ignore[type-arg]
+    ) -> None:
+        """Transform before fit raises error."""
+        reducer = PCAReducer()
+
+        with pytest.raises(AncestryError, match="must be fitted"):
+            reducer.transform(sample_data)
+
+    def test_transform(self, sample_data: np.ndarray) -> None:  # type: ignore[type-arg]
+        """PCAReducer transforms data after fit."""
+        config = PCAConfig(n_components=10)
+        reducer = PCAReducer(config=config)
+        reducer.fit(sample_data)
+
+        transformed = reducer.transform(sample_data)
+        assert isinstance(transformed, np.ndarray)
+        assert transformed.shape == (100, 10)
+
+    def test_transform_returns_dataframe(
+        self, sample_data: np.ndarray  # type: ignore[type-arg]
+    ) -> None:
+        """Transform can return DataFrame."""
+        config = PCAConfig(n_components=10)
+        reducer = PCAReducer(config=config)
+        reducer.fit(sample_data)
+
+        result = reducer.transform(sample_data, return_dataframe=True)
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == [f"PC{i+1}" for i in range(10)]
+
+    def test_fit_transform(self, sample_data: np.ndarray) -> None:  # type: ignore[type-arg]
+        """fit_transform works in one step."""
+        config = PCAConfig(n_components=10)
+        reducer = PCAReducer(config=config)
+
+        result = reducer.fit_transform(sample_data)
+        assert reducer.is_fitted
+        assert result.shape == (100, 10)
+
+    def test_eigenvalues(self, sample_data: np.ndarray) -> None:  # type: ignore[type-arg]
+        """Eigenvalues are available after fit."""
+        config = PCAConfig(n_components=10)
+        reducer = PCAReducer(config=config)
+        reducer.fit(sample_data)
+
+        assert reducer.eigenvalues is not None
+        assert len(reducer.eigenvalues) == 10
+        # Eigenvalues should be in descending order
+        assert all(
+            reducer.eigenvalues[i] >= reducer.eigenvalues[i + 1]
+            for i in range(len(reducer.eigenvalues) - 1)
+        )
+
+    def test_explained_variance_ratio(
+        self, sample_data: np.ndarray  # type: ignore[type-arg]
+    ) -> None:
+        """Explained variance ratio is available after fit."""
+        config = PCAConfig(n_components=10)
+        reducer = PCAReducer(config=config)
+        reducer.fit(sample_data)
+
+        assert reducer.explained_variance_ratio is not None
+        assert len(reducer.explained_variance_ratio) == 10
+        # Sum should be <= 1
+        assert reducer.explained_variance_ratio.sum() <= 1.0
+
+    def test_save_eigenvalues(
+        self, sample_data: np.ndarray, tmp_path: Path  # type: ignore[type-arg]
+    ) -> None:
+        """Eigenvalues can be saved to file."""
+        config = PCAConfig(n_components=10)
+        reducer = PCAReducer(config=config)
+        reducer.fit(sample_data)
+
+        output = tmp_path / "eigenvalues.txt"
+        reducer.save_eigenvalues(output)
+
+        assert output.exists()
+        df = pd.read_csv(output, sep="\t")
+        assert len(df) == 10
+        assert "PC" in df.columns
+        assert "eigenvalue" in df.columns
+
+    def test_insufficient_samples_raises(self) -> None:
+        """Fit with too few samples raises error."""
+        # Only 20 samples
+        data = np.random.choice([0, 1, 2], size=(20, 100))
+        data = data.astype(float)
+
+        reducer = PCAReducer()
+        with pytest.raises(AncestryError, match="insufficient for PCA"):
+            reducer.fit(data)
+
+    def test_insufficient_snps_raises(self) -> None:
+        """Fit with too few SNPs raises error."""
+        # Only 20 SNPs
+        data = np.random.choice([0, 1, 2], size=(100, 20))
+        data = data.astype(float)
+
+        reducer = PCAReducer()
+        with pytest.raises(AncestryError, match="insufficient for PCA"):
+            reducer.fit(data)
+
+    def test_handles_missing_values(
+        self, sample_data: np.ndarray  # type: ignore[type-arg]
+    ) -> None:
+        """PCAReducer handles NaN values via imputation."""
+        # Add some missing values
+        data_with_nan = sample_data.copy()
+        data_with_nan[0, 0] = np.nan
+        data_with_nan[10, 5] = np.nan
+
+        config = PCAConfig(n_components=10)
+        reducer = PCAReducer(config=config)
+        reducer.fit(data_with_nan)
+
+        # Should fit without error
+        assert reducer.is_fitted
+
+
+class TestUMAPReducer:
+    """Tests for UMAPReducer class."""
+
+    @pytest.fixture
+    def sample_pca_data(self) -> np.ndarray:  # type: ignore[type-arg]
+        """Create sample PCA-like data."""
+        np.random.seed(42)
+        # 100 samples, 20 PCs
+        return np.random.randn(100, 20)
+
+    def test_default_config(self) -> None:
+        """UMAPReducer uses default config."""
+        reducer = UMAPReducer()
+        assert reducer.n_components == 2
+        assert not reducer.is_fitted
+
+    def test_custom_config(self) -> None:
+        """UMAPReducer accepts custom config."""
+        config = UMAPConfig(n_neighbors=10, n_components=3)
+        reducer = UMAPReducer(config=config)
+        assert reducer.n_components == 3
+
+    def test_fit(self, sample_pca_data: np.ndarray) -> None:  # type: ignore[type-arg]
+        """UMAPReducer fits on data."""
+        reducer = UMAPReducer()
+        reducer.fit(sample_pca_data)
+
+        assert reducer.is_fitted
+        assert reducer.umap is not None
+
+    def test_transform(self, sample_pca_data: np.ndarray) -> None:  # type: ignore[type-arg]
+        """UMAPReducer transforms data."""
+        reducer = UMAPReducer()
+        reducer.fit(sample_pca_data)
+
+        transformed = reducer.transform(sample_pca_data)
+        assert isinstance(transformed, np.ndarray)
+        assert transformed.shape == (100, 2)
+
+    def test_transform_returns_dataframe(
+        self, sample_pca_data: np.ndarray  # type: ignore[type-arg]
+    ) -> None:
+        """Transform can return DataFrame."""
+        reducer = UMAPReducer()
+        reducer.fit(sample_pca_data)
+
+        result = reducer.transform(sample_pca_data, return_dataframe=True)
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == ["UMAP1", "UMAP2"]
+
+    def test_fit_transform(self, sample_pca_data: np.ndarray) -> None:  # type: ignore[type-arg]
+        """fit_transform works in one step."""
+        reducer = UMAPReducer()
+        result = reducer.fit_transform(sample_pca_data)
+
+        assert reducer.is_fitted
+        assert result.shape == (100, 2)
+
+    def test_transform_before_fit_raises(
+        self, sample_pca_data: np.ndarray  # type: ignore[type-arg]
+    ) -> None:
+        """Transform before fit raises error."""
+        reducer = UMAPReducer()
+
+        with pytest.raises(AncestryError, match="must be fitted"):
+            reducer.transform(sample_pca_data)
+
+    def test_from_params(self) -> None:
+        """UMAPReducer can be created from parameter dict."""
+        params = {
+            "umap__n_neighbors": 20,
+            "umap__n_components": 3,
+            "umap__a": 1.5,
+            "umap__b": 0.5,
+        }
+        reducer = UMAPReducer.from_params(params)
+
+        assert reducer.config.n_neighbors == 20
+        assert reducer.config.n_components == 3
+        assert reducer.config.a == 1.5
+        assert reducer.config.b == 0.5
+
+    def test_from_params_plain_keys(self) -> None:
+        """from_params works with plain key names."""
+        params = {
+            "n_neighbors": 20,
+            "n_components": 3,
+        }
+        reducer = UMAPReducer.from_params(params)
+
+        assert reducer.config.n_neighbors == 20
+        assert reducer.config.n_components == 3
+
+    def test_insufficient_samples_raises(self) -> None:
+        """Fit with too few samples raises error."""
+        # Only 5 samples, but n_neighbors defaults to 15
+        data = np.random.randn(5, 20)
+
+        reducer = UMAPReducer()
+        with pytest.raises(AncestryError, match="requires at least"):
+            reducer.fit(data)

--- a/tests/unit/test_ancestry/test_results.py
+++ b/tests/unit/test_ancestry/test_results.py
@@ -1,0 +1,299 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for ancestry result classes."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from genotools.ancestry.results import (
+    AncestryPredictions,
+    AncestryResult,
+    PCAResult,
+    SplitResult,
+    TrainingMetrics,
+    UMAPResult,
+)
+
+
+class TestAncestryPredictions:
+    """Tests for AncestryPredictions class."""
+
+    @pytest.fixture
+    def sample_predictions(self) -> pd.DataFrame:
+        """Create sample predictions DataFrame."""
+        return pd.DataFrame({
+            "FID": ["FAM1", "FAM1", "FAM2", "FAM2", "FAM3"],
+            "IID": ["SAMP1", "SAMP2", "SAMP3", "SAMP4", "SAMP5"],
+            "predicted_ancestry": ["EUR", "EUR", "AFR", "AFR", "EAS"],
+        })
+
+    def test_create_predictions(self, sample_predictions: pd.DataFrame) -> None:
+        """Predictions can be created from DataFrame."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        assert preds.sample_count == 5
+        assert len(preds.unique_ancestries) == 3
+
+    def test_missing_columns_raises(self) -> None:
+        """Missing required columns raises ValueError."""
+        df = pd.DataFrame({
+            "FID": ["FAM1"],
+            "IID": ["SAMP1"],
+            # Missing predicted_ancestry
+        })
+        with pytest.raises(ValueError, match="missing required columns"):
+            AncestryPredictions(predictions=df)
+
+    def test_get_ancestry(self, sample_predictions: pd.DataFrame) -> None:
+        """get_ancestry returns correct ancestry for sample."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        assert preds.get_ancestry("SAMP1") == "EUR"
+        assert preds.get_ancestry("SAMP3") == "AFR"
+        assert preds.get_ancestry("SAMP5") == "EAS"
+
+    def test_get_ancestry_not_found(
+        self, sample_predictions: pd.DataFrame
+    ) -> None:
+        """get_ancestry returns None for unknown sample."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        assert preds.get_ancestry("UNKNOWN") is None
+
+    def test_filter_by_ancestry(self, sample_predictions: pd.DataFrame) -> None:
+        """filter_by_ancestry returns correct sample IDs."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        eur_samples = preds.filter_by_ancestry("EUR")
+        assert set(eur_samples) == {"SAMP1", "SAMP2"}
+
+        afr_samples = preds.filter_by_ancestry("AFR")
+        assert set(afr_samples) == {"SAMP3", "SAMP4"}
+
+    def test_filter_by_ancestry_empty(
+        self, sample_predictions: pd.DataFrame
+    ) -> None:
+        """filter_by_ancestry returns empty list for missing ancestry."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        assert preds.filter_by_ancestry("SAS") == []
+
+    def test_ancestry_counts(self, sample_predictions: pd.DataFrame) -> None:
+        """ancestry_counts returns correct counts."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        counts = preds.ancestry_counts
+        assert counts["EUR"] == 2
+        assert counts["AFR"] == 2
+        assert counts["EAS"] == 1
+
+    def test_to_dataframe(self, sample_predictions: pd.DataFrame) -> None:
+        """to_dataframe returns copy of predictions."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        df = preds.to_dataframe()
+
+        # Should be a copy, not the same object
+        assert df is not preds.predictions
+        assert len(df) == 5
+
+    def test_to_dict_format(self, sample_predictions: pd.DataFrame) -> None:
+        """to_dict returns legacy format."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        result = preds.to_dict()
+
+        assert "data" in result
+        assert "metrics" in result
+        assert "output" in result
+        assert "ids" in result["data"]
+        assert "predicted_counts" in result["metrics"]
+
+    def test_save(
+        self, sample_predictions: pd.DataFrame, tmp_path: Path
+    ) -> None:
+        """save writes predictions to file."""
+        preds = AncestryPredictions(predictions=sample_predictions)
+        output_path = tmp_path / "predictions.txt"
+        preds.save(output_path)
+
+        assert output_path.exists()
+        # Read back and verify
+        df = pd.read_csv(output_path, sep="\t")
+        assert "FID" in df.columns
+        assert "IID" in df.columns
+        assert "label" in df.columns  # renamed from predicted_ancestry
+        assert len(df) == 5
+
+
+class TestTrainingMetrics:
+    """Tests for TrainingMetrics class."""
+
+    def test_create_metrics(self) -> None:
+        """TrainingMetrics can be created."""
+        metrics = TrainingMetrics(
+            train_accuracy=0.95,
+            test_accuracy=0.90,
+            train_accuracy_ci=(0.93, 0.97),
+            test_accuracy_ci=(0.85, 0.95),
+            confusion_matrix=np.array([[10, 2], [1, 15]]),
+            best_params={"umap__n_neighbors": 15},
+            label_encoder_classes=["EUR", "AFR"],
+        )
+        assert metrics.train_accuracy == 0.95
+        assert metrics.test_accuracy == 0.90
+
+    def test_to_dict(self) -> None:
+        """to_dict returns all metrics."""
+        metrics = TrainingMetrics(
+            train_accuracy=0.95,
+            test_accuracy=0.90,
+            train_accuracy_ci=(0.93, 0.97),
+            test_accuracy_ci=(0.85, 0.95),
+            confusion_matrix=np.array([[10, 2], [1, 15]]),
+            best_params={"umap__n_neighbors": 15},
+            label_encoder_classes=["EUR", "AFR"],
+        )
+        result = metrics.to_dict()
+
+        assert result["train_accuracy"] == 0.95
+        assert result["test_accuracy"] == 0.90
+        assert "confusion_matrix" in result
+        assert result["best_params"] == {"umap__n_neighbors": 15}
+
+
+class TestPCAResult:
+    """Tests for PCAResult class."""
+
+    @pytest.fixture
+    def sample_pca_result(self) -> PCAResult:
+        """Create sample PCA result."""
+        n_samples = 10
+        n_components = 5
+
+        return PCAResult(
+            train_pca=pd.DataFrame({
+                "FID": [f"F{i}" for i in range(n_samples)],
+                "IID": [f"S{i}" for i in range(n_samples)],
+                **{f"PC{i+1}": np.random.randn(n_samples) for i in range(n_components)},
+                "label": ["EUR"] * (n_samples // 2) + ["AFR"] * (n_samples // 2),
+            }),
+            test_pca=pd.DataFrame({
+                "FID": [f"F{i}" for i in range(n_samples)],
+                "IID": [f"S{i}" for i in range(n_samples)],
+                **{f"PC{i+1}": np.random.randn(n_samples) for i in range(n_components)},
+                "label": ["EUR"] * (n_samples // 2) + ["AFR"] * (n_samples // 2),
+            }),
+            ref_pca=pd.DataFrame(),  # Combined train + test
+            projected_pca=pd.DataFrame(),  # New samples
+            eigenvalues=np.array([10.0, 5.0, 2.0, 1.0, 0.5]),
+            explained_variance_ratio=np.array([0.5, 0.25, 0.1, 0.05, 0.025]),
+            n_components=n_components,
+            n_snps_used=10000,
+            train_mean=np.zeros(10000),
+            train_sd=np.ones(10000),
+        )
+
+    def test_save_eigenvalues(
+        self, sample_pca_result: PCAResult, tmp_path: Path
+    ) -> None:
+        """save_eigenvalues writes to file."""
+        output_path = tmp_path / "eigenvalues.txt"
+        sample_pca_result.save_eigenvalues(output_path)
+
+        assert output_path.exists()
+        df = pd.read_csv(output_path, sep="\t")
+        assert "PC" in df.columns
+        assert "eigenvalue" in df.columns
+        assert "explained_variance_ratio" in df.columns
+        assert len(df) == 5
+
+
+class TestUMAPResult:
+    """Tests for UMAPResult class."""
+
+    def test_create_result(self) -> None:
+        """UMAPResult can be created."""
+        result = UMAPResult(
+            ref_umap=pd.DataFrame({
+                "UMAP1": [0.1, 0.2],
+                "UMAP2": [0.3, 0.4],
+                "label": ["EUR", "AFR"],
+            }),
+            new_umap=pd.DataFrame({
+                "UMAP1": [0.15],
+                "UMAP2": [0.35],
+                "label": ["EUR"],
+            }),
+            total_umap=pd.DataFrame(),
+            params={"umap__n_neighbors": 15},
+        )
+        assert len(result.ref_umap) == 2
+        assert len(result.new_umap) == 1
+
+
+class TestSplitResult:
+    """Tests for SplitResult class."""
+
+    def test_create_result(self) -> None:
+        """SplitResult can be created."""
+        result = SplitResult(
+            ancestry_paths={
+                "EUR": Path("/path/to/eur"),
+                "AFR": Path("/path/to/afr"),
+            },
+            ancestry_labels=["EUR", "AFR"],
+            pruned_samples=pd.DataFrame({
+                "FID": ["F1"],
+                "IID": ["S1"],
+                "step": ["insufficient_ancestry_sample_n"],
+                "label": ["SAS"],
+            }),
+        )
+        assert result.n_ancestries == 2
+        assert result.n_pruned == 1
+
+
+class TestAncestryResult:
+    """Tests for AncestryResult class."""
+
+    @pytest.fixture
+    def sample_predictions(self) -> AncestryPredictions:
+        """Create sample predictions."""
+        return AncestryPredictions(
+            predictions=pd.DataFrame({
+                "FID": ["FAM1", "FAM2"],
+                "IID": ["SAMP1", "SAMP2"],
+                "predicted_ancestry": ["EUR", "AFR"],
+            })
+        )
+
+    def test_create_minimal_result(
+        self, sample_predictions: AncestryPredictions
+    ) -> None:
+        """AncestryResult can be created with just predictions."""
+        result = AncestryResult(predictions=sample_predictions)
+        assert result.predictions.sample_count == 2
+        assert result.training_metrics is None
+        assert result.pca_result is None
+
+    def test_to_dict_format(
+        self, sample_predictions: AncestryPredictions
+    ) -> None:
+        """to_dict returns legacy format."""
+        result = AncestryResult(predictions=sample_predictions)
+        legacy = result.to_dict()
+
+        assert legacy["step"] == "predict_ancestry"
+        assert "data" in legacy
+        assert "metrics" in legacy
+        assert "output" in legacy

--- a/tests/unit/test_qc/__init__.py
+++ b/tests/unit/test_qc/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Unit tests for the QC module."""

--- a/tests/unit/test_qc/test_config.py
+++ b/tests/unit/test_qc/test_config.py
@@ -1,0 +1,289 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for QC configuration classes."""
+
+import pytest
+
+from genotools.qc.config import (
+    CallrateConfig,
+    CaseControlConfig,
+    GenoConfig,
+    HaplotypeConfig,
+    HetConfig,
+    HWEConfig,
+    LDConfig,
+    RelatedConfig,
+    SexConfig,
+)
+
+
+class TestCallrateConfig:
+    """Tests for CallrateConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = CallrateConfig()
+        assert config.mind == 0.05
+
+    def test_custom_value(self) -> None:
+        """Custom values are accepted."""
+        config = CallrateConfig(mind=0.02)
+        assert config.mind == 0.02
+
+    def test_invalid_mind_negative(self) -> None:
+        """Negative mind raises ValueError."""
+        with pytest.raises(ValueError, match="mind"):
+            CallrateConfig(mind=-0.1)
+
+    def test_invalid_mind_too_large(self) -> None:
+        """Mind > 1 raises ValueError."""
+        with pytest.raises(ValueError, match="mind"):
+            CallrateConfig(mind=1.5)
+
+    def test_frozen(self) -> None:
+        """Config is immutable."""
+        config = CallrateConfig()
+        with pytest.raises(AttributeError):
+            config.mind = 0.1  # type: ignore[misc]
+
+
+class TestSexConfig:
+    """Tests for SexConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = SexConfig()
+        assert config.female_max_f == 0.25
+        assert config.male_min_f == 0.75
+
+    def test_custom_values(self) -> None:
+        """Custom values are accepted."""
+        config = SexConfig(female_max_f=0.2, male_min_f=0.8)
+        assert config.female_max_f == 0.2
+        assert config.male_min_f == 0.8
+
+    def test_invalid_female_max_f_negative(self) -> None:
+        """Negative female_max_f raises ValueError."""
+        with pytest.raises(ValueError, match="female_max_f"):
+            SexConfig(female_max_f=-0.1)
+
+    def test_invalid_male_min_f_too_large(self) -> None:
+        """male_min_f > 1 raises ValueError."""
+        with pytest.raises(ValueError, match="male_min_f"):
+            SexConfig(male_min_f=1.5)
+
+    def test_invalid_thresholds_overlap(self) -> None:
+        """female_max_f >= male_min_f raises ValueError."""
+        with pytest.raises(ValueError, match="female_max_f.*must be less than"):
+            SexConfig(female_max_f=0.6, male_min_f=0.5)
+
+    def test_invalid_thresholds_equal(self) -> None:
+        """female_max_f == male_min_f raises ValueError."""
+        with pytest.raises(ValueError, match="female_max_f.*must be less than"):
+            SexConfig(female_max_f=0.5, male_min_f=0.5)
+
+
+class TestHetConfig:
+    """Tests for HetConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = HetConfig()
+        assert config.f_lower == -0.15
+        assert config.f_upper == 0.15
+        assert config.auto_detect is False
+
+    def test_auto_detect_mode(self) -> None:
+        """Auto-detect mode can be enabled."""
+        config = HetConfig(auto_detect=True)
+        assert config.auto_detect is True
+
+    def test_auto_detect_via_sentinel(self) -> None:
+        """Setting both bounds to -1 enables auto-detect mode."""
+        config = HetConfig(f_lower=-1.0, f_upper=-1.0)
+        # Should not raise validation error
+        assert config.f_lower == -1.0
+        assert config.f_upper == -1.0
+
+    def test_invalid_bounds_order(self) -> None:
+        """f_lower >= f_upper raises ValueError."""
+        with pytest.raises(ValueError, match="f_lower.*must be less than"):
+            HetConfig(f_lower=0.2, f_upper=0.1)
+
+    def test_invalid_bounds_equal(self) -> None:
+        """f_lower == f_upper raises ValueError."""
+        with pytest.raises(ValueError, match="f_lower.*must be less than"):
+            HetConfig(f_lower=0.15, f_upper=0.15)
+
+
+class TestRelatedConfig:
+    """Tests for RelatedConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = RelatedConfig()
+        assert config.related_cutoff == 0.0884
+        assert config.duplicated_cutoff == 0.354
+        assert config.prune_related is True
+        assert config.prune_duplicated is True
+
+    def test_custom_values(self) -> None:
+        """Custom values are accepted."""
+        config = RelatedConfig(
+            related_cutoff=0.1,
+            duplicated_cutoff=0.4,
+            prune_related=False,
+            prune_duplicated=False,
+        )
+        assert config.related_cutoff == 0.1
+        assert config.duplicated_cutoff == 0.4
+        assert config.prune_related is False
+        assert config.prune_duplicated is False
+
+    def test_invalid_related_without_duplicated(self) -> None:
+        """Cannot prune related without also pruning duplicated."""
+        with pytest.raises(ValueError, match="Cannot prune related.*without"):
+            RelatedConfig(prune_related=True, prune_duplicated=False)
+
+    def test_invalid_cutoff_negative(self) -> None:
+        """Negative cutoff raises ValueError."""
+        with pytest.raises(ValueError, match="related_cutoff"):
+            RelatedConfig(related_cutoff=-0.1)
+
+    def test_invalid_cutoff_too_large(self) -> None:
+        """Cutoff > 0.5 raises ValueError."""
+        with pytest.raises(ValueError, match="duplicated_cutoff"):
+            RelatedConfig(duplicated_cutoff=0.6)
+
+
+class TestGenoConfig:
+    """Tests for GenoConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = GenoConfig()
+        assert config.geno == 0.05
+
+    def test_custom_value(self) -> None:
+        """Custom values are accepted."""
+        config = GenoConfig(geno=0.02)
+        assert config.geno == 0.02
+
+    def test_invalid_geno_negative(self) -> None:
+        """Negative geno raises ValueError."""
+        with pytest.raises(ValueError, match="geno"):
+            GenoConfig(geno=-0.1)
+
+
+class TestCaseControlConfig:
+    """Tests for CaseControlConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = CaseControlConfig()
+        assert config.p_threshold == 1e-4
+
+    def test_custom_value(self) -> None:
+        """Custom values are accepted."""
+        config = CaseControlConfig(p_threshold=1e-6)
+        assert config.p_threshold == 1e-6
+
+    def test_invalid_threshold_negative(self) -> None:
+        """Negative threshold raises ValueError."""
+        with pytest.raises(ValueError, match="p_threshold"):
+            CaseControlConfig(p_threshold=-0.1)
+
+
+class TestHaplotypeConfig:
+    """Tests for HaplotypeConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = HaplotypeConfig()
+        assert config.p_threshold == 1e-4
+        assert config.adjust_for_sample_size is True
+
+    def test_disable_sample_size_adjustment(self) -> None:
+        """Sample size adjustment can be disabled."""
+        config = HaplotypeConfig(adjust_for_sample_size=False)
+        assert config.adjust_for_sample_size is False
+
+
+class TestHWEConfig:
+    """Tests for HWEConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = HWEConfig()
+        assert config.hwe_threshold == 1e-4
+        assert config.filter_controls is False
+
+    def test_filter_controls_enabled(self) -> None:
+        """Filter controls can be enabled."""
+        config = HWEConfig(filter_controls=True)
+        assert config.filter_controls is True
+
+
+class TestLDConfig:
+    """Tests for LDConfig."""
+
+    def test_default_values(self) -> None:
+        """Default values are set correctly."""
+        config = LDConfig()
+        assert config.window_size == 50
+        assert config.step_size == 5
+        assert config.r2_threshold == 0.5
+
+    def test_custom_values(self) -> None:
+        """Custom values are accepted."""
+        config = LDConfig(window_size=100, step_size=10, r2_threshold=0.2)
+        assert config.window_size == 100
+        assert config.step_size == 10
+        assert config.r2_threshold == 0.2
+
+    def test_invalid_r2_too_large(self) -> None:
+        """r2 > 1 raises ValueError."""
+        with pytest.raises(ValueError, match="r2_threshold"):
+            LDConfig(r2_threshold=1.5)
+
+    def test_invalid_window_size_negative(self) -> None:
+        """Negative window_size raises ValueError."""
+        with pytest.raises(ValueError, match="window_size"):
+            LDConfig(window_size=-10)
+
+
+class TestConfigImmutability:
+    """Tests that all configs are immutable (frozen)."""
+
+    def test_all_configs_frozen(self) -> None:
+        """All config classes are frozen dataclasses."""
+        configs = [
+            CallrateConfig(),
+            SexConfig(),
+            HetConfig(),
+            RelatedConfig(),
+            GenoConfig(),
+            CaseControlConfig(),
+            HaplotypeConfig(),
+            HWEConfig(),
+            LDConfig(),
+        ]
+
+        for config in configs:
+            # Try to modify an attribute - should raise
+            attr = list(config.__dataclass_fields__.keys())[0]
+            with pytest.raises(AttributeError):
+                setattr(config, attr, "new_value")

--- a/tests/unit/test_qc/test_pipeline.py
+++ b/tests/unit/test_qc/test_pipeline.py
@@ -1,0 +1,325 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for QC pipeline orchestration."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from genotools.core.exceptions import QCError
+from genotools.qc.config import CallrateConfig, GenoConfig, SexConfig
+from genotools.qc.pipeline import QCPipeline
+from genotools.qc.results import FilterResult
+
+
+class TestQCPipeline:
+    """Tests for QCPipeline class."""
+
+    @pytest.fixture
+    def mock_genotype_data(self) -> MagicMock:
+        """Create a mock GenotypeData object."""
+        mock = MagicMock()
+        mock.path = Path("/input/test")
+        mock.sample_count = 500
+        mock.variant_count = 10000
+        mock.pgen = MagicMock()
+        mock.pgen.exists.return_value = True
+        return mock
+
+    @pytest.fixture
+    def mock_step_fn(self, mock_genotype_data: MagicMock) -> MagicMock:
+        """Create a mock step function."""
+
+        def create_output(sample_count: int, variant_count: int) -> MagicMock:
+            output = MagicMock()
+            output.path = Path("/output/step")
+            output.sample_count = sample_count
+            output.variant_count = variant_count
+            return output
+
+        def step_fn(
+            data: Any, config: Any, out_path: Path
+        ) -> FilterResult:
+            output = create_output(
+                data.sample_count - 10,  # Remove 10 samples
+                data.variant_count,
+            )
+            return FilterResult(
+                output=output,
+                samples_removed=10,
+                variants_removed=0,
+                metrics={},
+                log="",
+                pruned_samples_file=None,
+                step_name="test_step",
+            )
+
+        return MagicMock(side_effect=step_fn)
+
+    def test_empty_pipeline(self, mock_genotype_data: MagicMock, tmp_path: Path) -> None:
+        """Empty pipeline returns input data unchanged."""
+        pipeline = QCPipeline(steps=[])
+        result = pipeline.run(mock_genotype_data, tmp_path)
+
+        assert result.input == mock_genotype_data
+        assert result.output == mock_genotype_data
+        assert len(result.step_results) == 0
+
+    def test_single_step(
+        self, mock_genotype_data: MagicMock, mock_step_fn: MagicMock, tmp_path: Path
+    ) -> None:
+        """Single step pipeline executes correctly."""
+        pipeline = QCPipeline(
+            steps=[("test_step", mock_step_fn, CallrateConfig())]
+        )
+        result = pipeline.run(mock_genotype_data, tmp_path)
+
+        assert mock_step_fn.called
+        assert len(result.step_results) == 1
+        assert result.step_results[0][0] == "test_step"
+
+    def test_multiple_steps(
+        self, mock_genotype_data: MagicMock, tmp_path: Path
+    ) -> None:
+        """Multiple steps are chained correctly."""
+        step_calls = []
+
+        def make_step(name: str) -> MagicMock:
+            def step_fn(data: Any, config: Any, out_path: Path) -> FilterResult:
+                step_calls.append(name)
+                output = MagicMock()
+                output.path = out_path
+                output.sample_count = data.sample_count - 5
+                output.variant_count = data.variant_count
+                return FilterResult(
+                    output=output,
+                    samples_removed=5,
+                    variants_removed=0,
+                    metrics={},
+                    log="",
+                    pruned_samples_file=None,
+                    step_name=name,
+                )
+
+            return MagicMock(side_effect=step_fn)
+
+        step1 = make_step("step1")
+        step2 = make_step("step2")
+        step3 = make_step("step3")
+
+        pipeline = QCPipeline(
+            steps=[
+                ("step1", step1, CallrateConfig()),
+                ("step2", step2, SexConfig()),
+                ("step3", step3, GenoConfig()),
+            ]
+        )
+        result = pipeline.run(mock_genotype_data, tmp_path)
+
+        assert step_calls == ["step1", "step2", "step3"]
+        assert len(result.step_results) == 3
+        assert result.total_samples_removed == 15  # 5 + 5 + 5
+
+    def test_warn_only_continues_on_error(
+        self, mock_genotype_data: MagicMock, tmp_path: Path
+    ) -> None:
+        """warn_only=True continues pipeline after step failure."""
+        step_calls = []
+
+        def failing_step(data: Any, config: Any, out_path: Path) -> FilterResult:
+            step_calls.append("failing")
+            raise QCError("Step failed")
+
+        def passing_step(data: Any, config: Any, out_path: Path) -> FilterResult:
+            step_calls.append("passing")
+            output = MagicMock()
+            output.path = out_path
+            output.sample_count = data.sample_count
+            output.variant_count = data.variant_count
+            return FilterResult(
+                output=output,
+                samples_removed=0,
+                variants_removed=0,
+                metrics={},
+                log="",
+                pruned_samples_file=None,
+                step_name="passing",
+            )
+
+        pipeline = QCPipeline(
+            steps=[
+                ("failing", failing_step, CallrateConfig()),
+                ("passing", passing_step, SexConfig()),
+            ],
+            warn_only=True,
+        )
+        result = pipeline.run(mock_genotype_data, tmp_path)
+
+        assert step_calls == ["failing", "passing"]
+        assert len(result.step_results) == 1  # Only passing step has result
+        assert result.step_results[0][0] == "passing"
+
+    def test_warn_only_false_raises_on_error(
+        self, mock_genotype_data: MagicMock, tmp_path: Path
+    ) -> None:
+        """warn_only=False raises exception on step failure."""
+
+        def failing_step(data: Any, config: Any, out_path: Path) -> FilterResult:
+            raise QCError("Step failed")
+
+        pipeline = QCPipeline(
+            steps=[("failing", failing_step, CallrateConfig())],
+            warn_only=False,
+        )
+
+        with pytest.raises(QCError, match="Step failed"):
+            pipeline.run(mock_genotype_data, tmp_path)
+
+    def test_raises_when_all_samples_removed(
+        self, mock_genotype_data: MagicMock, tmp_path: Path
+    ) -> None:
+        """Raises QCError when all samples are removed."""
+
+        def remove_all_step(data: Any, config: Any, out_path: Path) -> FilterResult:
+            output = MagicMock()
+            output.path = out_path
+            output.sample_count = 0  # All samples removed
+            output.variant_count = data.variant_count
+            return FilterResult(
+                output=output,
+                samples_removed=data.sample_count,
+                variants_removed=0,
+                metrics={},
+                log="",
+                pruned_samples_file=None,
+                step_name="remove_all",
+            )
+
+        pipeline = QCPipeline(
+            steps=[("remove_all", remove_all_step, CallrateConfig())]
+        )
+
+        with pytest.raises(QCError, match="All samples removed"):
+            pipeline.run(mock_genotype_data, tmp_path)
+
+    def test_raises_when_all_variants_removed(
+        self, mock_genotype_data: MagicMock, tmp_path: Path
+    ) -> None:
+        """Raises QCError when all variants are removed."""
+
+        def remove_all_step(data: Any, config: Any, out_path: Path) -> FilterResult:
+            output = MagicMock()
+            output.path = out_path
+            output.sample_count = data.sample_count
+            output.variant_count = 0  # All variants removed
+            return FilterResult(
+                output=output,
+                samples_removed=0,
+                variants_removed=data.variant_count,
+                metrics={},
+                log="",
+                pruned_samples_file=None,
+                step_name="remove_all",
+            )
+
+        pipeline = QCPipeline(
+            steps=[("remove_all", remove_all_step, GenoConfig())]
+        )
+
+        with pytest.raises(QCError, match="All variants removed"):
+            pipeline.run(mock_genotype_data, tmp_path)
+
+    def test_add_step_returns_new_pipeline(self) -> None:
+        """add_step returns a new pipeline, doesn't modify original."""
+        original = QCPipeline(steps=[])
+
+        def dummy_step(data: Any, config: Any, out_path: Path) -> FilterResult:
+            raise NotImplementedError
+
+        new_pipeline = original.add_step("new_step", dummy_step, CallrateConfig())
+
+        assert len(original.steps) == 0
+        assert len(new_pipeline.steps) == 1
+        assert new_pipeline is not original
+
+
+class TestQCPipelineFactories:
+    """Tests for QCPipeline factory methods."""
+
+    def test_sample_qc_all_steps(self) -> None:
+        """sample_qc creates pipeline with all steps when all configs provided."""
+        pipeline = QCPipeline.sample_qc(
+            callrate_config=CallrateConfig(),
+            sex_config=SexConfig(),
+            het_config=MagicMock(),
+            related_config=MagicMock(),
+        )
+
+        assert len(pipeline.steps) == 4
+        step_names = [name for name, _, _ in pipeline.steps]
+        assert step_names == ["callrate", "sex", "het", "related"]
+
+    def test_sample_qc_some_steps(self) -> None:
+        """sample_qc creates pipeline with only specified steps."""
+        pipeline = QCPipeline.sample_qc(
+            callrate_config=CallrateConfig(),
+            sex_config=None,
+            het_config=MagicMock(),
+            related_config=None,
+        )
+
+        assert len(pipeline.steps) == 2
+        step_names = [name for name, _, _ in pipeline.steps]
+        assert step_names == ["callrate", "het"]
+
+    def test_sample_qc_warn_only(self) -> None:
+        """sample_qc respects warn_only parameter."""
+        pipeline = QCPipeline.sample_qc(
+            callrate_config=CallrateConfig(),
+            warn_only=True,
+        )
+
+        assert pipeline.warn_only is True
+
+    def test_variant_qc_all_steps(self) -> None:
+        """variant_qc creates pipeline with all steps when all configs provided."""
+        pipeline = QCPipeline.variant_qc(
+            geno_config=GenoConfig(),
+            case_control_config=MagicMock(),
+            haplotype_config=MagicMock(),
+            hwe_config=MagicMock(),
+            ld_config=MagicMock(),
+        )
+
+        assert len(pipeline.steps) == 5
+        step_names = [name for name, _, _ in pipeline.steps]
+        assert step_names == ["geno", "case_control", "haplotype", "hwe", "ld"]
+
+    def test_variant_qc_some_steps(self) -> None:
+        """variant_qc creates pipeline with only specified steps."""
+        pipeline = QCPipeline.variant_qc(
+            geno_config=GenoConfig(),
+            case_control_config=None,
+            haplotype_config=None,
+            hwe_config=MagicMock(),
+            ld_config=None,
+        )
+
+        assert len(pipeline.steps) == 2
+        step_names = [name for name, _, _ in pipeline.steps]
+        assert step_names == ["geno", "hwe"]

--- a/tests/unit/test_qc/test_results.py
+++ b/tests/unit/test_qc/test_results.py
@@ -1,0 +1,230 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for QC result dataclasses."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from genotools.qc.results import FilterResult, QCResult
+
+
+class TestFilterResult:
+    """Tests for FilterResult dataclass."""
+
+    @pytest.fixture
+    def mock_genotype_data(self) -> MagicMock:
+        """Create a mock GenotypeData object."""
+        mock = MagicMock()
+        mock.path = Path("/output/test")
+        mock.sample_count = 100
+        mock.variant_count = 1000
+        return mock
+
+    @pytest.fixture
+    def sample_filter_result(self, mock_genotype_data: MagicMock) -> FilterResult:
+        """Create a sample FilterResult for testing."""
+        return FilterResult(
+            output=mock_genotype_data,
+            samples_removed=10,
+            variants_removed=0,
+            metrics={"threshold": 0.05},
+            log="PLINK output here",
+            pruned_samples_file=Path("/output/test.outliers"),
+            step_name="callrate_prune",
+        )
+
+    def test_to_dict_format(self, sample_filter_result: FilterResult) -> None:
+        """to_dict returns the correct legacy format."""
+        result_dict = sample_filter_result.to_dict()
+
+        assert result_dict["pass"] is True
+        assert result_dict["step"] == "callrate_prune"
+        assert "outlier_count" in result_dict["metrics"]
+        assert result_dict["metrics"]["outlier_count"] == 10  # samples_removed
+        assert result_dict["metrics"]["threshold"] == 0.05
+        assert result_dict["output"]["pruned_samples"] == "/output/test.outliers"
+        assert result_dict["output"]["plink_out"] == "/output/test"
+
+    def test_to_dict_no_pruned_samples(self, mock_genotype_data: MagicMock) -> None:
+        """to_dict handles None pruned_samples_file."""
+        result = FilterResult(
+            output=mock_genotype_data,
+            samples_removed=0,
+            variants_removed=0,
+            metrics={},
+            log="",
+            pruned_samples_file=None,
+            step_name="test_step",
+        )
+        result_dict = result.to_dict()
+
+        assert result_dict["output"]["pruned_samples"] is None
+
+    def test_to_dict_variant_removal(self, mock_genotype_data: MagicMock) -> None:
+        """to_dict correctly sums sample and variant removals."""
+        result = FilterResult(
+            output=mock_genotype_data,
+            samples_removed=5,
+            variants_removed=100,
+            metrics={},
+            log="",
+            pruned_samples_file=None,
+            step_name="combined_prune",
+        )
+        result_dict = result.to_dict()
+
+        assert result_dict["metrics"]["outlier_count"] == 105
+
+    def test_frozen(self, sample_filter_result: FilterResult) -> None:
+        """FilterResult is immutable."""
+        with pytest.raises(AttributeError):
+            sample_filter_result.samples_removed = 0  # type: ignore[misc]
+
+
+class TestQCResult:
+    """Tests for QCResult dataclass."""
+
+    @pytest.fixture
+    def mock_input_data(self) -> MagicMock:
+        """Create mock input GenotypeData."""
+        mock = MagicMock()
+        mock.path = Path("/input/test")
+        mock.sample_count = 500
+        mock.variant_count = 10000
+        return mock
+
+    @pytest.fixture
+    def mock_output_data(self) -> MagicMock:
+        """Create mock output GenotypeData."""
+        mock = MagicMock()
+        mock.path = Path("/output/test")
+        mock.sample_count = 450
+        mock.variant_count = 9000
+        return mock
+
+    @pytest.fixture
+    def sample_qc_result(
+        self,
+        mock_input_data: MagicMock,
+        mock_output_data: MagicMock,
+    ) -> QCResult:
+        """Create a sample QCResult for testing."""
+        step1_output = MagicMock()
+        step1_output.path = Path("/output/step1")
+        step1_output.sample_count = 480
+
+        step1_result = FilterResult(
+            output=step1_output,
+            samples_removed=20,
+            variants_removed=0,
+            metrics={},
+            log="",
+            pruned_samples_file=Path("/output/step1.outliers"),
+            step_name="step1",
+        )
+
+        step2_result = FilterResult(
+            output=mock_output_data,
+            samples_removed=30,
+            variants_removed=1000,
+            metrics={},
+            log="",
+            pruned_samples_file=Path("/output/step2.outliers"),
+            step_name="step2",
+        )
+
+        return QCResult(
+            input=mock_input_data,
+            output=mock_output_data,
+            step_results=[("step1", step1_result), ("step2", step2_result)],
+        )
+
+    def test_total_samples_removed(self, sample_qc_result: QCResult) -> None:
+        """total_samples_removed sums across all steps."""
+        assert sample_qc_result.total_samples_removed == 50  # 20 + 30
+
+    def test_total_variants_removed(self, sample_qc_result: QCResult) -> None:
+        """total_variants_removed sums across all steps."""
+        assert sample_qc_result.total_variants_removed == 1000  # 0 + 1000
+
+    def test_to_legacy_dict(self, sample_qc_result: QCResult) -> None:
+        """to_legacy_dict returns correct format."""
+        legacy_dict = sample_qc_result.to_legacy_dict()
+
+        assert "step1" in legacy_dict
+        assert "step2" in legacy_dict
+        assert legacy_dict["step1"]["step"] == "step1"
+        assert legacy_dict["step2"]["step"] == "step2"
+
+    def test_get_step_result_found(self, sample_qc_result: QCResult) -> None:
+        """get_step_result returns correct result when found."""
+        result = sample_qc_result.get_step_result("step1")
+        assert result is not None
+        assert result.step_name == "step1"
+        assert result.samples_removed == 20
+
+    def test_get_step_result_not_found(self, sample_qc_result: QCResult) -> None:
+        """get_step_result returns None when not found."""
+        result = sample_qc_result.get_step_result("nonexistent")
+        assert result is None
+
+    def test_frozen(self, sample_qc_result: QCResult) -> None:
+        """QCResult is immutable."""
+        with pytest.raises(AttributeError):
+            sample_qc_result.output = MagicMock()  # type: ignore[misc]
+
+
+class TestLegacyCompatibility:
+    """Tests ensuring backward compatibility with old return format."""
+
+    def test_filter_result_matches_old_format(self) -> None:
+        """FilterResult.to_dict() matches the old SampleQC/VariantQC return format."""
+        mock_output = MagicMock()
+        mock_output.path = Path("/path/to/output")
+
+        result = FilterResult(
+            output=mock_output,
+            samples_removed=5,
+            variants_removed=0,
+            metrics={"extra_metric": "value"},
+            log="",
+            pruned_samples_file=Path("/path/to/output.outliers"),
+            step_name="callrate_prune",
+        )
+
+        result_dict = result.to_dict()
+
+        # Check all required keys exist
+        assert "pass" in result_dict
+        assert "step" in result_dict
+        assert "metrics" in result_dict
+        assert "output" in result_dict
+
+        # Check nested structure
+        assert "outlier_count" in result_dict["metrics"]
+        assert "pruned_samples" in result_dict["output"]
+        assert "plink_out" in result_dict["output"]
+
+        # Check types
+        assert isinstance(result_dict["pass"], bool)
+        assert isinstance(result_dict["step"], str)
+        assert isinstance(result_dict["metrics"], dict)
+        assert isinstance(result_dict["output"], dict)
+
+        # Check custom metrics are preserved
+        assert result_dict["metrics"]["extra_metric"] == "value"


### PR DESCRIPTION
## Summary
- Migrate monolithic `Ancestry` class to modular architecture with ML fit/predict interface
- Add frozen configuration dataclasses with validation
- Add typed result classes with backward-compatible serialization
- Add comprehensive unit test suite (85 tests)

## Test plan
- [x] All 85 unit tests pass (`pytest tests/unit/test_ancestry/`)
- [x] Mypy passes with `--ignore-missing-imports`
- [x] Module imports work correctly
- [ ] Integration testing pending - new module not yet wired into pipeline

**Note**: This PR creates the new module structure but does **not** replace the existing `genotools/ancestry.py`. The original code continues to run when using `--ancestry`. Integration (swapping old for new) should happen in a follow-up PR with side-by-side regression testing to verify identical outputs.