### PR TITLE
Refactor/phase4 cli migration

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1674,7 +1674,7 @@ Migrate GWAS module and remove deprecated code.
 | 1: Core Foundation | ✅ Complete | A1, P1, R1, R2, R3, D1, D2, D3 |
 | 2: QC Migration | ✅ Complete | A1, A2, M1, M2, D1 |
 | 3: Ancestry Migration | ✅ Complete | A2, M1, D1 |
-| 4: CLI Migration | Not Started | A3, M3, C1 |
+| 4: CLI Migration | ✅ Complete | A3, M3, C1 |
 | 5: GWAS & Cleanup | Not Started | - |
 
 ---
@@ -1787,3 +1787,90 @@ print(predictions.ancestry_counts)
 model.save(Path("model.pkl"))
 loaded = AncestryModel.load(Path("model.pkl"))
 ```
+
+---
+
+## Phase 4 Completion Notes
+
+**Completed:** 2026-01-22
+
+### Deliverables
+
+| File | Status | Description |
+|------|--------|-------------|
+| `cli/__init__.py` | ✅ | Public exports for all CLI components |
+| `cli/parser.py` | ✅ | Argument parsing with typed dataclasses (PipelineArgs, InputArgs, SampleQCArgs, etc.) |
+| `cli/runner.py` | ✅ | Pipeline orchestration (PipelineRunner, run_pipeline) |
+| `cli/output.py` | ✅ | Result formatting and JSON serialization (PipelineOutput, QCMetrics, GWASMetrics) |
+
+### Success Criteria Met
+
+- [x] CLI argument parsing with proper types (no boolean string parsing)
+- [x] Clean separation: parser → runner → output
+- [x] `parse_args()` returns typed `PipelineArgs` dataclass
+- [x] `--all-sample` and `--all-variant` convenience flags
+- [x] `--warn` flag (now `--no-warn` to disable, warn is default)
+- [x] `--container`, `--singularity`, `--cloud` flags for inference mode
+- [x] `mypy genotools/cli/ --ignore-missing-imports` passes
+- [x] Unit tests: 90 tests passing for parser, runner, and output
+
+### Key Design Decisions
+
+1. **Typed argument groups**: Separate dataclasses for InputArgs, SampleQCArgs, VariantQCArgs, AncestryArgs, GWASArgs, OutputArgs
+2. **Legacy compatibility**: `to_legacy_dict()` method on PipelineArgs for backward compatibility with existing pipeline code
+3. **Flexible nargs**: `--sex`, `--het`, `--ld` accept variable arguments (0 for defaults, 2/3 for custom)
+4. **Negated booleans**: `--no-warn` disables warn mode (warn is now default), `--no-prune-duplicated` disables duplicate pruning
+5. **Config conversion**: SampleQCArgs and VariantQCArgs have `to_*_config()` methods for creating typed config objects
+
+### New Module Structure
+
+```
+genotools/cli/
+├── __init__.py     # Public API exports
+├── parser.py       # Argument parsing with typed dataclasses
+├── runner.py       # Pipeline orchestration (PipelineRunner)
+└── output.py       # Result formatting (PipelineOutput, write_results)
+```
+
+### Usage Example
+
+```python
+from genotools.cli import parse_args, run_pipeline, PipelineArgs
+
+# Parse command line arguments
+args = parse_args([
+    "--pfile", "data/test",
+    "--out", "results/output",
+    "--all-sample",
+    "--ancestry",
+    "--container"
+])
+
+# Inspect parsed arguments
+print(f"Input: {args.geno_path}")
+print(f"Steps: {args.get_all_enabled_steps()}")
+print(f"Inference mode: {args.ancestry.inference_mode}")
+
+# Convert to legacy format for backward compatibility
+legacy_dict = args.to_legacy_dict()
+
+# Or run the pipeline directly
+result = run_pipeline(args)
+result.save(args.out_path.with_suffix(".json"))
+```
+
+### CLI Argument Changes
+
+| Old Argument | New Argument | Notes |
+|--------------|--------------|-------|
+| `--warn True/False` | `--no-warn` | Boolean flag, warn is now default |
+| `--full_output True/False` | `--full-output` | Boolean flag with dashes |
+| `--skip_fails True/False` | `--skip-fails` | Boolean flag with dashes |
+| `--filter_controls True/False` | `--filter-controls` | Boolean flag with dashes |
+
+### Integration Notes
+
+The CLI module is designed to be used in two ways:
+
+1. **With legacy code**: Use `PipelineArgs.to_legacy_dict()` to get the old-style args dict
+2. **With new modules**: Use the typed config objects directly (e.g., `args.sample_qc.to_callrate_config()`)

--- a/genotools/cli/__init__.py
+++ b/genotools/cli/__init__.py
@@ -1,0 +1,81 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Command-line interface for GenoTools.
+
+This module provides the CLI layer for the GenoTools pipeline, including:
+- Typed argument parsing with validation
+- Pipeline orchestration
+- Result formatting and output
+
+Example usage:
+    >>> from genotools.cli import parse_args, run_pipeline
+    >>> args = parse_args(["--pfile", "data/test", "--out", "results/output", "--all-sample"])
+    >>> result = run_pipeline(args)
+    >>> result.save("results/output.json")
+"""
+
+from .parser import (
+    InputArgs,
+    SampleQCArgs,
+    VariantQCArgs,
+    AncestryArgs,
+    GWASArgs,
+    OutputArgs,
+    PipelineArgs,
+    create_parser,
+    parse_args,
+)
+from .runner import (
+    StepResult,
+    PassFailRecord,
+    PipelineState,
+    PipelineRunner,
+    run_pipeline,
+)
+from .output import (
+    QCMetrics,
+    GWASMetrics,
+    PipelineOutput,
+    write_results,
+    build_metrics_dataframe,
+    build_gwas_dataframe,
+)
+
+__all__ = [
+    # Parser
+    "InputArgs",
+    "SampleQCArgs",
+    "VariantQCArgs",
+    "AncestryArgs",
+    "GWASArgs",
+    "OutputArgs",
+    "PipelineArgs",
+    "create_parser",
+    "parse_args",
+    # Runner
+    "StepResult",
+    "PassFailRecord",
+    "PipelineState",
+    "PipelineRunner",
+    "run_pipeline",
+    # Output
+    "QCMetrics",
+    "GWASMetrics",
+    "PipelineOutput",
+    "write_results",
+    "build_metrics_dataframe",
+    "build_gwas_dataframe",
+]

--- a/genotools/cli/output.py
+++ b/genotools/cli/output.py
@@ -1,0 +1,475 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Output formatting and writing for GenoTools pipeline.
+
+This module handles the construction and serialization of pipeline results
+to JSON and other output formats.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from .parser import PipelineArgs
+    from .runner import PipelineState
+
+
+@dataclass
+class QCMetrics:
+    """QC step metrics."""
+
+    step: str
+    pruned_count: int
+    metric: str
+    ancestry: str = "all"
+    level: str = "sample"  # or "variant"
+    passed: bool = True
+
+
+@dataclass
+class GWASMetrics:
+    """GWAS result metrics."""
+
+    value: float
+    metric: str
+    ancestry: str = "all"
+
+
+@dataclass
+class PipelineOutput:
+    """Complete pipeline output.
+
+    This class aggregates all results from the pipeline and provides
+    methods for serialization to various formats.
+
+    Attributes:
+        input_samples: DataFrame of input samples.
+        ancestry_counts: Ancestry prediction counts.
+        ancestry_labels: Per-sample ancestry labels.
+        confusion_matrix: Ancestry model confusion matrix.
+        test_accuracy: Ancestry model test accuracy.
+        ref_pcs: Reference PCA coordinates.
+        projected_pcs: Projected sample PCA coordinates.
+        total_umap: Combined UMAP coordinates.
+        ref_umap: Reference UMAP coordinates.
+        new_samples_umap: New sample UMAP coordinates.
+        qc_metrics: List of QC metrics.
+        gwas_metrics: List of GWAS metrics.
+        pruned_samples: DataFrame of pruned samples.
+        related_samples: DataFrame of related samples.
+        pass_fail: Step pass/fail status by ancestry.
+    """
+
+    input_samples: Optional[pd.DataFrame] = None
+    ancestry_counts: Optional[pd.DataFrame] = None
+    ancestry_labels: Optional[pd.DataFrame] = None
+    confusion_matrix: Optional[pd.DataFrame] = None
+    test_accuracy: Optional[float] = None
+    ref_pcs: Optional[pd.DataFrame] = None
+    projected_pcs: Optional[pd.DataFrame] = None
+    total_umap: Optional[pd.DataFrame] = None
+    ref_umap: Optional[pd.DataFrame] = None
+    new_samples_umap: Optional[pd.DataFrame] = None
+    qc_metrics: List[QCMetrics] = field(default_factory=list)
+    gwas_metrics: List[GWASMetrics] = field(default_factory=list)
+    pruned_samples: Optional[pd.DataFrame] = None
+    related_samples: Optional[pd.DataFrame] = None
+    pass_fail: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    @classmethod
+    def from_runner_state(
+        cls,
+        args: "PipelineArgs",
+        state: "PipelineState",
+    ) -> "PipelineOutput":
+        """Create PipelineOutput from runner state.
+
+        Args:
+            args: Pipeline arguments.
+            state: Pipeline execution state.
+
+        Returns:
+            Populated PipelineOutput instance.
+        """
+        output = cls()
+
+        # Load input samples
+        psam_path = f"{args.geno_path}.psam"
+        if os.path.isfile(psam_path):
+            output.input_samples = pd.read_csv(psam_path, sep=r"\s+")
+
+        # Process ancestry results
+        if state.ancestry_result is not None:
+            output._process_ancestry_result(state.ancestry_result)
+
+        # Process QC results
+        output._process_qc_results(state, args)
+
+        return output
+
+    def _process_ancestry_result(self, ancestry_result: Dict[str, Any]) -> None:
+        """Process ancestry prediction results.
+
+        Args:
+            ancestry_result: Raw ancestry result dictionary.
+        """
+        # Ancestry counts
+        if "metrics" in ancestry_result and "predicted_counts" in ancestry_result["metrics"]:
+            counts_df = pd.DataFrame(
+                ancestry_result["metrics"]["predicted_counts"]
+            ).reset_index()
+            counts_df.columns = ["label", "count"]
+            self.ancestry_counts = counts_df
+
+        # Ancestry labels
+        if "data" in ancestry_result:
+            data = ancestry_result["data"]
+
+            if "predict_data" in data and "ids" in data["predict_data"]:
+                self.ancestry_labels = pd.DataFrame(data["predict_data"]["ids"])
+
+            # Confusion matrix
+            if "confusion_matrix" in data and "label_encoder" in data:
+                le = data["label_encoder"]
+                cm = pd.DataFrame(data["confusion_matrix"])
+                labels = le.inverse_transform([i for i in range(len(cm))])
+                cm.columns = labels
+                cm.index = labels
+                self.confusion_matrix = cm
+
+            # PCA and UMAP data
+            if "ref_pcs" in data:
+                self.ref_pcs = data["ref_pcs"]
+            if "projected_pcs" in data:
+                self.projected_pcs = data["projected_pcs"]
+            if "total_umap" in data:
+                self.total_umap = data["total_umap"]
+            if "ref_umap" in data:
+                self.ref_umap = data["ref_umap"]
+            if "new_samples_umap" in data:
+                self.new_samples_umap = data["new_samples_umap"]
+
+        # Test accuracy
+        if "metrics" in ancestry_result and "test_accuracy" in ancestry_result["metrics"]:
+            self.test_accuracy = ancestry_result["metrics"]["test_accuracy"]
+
+    def _process_qc_results(
+        self,
+        state: "PipelineState",
+        args: "PipelineArgs",
+    ) -> None:
+        """Process QC step results.
+
+        Args:
+            state: Pipeline execution state.
+            args: Pipeline arguments.
+        """
+        metrics_list: List[QCMetrics] = []
+        pruned_dfs: List[pd.DataFrame] = []
+        related_dfs: List[pd.DataFrame] = []
+
+        sample_steps = ["callrate", "sex", "het", "related"]
+        variant_steps = ["case_control", "haplotype", "hwe", "geno", "ld"]
+
+        # Process ancestry-specific results
+        if hasattr(state, "ancestry_results"):
+            ancestry_results = getattr(state, "ancestry_results")
+            for ancestry, result_dict in ancestry_results.items():
+                self._extract_qc_metrics(
+                    result_dict,
+                    ancestry,
+                    sample_steps,
+                    variant_steps,
+                    metrics_list,
+                    pruned_dfs,
+                    related_dfs,
+                    args,
+                )
+                self.pass_fail[f"{ancestry}_pass_fail"] = result_dict.get("pass_fail", {})
+        else:
+            # Single run (no ancestry split)
+            result_dict = {
+                k: {"pass": v.passed, "step": v.step, "metrics": v.metrics, "output": v.output}
+                for k, v in state.step_results.items()
+            }
+            self._extract_qc_metrics(
+                result_dict,
+                "all",
+                sample_steps,
+                variant_steps,
+                metrics_list,
+                pruned_dfs,
+                related_dfs,
+                args,
+            )
+            self.pass_fail["pass_fail"] = {
+                k: {"status": v.status, "input": v.input_path, "output": v.output_path}
+                for k, v in state.pass_fail.items()
+            }
+
+        self.qc_metrics = metrics_list
+
+        # Combine pruned samples
+        if pruned_dfs:
+            combined = pd.concat(pruned_dfs, ignore_index=True)
+            combined = combined.drop_duplicates(subset=["#FID", "IID"], ignore_index=True)
+            combined = combined.rename({"#FID": "FID"}, axis=1)
+            self.pruned_samples = combined
+
+        # Combine related samples
+        if related_dfs:
+            self.related_samples = pd.concat(related_dfs, ignore_index=True)
+
+    def _extract_qc_metrics(
+        self,
+        result_dict: Dict[str, Any],
+        ancestry: str,
+        sample_steps: List[str],
+        variant_steps: List[str],
+        metrics_list: List[QCMetrics],
+        pruned_dfs: List[pd.DataFrame],
+        related_dfs: List[pd.DataFrame],
+        args: "PipelineArgs",
+    ) -> None:
+        """Extract metrics from a QC result dictionary.
+
+        Args:
+            result_dict: Step result dictionary.
+            ancestry: Ancestry label.
+            sample_steps: List of sample-level steps.
+            variant_steps: List of variant-level steps.
+            metrics_list: List to append metrics to.
+            pruned_dfs: List to append pruned sample DataFrames.
+            related_dfs: List to append related sample DataFrames.
+            args: Pipeline arguments.
+        """
+        for step in sample_steps + variant_steps:
+            if step not in result_dict:
+                continue
+
+            step_result = result_dict[step]
+            level = "sample" if step in sample_steps else "variant"
+            passed = step_result.get("pass", False)
+
+            # Extract metrics
+            if "metrics" in step_result:
+                for metric, value in step_result["metrics"].items():
+                    metrics_list.append(
+                        QCMetrics(
+                            step=step_result.get("step", step),
+                            pruned_count=value,
+                            metric=metric,
+                            ancestry=ancestry,
+                            level=level,
+                            passed=passed,
+                        )
+                    )
+
+            # Extract pruned samples
+            if step in sample_steps and "output" in step_result:
+                samplefile = step_result["output"].get("pruned_samples")
+                if samplefile and os.path.isfile(samplefile):
+                    pruned = pd.read_csv(samplefile, sep="\t")
+                    if len(pruned) > 0:
+                        pruned["step"] = step
+                        pruned_dfs.append(pruned[["#FID", "IID", "step"]])
+
+            # Extract related samples
+            if step == "related" and "output" in step_result:
+                relatedfile = step_result["output"].get("related_samples")
+                if relatedfile and os.path.isfile(relatedfile):
+                    related = pd.read_csv(relatedfile, sep=",")
+                    if len(related) > 0:
+                        # Write per-ancestry related file
+                        if ancestry == "all":
+                            related_out = f"{args.out_path}.related"
+                        else:
+                            related_out = f"{args.out_path}_{ancestry}.related"
+                        related.to_csv(related_out, index=False)
+                        related["ancestry"] = ancestry
+                        related_dfs.append(related)
+
+        # Extract GWAS metrics
+        if "assoc" in result_dict and "gwas" in result_dict["assoc"]:
+            gwas_result = result_dict["assoc"]["gwas"]
+            if "metrics" in gwas_result:
+                for metric, value in gwas_result["metrics"].items():
+                    self.gwas_metrics.append(
+                        GWASMetrics(
+                            value=value,
+                            metric=metric,
+                            ancestry=ancestry,
+                        )
+                    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization.
+
+        Returns:
+            Dictionary suitable for JSON serialization.
+        """
+        result: Dict[str, Any] = {}
+
+        # Input samples
+        if self.input_samples is not None:
+            result["input_samples"] = self.input_samples.to_dict()
+
+        # Ancestry results
+        if self.ancestry_counts is not None:
+            result["ancestry_counts"] = self.ancestry_counts.to_dict()
+        if self.ancestry_labels is not None:
+            result["ancestry_labels"] = self.ancestry_labels.to_dict()
+        if self.confusion_matrix is not None:
+            result["confusion_matrix"] = self.confusion_matrix.to_dict()
+        if self.test_accuracy is not None:
+            result["test_accuracy"] = self.test_accuracy
+
+        # PCA/UMAP data
+        if self.ref_pcs is not None:
+            result["ref_pcs"] = self.ref_pcs.to_dict()
+        if self.projected_pcs is not None:
+            result["projected_pcs"] = self.projected_pcs.to_dict()
+        if self.total_umap is not None:
+            result["total_umap"] = self.total_umap.to_dict()
+        if self.ref_umap is not None:
+            result["ref_umap"] = self.ref_umap.to_dict()
+        if self.new_samples_umap is not None:
+            result["new_samples_umap"] = self.new_samples_umap.to_dict()
+
+        # QC metrics
+        if self.qc_metrics:
+            qc_df = pd.DataFrame([
+                {
+                    "step": m.step,
+                    "pruned_count": m.pruned_count,
+                    "metric": m.metric,
+                    "ancestry": m.ancestry,
+                    "level": m.level,
+                    "pass": m.passed,
+                }
+                for m in self.qc_metrics
+            ])
+            result["QC"] = qc_df.to_dict()
+
+        # GWAS metrics
+        if self.gwas_metrics:
+            gwas_df = pd.DataFrame([
+                {
+                    "value": m.value,
+                    "metric": m.metric,
+                    "ancestry": m.ancestry,
+                }
+                for m in self.gwas_metrics
+            ])
+            result["GWAS"] = gwas_df.to_dict()
+
+        # Pruned samples
+        if self.pruned_samples is not None and not self.pruned_samples.empty:
+            result["pruned_samples"] = self.pruned_samples.to_dict()
+
+        # Related samples
+        if self.related_samples is not None and not self.related_samples.empty:
+            result["related_samples"] = self.related_samples.to_dict()
+
+        # Pass/fail status
+        result.update(self.pass_fail)
+
+        return result
+
+    def to_json(self, indent: Optional[int] = None) -> str:
+        """Convert to JSON string.
+
+        Args:
+            indent: JSON indentation level.
+
+        Returns:
+            JSON string representation.
+        """
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def save(self, path: Path) -> None:
+        """Save results to JSON file.
+
+        Args:
+            path: Output file path.
+        """
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f)
+
+
+def write_results(output: PipelineOutput, out_path: Path) -> None:
+    """Write pipeline results to output file.
+
+    Args:
+        output: Pipeline output to write.
+        out_path: Output path prefix.
+    """
+    json_path = Path(f"{out_path}.json")
+    output.save(json_path)
+
+
+def build_metrics_dataframe(metrics: List[QCMetrics]) -> pd.DataFrame:
+    """Build metrics DataFrame from list of QCMetrics.
+
+    Args:
+        metrics: List of QC metrics.
+
+    Returns:
+        DataFrame with metrics.
+    """
+    if not metrics:
+        return pd.DataFrame()
+
+    return pd.DataFrame([
+        {
+            "step": m.step,
+            "pruned_count": m.pruned_count,
+            "metric": m.metric,
+            "ancestry": m.ancestry,
+            "level": m.level,
+            "pass": m.passed,
+        }
+        for m in metrics
+    ])
+
+
+def build_gwas_dataframe(metrics: List[GWASMetrics]) -> pd.DataFrame:
+    """Build GWAS metrics DataFrame.
+
+    Args:
+        metrics: List of GWAS metrics.
+
+    Returns:
+        DataFrame with GWAS metrics.
+    """
+    if not metrics:
+        return pd.DataFrame()
+
+    return pd.DataFrame([
+        {
+            "value": m.value,
+            "metric": m.metric,
+            "ancestry": m.ancestry,
+        }
+        for m in metrics
+    ])

--- a/genotools/cli/parser.py
+++ b/genotools/cli/parser.py
@@ -1,0 +1,929 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Command-line argument parsing for GenoTools pipeline.
+
+This module provides typed argument parsing with validation, replacing the
+legacy string-based boolean parsing with proper argparse actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple, Sequence
+
+from ..qc.config import (
+    CallrateConfig,
+    SexConfig,
+    HetConfig,
+    RelatedConfig,
+    GenoConfig,
+    CaseControlConfig,
+    HaplotypeConfig,
+    HWEConfig,
+    LDConfig,
+)
+from ..ancestry.config import InferenceMode
+
+
+@dataclass
+class InputArgs:
+    """Input file arguments."""
+
+    bfile: Optional[Path] = None
+    pfile: Optional[Path] = None
+    vcf: Optional[Path] = None
+
+    def __post_init__(self) -> None:
+        """Validate that at least one input is provided."""
+        if self.bfile is None and self.pfile is None and self.vcf is None:
+            raise ValueError(
+                "At least one input must be provided: --bfile, --pfile, or --vcf"
+            )
+
+    @property
+    def geno_path(self) -> Path:
+        """Get the resolved genotype path (after conversion to pfiles)."""
+        if self.pfile is not None:
+            return self.pfile
+        elif self.bfile is not None:
+            return self.bfile
+        elif self.vcf is not None:
+            # VCF path without .vcf extension
+            vcf_str = str(self.vcf)
+            if ".vcf" in vcf_str:
+                return Path(vcf_str.split(".vcf")[0])
+            return self.vcf
+        raise ValueError("No input file specified")
+
+    @property
+    def input_format(self) -> str:
+        """Get the input format type."""
+        if self.pfile is not None:
+            return "pfile"
+        elif self.bfile is not None:
+            return "bfile"
+        elif self.vcf is not None:
+            return "vcf"
+        raise ValueError("No input file specified")
+
+
+@dataclass
+class SampleQCArgs:
+    """Sample-level QC arguments."""
+
+    # Callrate
+    run_callrate: bool = False
+    callrate_threshold: float = 0.02
+
+    # Sex check
+    run_sex: bool = False
+    female_max_f: float = 0.25
+    male_min_f: float = 0.75
+
+    # Heterozygosity
+    run_het: bool = False
+    het_lower: float = -0.15
+    het_upper: float = 0.15
+    amr_het: bool = False
+
+    # Relatedness
+    run_related: bool = False
+    related_cutoff: float = 0.0884
+    duplicated_cutoff: float = 0.354
+    prune_related: bool = False
+    prune_duplicated: bool = True
+
+    # Kinship check
+    run_kinship_check: bool = False
+
+    def to_callrate_config(self) -> CallrateConfig:
+        """Convert to CallrateConfig."""
+        return CallrateConfig(mind=self.callrate_threshold)
+
+    def to_sex_config(self) -> SexConfig:
+        """Convert to SexConfig."""
+        return SexConfig(
+            female_max_f=self.female_max_f,
+            male_min_f=self.male_min_f,
+        )
+
+    def to_het_config(self) -> HetConfig:
+        """Convert to HetConfig."""
+        return HetConfig(
+            f_lower=self.het_lower,
+            f_upper=self.het_upper,
+        )
+
+    def to_related_config(self) -> RelatedConfig:
+        """Convert to RelatedConfig."""
+        return RelatedConfig(
+            related_cutoff=self.related_cutoff,
+            duplicated_cutoff=self.duplicated_cutoff,
+            prune_related=self.prune_related,
+            prune_duplicated=self.prune_duplicated,
+        )
+
+
+@dataclass
+class VariantQCArgs:
+    """Variant-level QC arguments."""
+
+    # Genotype missingness
+    run_geno: bool = False
+    geno_threshold: float = 0.05
+
+    # Case-control
+    run_case_control: bool = False
+    case_control_threshold: float = 1e-4
+
+    # Haplotype
+    run_haplotype: bool = False
+    haplotype_threshold: float = 1e-4
+
+    # HWE
+    run_hwe: bool = False
+    hwe_threshold: float = 1e-4
+    filter_controls: bool = False
+
+    # LD pruning
+    run_ld: bool = False
+    ld_window_size: int = 50
+    ld_step_size: int = 5
+    ld_r2_threshold: float = 0.5
+
+    def to_geno_config(self) -> GenoConfig:
+        """Convert to GenoConfig."""
+        return GenoConfig(geno=self.geno_threshold)
+
+    def to_case_control_config(self) -> CaseControlConfig:
+        """Convert to CaseControlConfig."""
+        return CaseControlConfig(p_threshold=self.case_control_threshold)
+
+    def to_haplotype_config(self) -> HaplotypeConfig:
+        """Convert to HaplotypeConfig."""
+        return HaplotypeConfig(p_threshold=self.haplotype_threshold)
+
+    def to_hwe_config(self) -> HWEConfig:
+        """Convert to HWEConfig."""
+        return HWEConfig(
+            hwe_threshold=self.hwe_threshold,
+            filter_controls=self.filter_controls,
+        )
+
+    def to_ld_config(self) -> LDConfig:
+        """Convert to LDConfig."""
+        return LDConfig(
+            window_size=self.ld_window_size,
+            step_size=self.ld_step_size,
+            r2_threshold=self.ld_r2_threshold,
+        )
+
+
+@dataclass
+class AncestryArgs:
+    """Ancestry prediction arguments."""
+
+    run_ancestry: bool = False
+    ref_panel: Optional[Path] = None
+    ref_labels: Optional[Path] = None
+    model_path: Optional[Path] = None
+    subset_ancestry: Optional[List[str]] = None
+    min_samples: int = 0
+
+    # Inference mode
+    use_container: bool = False
+    use_singularity: bool = False
+    use_cloud: bool = False
+
+    @property
+    def inference_mode(self) -> InferenceMode:
+        """Get the inference mode."""
+        if self.use_cloud:
+            return InferenceMode.CLOUD
+        elif self.use_singularity:
+            return InferenceMode.SINGULARITY
+        elif self.use_container:
+            return InferenceMode.CONTAINER
+        return InferenceMode.LOCAL
+
+    def __post_init__(self) -> None:
+        """Validate ancestry arguments."""
+        if self.use_container and self.model_path is not None:
+            raise ValueError(
+                "Cannot use both --model and --container. "
+                "Container mode uses its own pre-trained model."
+            )
+
+
+@dataclass
+class GWASArgs:
+    """GWAS and PCA arguments."""
+
+    run_pca: bool = False
+    n_pcs: int = 10
+    build: str = "hg38"
+
+    run_gwas: bool = False
+    covar_path: Optional[Path] = None
+    covar_names: Optional[str] = None
+    maf_lambdas: bool = False
+
+
+@dataclass
+class OutputArgs:
+    """Output configuration arguments."""
+
+    out_path: Path = field(default_factory=lambda: Path("genotools_output"))
+    full_output: bool = False
+    skip_fails: bool = False
+    warn_only: bool = True  # Continue on step failure
+
+
+@dataclass
+class PipelineArgs:
+    """Complete validated pipeline arguments.
+
+    This dataclass aggregates all argument groups and provides
+    convenience methods for pipeline configuration.
+    """
+
+    input: InputArgs
+    output: OutputArgs
+    sample_qc: SampleQCArgs = field(default_factory=SampleQCArgs)
+    variant_qc: VariantQCArgs = field(default_factory=VariantQCArgs)
+    ancestry: AncestryArgs = field(default_factory=AncestryArgs)
+    gwas: GWASArgs = field(default_factory=GWASArgs)
+
+    @property
+    def geno_path(self) -> Path:
+        """Get the input genotype path."""
+        return self.input.geno_path
+
+    @property
+    def out_path(self) -> Path:
+        """Get the output path."""
+        return self.output.out_path
+
+    @property
+    def warn_only(self) -> bool:
+        """Get warn_only flag."""
+        return self.output.warn_only
+
+    @property
+    def full_output(self) -> bool:
+        """Get full_output flag."""
+        return self.output.full_output
+
+    def get_enabled_sample_steps(self) -> List[str]:
+        """Get list of enabled sample QC steps."""
+        steps = []
+        if self.sample_qc.run_callrate:
+            steps.append("callrate")
+        if self.sample_qc.run_sex:
+            steps.append("sex")
+        if self.sample_qc.run_het:
+            steps.append("het")
+        if self.sample_qc.run_related:
+            steps.append("related")
+        if self.sample_qc.run_kinship_check:
+            steps.append("kinship_check")
+        return steps
+
+    def get_enabled_variant_steps(self) -> List[str]:
+        """Get list of enabled variant QC steps."""
+        steps = []
+        if self.variant_qc.run_case_control:
+            steps.append("case_control")
+        if self.variant_qc.run_haplotype:
+            steps.append("haplotype")
+        if self.variant_qc.run_hwe:
+            steps.append("hwe")
+        if self.variant_qc.run_geno:
+            steps.append("geno")
+        if self.variant_qc.run_ld:
+            steps.append("ld")
+        return steps
+
+    def get_all_enabled_steps(self) -> List[str]:
+        """Get all enabled QC steps in order."""
+        steps = self.get_enabled_sample_steps() + self.get_enabled_variant_steps()
+        if self.gwas.run_pca or self.gwas.run_gwas:
+            steps.append("assoc")
+        return steps
+
+    def has_any_qc_steps(self) -> bool:
+        """Check if any QC steps are enabled."""
+        return len(self.get_enabled_sample_steps()) > 0 or len(
+            self.get_enabled_variant_steps()
+        ) > 0
+
+    def to_legacy_dict(self) -> dict:
+        """Convert to legacy args_dict format for backward compatibility.
+
+        This allows gradual migration by supporting the existing
+        execute_pipeline and execute_ancestry_predictions functions.
+        """
+        return {
+            # Input/output
+            "bfile": str(self.input.bfile) if self.input.bfile else None,
+            "pfile": str(self.input.pfile) if self.input.pfile else None,
+            "vcf": str(self.input.vcf) if self.input.vcf else None,
+            "geno_path": str(self.geno_path),
+            "out": str(self.out_path),
+            "full_output": self.full_output,
+            "skip_fails": self.output.skip_fails,
+            "warn": self.warn_only,
+            # Sample QC
+            "callrate": self.sample_qc.callrate_threshold
+            if self.sample_qc.run_callrate
+            else None,
+            "sex": [self.sample_qc.female_max_f, self.sample_qc.male_min_f]
+            if self.sample_qc.run_sex
+            else None,
+            "het": [self.sample_qc.het_lower, self.sample_qc.het_upper]
+            if self.sample_qc.run_het
+            else None,
+            "amr_het": self.sample_qc.amr_het,
+            "related": self.sample_qc.run_related,
+            "related_cutoff": self.sample_qc.related_cutoff,
+            "duplicated_cutoff": self.sample_qc.duplicated_cutoff,
+            "prune_related": self.sample_qc.prune_related,
+            "prune_duplicated": self.sample_qc.prune_duplicated,
+            "kinship_check": self.sample_qc.run_kinship_check,
+            "all_sample": False,  # Handled by enabling individual steps
+            # Variant QC
+            "geno": self.variant_qc.geno_threshold
+            if self.variant_qc.run_geno
+            else None,
+            "case_control": self.variant_qc.case_control_threshold
+            if self.variant_qc.run_case_control
+            else None,
+            "haplotype": self.variant_qc.haplotype_threshold
+            if self.variant_qc.run_haplotype
+            else None,
+            "hwe": self.variant_qc.hwe_threshold if self.variant_qc.run_hwe else None,
+            "filter_controls": self.variant_qc.filter_controls,
+            "ld": [
+                self.variant_qc.ld_window_size,
+                self.variant_qc.ld_step_size,
+                self.variant_qc.ld_r2_threshold,
+            ]
+            if self.variant_qc.run_ld
+            else None,
+            "all_variant": False,  # Handled by enabling individual steps
+            # Ancestry
+            "ancestry": self.ancestry.run_ancestry,
+            "ref_panel": str(self.ancestry.ref_panel)
+            if self.ancestry.ref_panel
+            else None,
+            "ref_labels": str(self.ancestry.ref_labels)
+            if self.ancestry.ref_labels
+            else None,
+            "model": str(self.ancestry.model_path)
+            if self.ancestry.model_path
+            else None,
+            "container": self.ancestry.use_container,
+            "singularity": self.ancestry.use_singularity,
+            "subset_ancestry": self.ancestry.subset_ancestry,
+            "min_samples": self.ancestry.min_samples,
+            # GWAS
+            "pca": self.gwas.n_pcs if self.gwas.run_pca else None,
+            "build": self.gwas.build,
+            "gwas": self.gwas.run_gwas,
+            "covars": str(self.gwas.covar_path) if self.gwas.covar_path else None,
+            "covar_names": self.gwas.covar_names,
+            "maf_lambdas": self.gwas.maf_lambdas,
+        }
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create argument parser with proper types.
+
+    Returns:
+        Configured ArgumentParser instance.
+    """
+    parser = argparse.ArgumentParser(
+        prog="genotools",
+        description="Genotype QC and ancestry prediction pipeline",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Run all sample QC
+  genotools --pfile data/mydata --out results/output --all-sample
+
+  # Run ancestry prediction only
+  genotools --pfile data/mydata --out results/output --ancestry \\
+            --ref-panel refs/panel --ref-labels refs/labels.txt
+
+  # Run full pipeline with ancestry split
+  genotools --pfile data/mydata --out results/output --ancestry \\
+            --ref-panel refs/panel --ref-labels refs/labels.txt \\
+            --all-sample --all-variant
+        """,
+    )
+
+    # Input file group
+    input_group = parser.add_argument_group("Input files")
+    input_group.add_argument(
+        "--bfile",
+        type=Path,
+        default=None,
+        help="PLINK 1.9 format genotype file path (without .bed/.bim/.fam extension)",
+    )
+    input_group.add_argument(
+        "--pfile",
+        type=Path,
+        default=None,
+        help="PLINK 2 format genotype file path (without .pgen/.pvar/.psam extension)",
+    )
+    input_group.add_argument(
+        "--vcf",
+        type=Path,
+        default=None,
+        help="VCF format genotype file path",
+    )
+
+    # Output group
+    output_group = parser.add_argument_group("Output configuration")
+    output_group.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Output prefix (including path)",
+    )
+    output_group.add_argument(
+        "--full-output",
+        action="store_true",
+        help="Output all intermediate files",
+    )
+    output_group.add_argument(
+        "--skip-fails",
+        action="store_true",
+        help="Skip up-front validation checks",
+    )
+    output_group.add_argument(
+        "--no-warn",
+        action="store_true",
+        help="Stop pipeline on first error (default: continue with warnings)",
+    )
+
+    # Sample QC group
+    sample_group = parser.add_argument_group("Sample-level QC")
+    sample_group.add_argument(
+        "--callrate",
+        type=float,
+        nargs="?",
+        const=0.02,
+        default=None,
+        metavar="THRESHOLD",
+        help="Sample callrate threshold (default: 0.02 if flag used)",
+    )
+    sample_group.add_argument(
+        "--sex",
+        type=float,
+        nargs="*",
+        default=None,
+        metavar="VALUE",
+        help="Sex check thresholds [female_max_f male_min_f] (default: 0.25 0.75)",
+    )
+    sample_group.add_argument(
+        "--het",
+        type=float,
+        nargs="*",
+        default=None,
+        metavar="VALUE",
+        help="Heterozygosity thresholds [lower upper] (default: -0.15 0.15)",
+    )
+    sample_group.add_argument(
+        "--amr-het",
+        action="store_true",
+        help="Use auto-detect heterozygosity for AMR samples",
+    )
+    sample_group.add_argument(
+        "--related",
+        action="store_true",
+        help="Run relatedness analysis",
+    )
+    sample_group.add_argument(
+        "--related-cutoff",
+        type=float,
+        default=0.0884,
+        metavar="CUTOFF",
+        help="Relatedness cutoff (default: 0.0884)",
+    )
+    sample_group.add_argument(
+        "--duplicated-cutoff",
+        type=float,
+        default=0.354,
+        metavar="CUTOFF",
+        help="Duplicate cutoff (default: 0.354)",
+    )
+    sample_group.add_argument(
+        "--prune-related",
+        action="store_true",
+        help="Prune related samples",
+    )
+    sample_group.add_argument(
+        "--no-prune-duplicated",
+        action="store_true",
+        help="Do not prune duplicated samples",
+    )
+    sample_group.add_argument(
+        "--kinship-check",
+        action="store_true",
+        help="Run kinship confirmation (Linux only)",
+    )
+    sample_group.add_argument(
+        "--all-sample",
+        action="store_true",
+        help="Run all sample-level QC with default thresholds",
+    )
+
+    # Variant QC group
+    variant_group = parser.add_argument_group("Variant-level QC")
+    variant_group.add_argument(
+        "--geno",
+        type=float,
+        nargs="?",
+        const=0.05,
+        default=None,
+        metavar="THRESHOLD",
+        help="Variant missingness threshold (default: 0.05 if flag used)",
+    )
+    variant_group.add_argument(
+        "--case-control",
+        type=float,
+        nargs="?",
+        const=1e-4,
+        default=None,
+        metavar="P_THRESHOLD",
+        help="Case-control missingness p-value threshold (default: 1e-4)",
+    )
+    variant_group.add_argument(
+        "--haplotype",
+        type=float,
+        nargs="?",
+        const=1e-4,
+        default=None,
+        metavar="P_THRESHOLD",
+        help="Haplotype test p-value threshold (default: 1e-4)",
+    )
+    variant_group.add_argument(
+        "--hwe",
+        type=float,
+        nargs="?",
+        const=1e-4,
+        default=None,
+        metavar="P_THRESHOLD",
+        help="HWE p-value threshold (default: 1e-4)",
+    )
+    variant_group.add_argument(
+        "--filter-controls",
+        action="store_true",
+        help="Apply HWE filter to controls only",
+    )
+    variant_group.add_argument(
+        "--ld",
+        type=float,
+        nargs="*",
+        default=None,
+        metavar="VALUE",
+        help="LD pruning [window_size step_size r2_threshold] (default: 50 5 0.5)",
+    )
+    variant_group.add_argument(
+        "--all-variant",
+        action="store_true",
+        help="Run all variant-level QC with default thresholds (except LD)",
+    )
+
+    # Ancestry group
+    ancestry_group = parser.add_argument_group("Ancestry prediction")
+    ancestry_group.add_argument(
+        "--ancestry",
+        action="store_true",
+        help="Run ancestry prediction",
+    )
+    ancestry_group.add_argument(
+        "--ref-panel",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Reference panel genotype file path",
+    )
+    ancestry_group.add_argument(
+        "--ref-labels",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Reference panel ancestry labels file (FID IID label, no header)",
+    )
+    ancestry_group.add_argument(
+        "--model",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Pre-trained ancestry model pickle file",
+    )
+    ancestry_group.add_argument(
+        "--container",
+        action="store_true",
+        help="Run ancestry prediction in Docker container",
+    )
+    ancestry_group.add_argument(
+        "--singularity",
+        action="store_true",
+        help="Run ancestry prediction in Singularity container",
+    )
+    ancestry_group.add_argument(
+        "--cloud",
+        action="store_true",
+        help="Run ancestry prediction on Google Cloud AI Platform",
+    )
+    ancestry_group.add_argument(
+        "--subset-ancestry",
+        type=str,
+        nargs="*",
+        default=None,
+        metavar="LABEL",
+        help="Subset to specific ancestry labels for downstream analysis",
+    )
+    ancestry_group.add_argument(
+        "--min-samples",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Minimum samples per ancestry for downstream analysis (default: 0)",
+    )
+
+    # GWAS group
+    gwas_group = parser.add_argument_group("GWAS and PCA")
+    gwas_group.add_argument(
+        "--pca",
+        type=int,
+        nargs="?",
+        const=10,
+        default=None,
+        metavar="N_PCS",
+        help="Run PCA with N principal components (default: 10)",
+    )
+    gwas_group.add_argument(
+        "--build",
+        type=str,
+        default="hg38",
+        choices=["hg19", "hg38"],
+        help="Genome build for PCA (default: hg38)",
+    )
+    gwas_group.add_argument(
+        "--gwas",
+        action="store_true",
+        help="Run GWAS",
+    )
+    gwas_group.add_argument(
+        "--covars",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="External covariates file path",
+    )
+    gwas_group.add_argument(
+        "--covar-names",
+        type=str,
+        default=None,
+        metavar="NAMES",
+        help="Covariate names to use from external file",
+    )
+    gwas_group.add_argument(
+        "--maf-lambdas",
+        action="store_true",
+        help="MAF prune before lambda calculations",
+    )
+
+    return parser
+
+
+def _parse_sex_args(
+    sex_values: Optional[List[float]],
+) -> Tuple[bool, float, float]:
+    """Parse sex check arguments.
+
+    Args:
+        sex_values: List of threshold values or None.
+
+    Returns:
+        Tuple of (run_sex, female_max_f, male_min_f).
+    """
+    if sex_values is None:
+        return False, 0.25, 0.75
+
+    if len(sex_values) == 0:
+        # Flag used without values - use defaults
+        return True, 0.25, 0.75
+    elif len(sex_values) == 2:
+        return True, sex_values[0], sex_values[1]
+    else:
+        raise ValueError(
+            f"--sex requires 0 or 2 values, got {len(sex_values)}: {sex_values}"
+        )
+
+
+def _parse_het_args(
+    het_values: Optional[List[float]],
+) -> Tuple[bool, float, float]:
+    """Parse heterozygosity arguments.
+
+    Args:
+        het_values: List of threshold values or None.
+
+    Returns:
+        Tuple of (run_het, het_lower, het_upper).
+    """
+    if het_values is None:
+        return False, -0.15, 0.15
+
+    if len(het_values) == 0:
+        # Flag used without values - use defaults
+        return True, -0.15, 0.15
+    elif len(het_values) == 2:
+        return True, het_values[0], het_values[1]
+    else:
+        raise ValueError(
+            f"--het requires 0 or 2 values, got {len(het_values)}: {het_values}"
+        )
+
+
+def _parse_ld_args(
+    ld_values: Optional[List[float]],
+) -> Tuple[bool, int, int, float]:
+    """Parse LD pruning arguments.
+
+    Args:
+        ld_values: List of LD parameters or None.
+
+    Returns:
+        Tuple of (run_ld, window_size, step_size, r2_threshold).
+    """
+    if ld_values is None:
+        return False, 50, 5, 0.5
+
+    if len(ld_values) == 0:
+        # Flag used without values - use defaults
+        return True, 50, 5, 0.5
+    elif len(ld_values) == 3:
+        return True, int(ld_values[0]), int(ld_values[1]), ld_values[2]
+    else:
+        raise ValueError(
+            f"--ld requires 0 or 3 values, got {len(ld_values)}: {ld_values}"
+        )
+
+
+def parse_args(args: Optional[Sequence[str]] = None) -> PipelineArgs:
+    """Parse and validate command-line arguments.
+
+    Args:
+        args: Command-line arguments (defaults to sys.argv).
+
+    Returns:
+        Validated PipelineArgs instance.
+
+    Raises:
+        SystemExit: If argument parsing fails.
+        ValueError: If argument validation fails.
+    """
+    parser = create_parser()
+    ns = parser.parse_args(args)
+
+    # Validate input files
+    if ns.bfile is None and ns.pfile is None and ns.vcf is None:
+        parser.error("At least one input required: --bfile, --pfile, or --vcf")
+
+    # Parse complex arguments
+    run_sex, female_max_f, male_min_f = _parse_sex_args(ns.sex)
+    run_het, het_lower, het_upper = _parse_het_args(ns.het)
+    run_ld, ld_window, ld_step, ld_r2 = _parse_ld_args(ns.ld)
+
+    # Handle --all-sample
+    run_callrate = ns.callrate is not None
+    callrate_threshold = ns.callrate if ns.callrate is not None else 0.02
+    run_related = ns.related
+
+    if ns.all_sample:
+        run_callrate = True
+        callrate_threshold = 0.05  # Different default for all_sample
+        run_sex = True
+        run_het = True
+        run_related = True
+
+    # Handle --all-variant
+    run_geno = ns.geno is not None
+    geno_threshold = ns.geno if ns.geno is not None else 0.05
+    run_case_control = ns.case_control is not None
+    case_control_threshold = ns.case_control if ns.case_control is not None else 1e-4
+    run_haplotype = ns.haplotype is not None
+    haplotype_threshold = ns.haplotype if ns.haplotype is not None else 1e-4
+    run_hwe = ns.hwe is not None
+    hwe_threshold = ns.hwe if ns.hwe is not None else 1e-4
+
+    if ns.all_variant:
+        run_geno = True
+        geno_threshold = 0.05
+        run_case_control = True
+        case_control_threshold = 1e-4
+        run_haplotype = True
+        haplotype_threshold = 1e-4
+        run_hwe = True
+        hwe_threshold = 1e-4
+        # Note: LD is NOT included in all_variant (matches legacy behavior)
+
+    # Build argument groups
+    input_args = InputArgs(
+        bfile=ns.bfile,
+        pfile=ns.pfile,
+        vcf=ns.vcf,
+    )
+
+    output_args = OutputArgs(
+        out_path=ns.out,
+        full_output=ns.full_output,
+        skip_fails=ns.skip_fails,
+        warn_only=not ns.no_warn,
+    )
+
+    sample_qc_args = SampleQCArgs(
+        run_callrate=run_callrate,
+        callrate_threshold=callrate_threshold,
+        run_sex=run_sex,
+        female_max_f=female_max_f,
+        male_min_f=male_min_f,
+        run_het=run_het,
+        het_lower=het_lower,
+        het_upper=het_upper,
+        amr_het=ns.amr_het,
+        run_related=run_related,
+        related_cutoff=ns.related_cutoff,
+        duplicated_cutoff=ns.duplicated_cutoff,
+        prune_related=ns.prune_related,
+        prune_duplicated=not ns.no_prune_duplicated,
+        run_kinship_check=ns.kinship_check,
+    )
+
+    variant_qc_args = VariantQCArgs(
+        run_geno=run_geno,
+        geno_threshold=geno_threshold,
+        run_case_control=run_case_control,
+        case_control_threshold=case_control_threshold,
+        run_haplotype=run_haplotype,
+        haplotype_threshold=haplotype_threshold,
+        run_hwe=run_hwe,
+        hwe_threshold=hwe_threshold,
+        filter_controls=ns.filter_controls,
+        run_ld=run_ld,
+        ld_window_size=ld_window,
+        ld_step_size=ld_step,
+        ld_r2_threshold=ld_r2,
+    )
+
+    ancestry_args = AncestryArgs(
+        run_ancestry=ns.ancestry,
+        ref_panel=ns.ref_panel,
+        ref_labels=ns.ref_labels,
+        model_path=ns.model,
+        subset_ancestry=ns.subset_ancestry,
+        min_samples=ns.min_samples,
+        use_container=ns.container,
+        use_singularity=ns.singularity,
+        use_cloud=ns.cloud,
+    )
+
+    gwas_args = GWASArgs(
+        run_pca=ns.pca is not None,
+        n_pcs=ns.pca if ns.pca is not None else 10,
+        build=ns.build,
+        run_gwas=ns.gwas,
+        covar_path=ns.covars,
+        covar_names=ns.covar_names,
+        maf_lambdas=ns.maf_lambdas,
+    )
+
+    return PipelineArgs(
+        input=input_args,
+        output=output_args,
+        sample_qc=sample_qc_args,
+        variant_qc=variant_qc_args,
+        ancestry=ancestry_args,
+        gwas=gwas_args,
+    )

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -1,0 +1,777 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Pipeline runner for GenoTools.
+
+This module provides the main pipeline orchestration logic, coordinating
+QC steps, ancestry prediction, and GWAS analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+import platform
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Callable
+
+from .parser import PipelineArgs
+from .output import PipelineOutput, write_results
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StepResult:
+    """Result from a single pipeline step."""
+
+    step: str
+    passed: bool
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    output: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    @classmethod
+    def from_legacy_dict(cls, step: str, legacy: Dict[str, Any]) -> "StepResult":
+        """Create from legacy output dictionary format."""
+        return cls(
+            step=step,
+            passed=legacy.get("pass", False),
+            metrics=legacy.get("metrics", {}),
+            output=legacy.get("output", {}),
+        )
+
+
+@dataclass
+class PassFailRecord:
+    """Record of step pass/fail status."""
+
+    status: bool
+    input_path: str
+    output_path: str
+    error: Optional[str] = None
+
+
+@dataclass
+class PipelineState:
+    """Tracks the current state of the pipeline execution."""
+
+    geno_path: Path
+    out_path: Path
+    tmp_dir: Optional[tempfile.TemporaryDirectory] = None  # type: ignore[type-arg]
+    current_input: Optional[str] = None
+    pass_fail: Dict[str, PassFailRecord] = field(default_factory=dict)
+    step_results: Dict[str, StepResult] = field(default_factory=dict)
+    ancestry_result: Optional[Dict[str, Any]] = None
+    labels_list: List[str] = field(default_factory=list)
+
+    def get_last_passed_output(self) -> Optional[str]:
+        """Get the output path of the last passed step."""
+        last_passed = None
+        for step_name, record in self.pass_fail.items():
+            if record.status:
+                last_passed = record.output_path
+        return last_passed
+
+
+class PipelineRunner:
+    """Runs the GenoTools QC and analysis pipeline.
+
+    This class orchestrates the execution of QC steps, ancestry prediction,
+    and GWAS analysis. It supports both the new modular architecture and
+    backward compatibility with legacy code.
+
+    Attributes:
+        args: Validated pipeline arguments.
+        state: Current pipeline execution state.
+    """
+
+    # Step categories
+    SAMPLE_STEPS = ["callrate", "sex", "het", "related", "kinship_check"]
+    VARIANT_STEPS = ["case_control", "haplotype", "hwe", "geno", "ld"]
+
+    def __init__(self, args: PipelineArgs) -> None:
+        """Initialize the pipeline runner.
+
+        Args:
+            args: Validated pipeline arguments.
+        """
+        self.args = args
+        self.state: Optional[PipelineState] = None
+
+        # These will be set up during run()
+        self._samp_qc: Any = None
+        self._var_qc: Any = None
+        self._ancestry: Any = None
+        self._assoc: Any = None
+        self._steps_dict: Dict[str, Callable[..., Dict[str, Any]]] = {}
+
+    def run(self) -> PipelineOutput:
+        """Run the complete pipeline.
+
+        Returns:
+            PipelineOutput containing all results.
+
+        Raises:
+            ValueError: If no input files or steps are specified.
+        """
+        # Initialize state
+        self._initialize_state()
+
+        # Initialize QC classes (legacy)
+        self._initialize_qc_classes()
+
+        # Set up logging
+        self._setup_logging()
+
+        # Convert input format if needed
+        self._convert_input_format()
+
+        # Validate we have something to do
+        steps = self.args.get_all_enabled_steps()
+        if not steps and not self.args.ancestry.run_ancestry:
+            raise ValueError("No QC steps or ancestry prediction requested")
+
+        # Run the pipeline
+        try:
+            if self.args.ancestry.run_ancestry:
+                result = self._run_with_ancestry(steps)
+            else:
+                result = self._run_qc_only(steps)
+
+            return result
+        finally:
+            # Cleanup temporary directory
+            if self.state and self.state.tmp_dir:
+                self.state.tmp_dir.cleanup()
+
+    def _initialize_state(self) -> None:
+        """Initialize pipeline state."""
+        out_dir = self.args.out_path.parent
+        if not out_dir.exists():
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create temporary directory
+        tmp_dir = tempfile.TemporaryDirectory(
+            suffix="_tmp", prefix=".", dir=str(out_dir)
+        )
+
+        self.state = PipelineState(
+            geno_path=self.args.geno_path,
+            out_path=self.args.out_path,
+            tmp_dir=tmp_dir,
+            current_input=str(self.args.geno_path),
+        )
+
+    def _initialize_qc_classes(self) -> None:
+        """Initialize legacy QC classes for backward compatibility."""
+        # Import here to avoid circular imports and allow gradual migration
+        # These imports use the legacy module structure (genotools/qc.py, etc.)
+        # which will be replaced during full integration
+        from ..qc import SampleQC, VariantQC  # type: ignore[attr-defined]
+        from ..ancestry import Ancestry  # type: ignore[attr-defined]
+        from ..gwas import Assoc  # type: ignore[attr-defined]
+
+        self._samp_qc = SampleQC()
+        self._var_qc = VariantQC()
+        self._ancestry = Ancestry()
+        self._assoc = Assoc()
+
+        # Build step dispatch dictionary
+        self._steps_dict = {
+            "callrate": self._samp_qc.run_callrate_prune,
+            "sex": self._samp_qc.run_sex_prune,
+            "het": self._samp_qc.run_het_prune,
+            "related": self._samp_qc.run_related_prune,
+            "kinship_check": self._samp_qc.run_confirming_kinship,
+            "case_control": self._var_qc.run_case_control_prune,
+            "haplotype": self._var_qc.run_haplotype_prune,
+            "hwe": self._var_qc.run_hwe_prune,
+            "geno": self._var_qc.run_geno_prune,
+            "ld": self._var_qc.run_ld_prune,
+            "assoc": self._assoc.run_association,
+        }
+
+    def _setup_logging(self) -> None:
+        """Set up log files."""
+        assert self.state is not None
+        out_path = str(self.state.out_path)
+
+        # Clear existing log files
+        all_logs = f"{out_path}_all_logs.log"
+        cleaned_logs = f"{out_path}_cleaned_logs.log"
+
+        if os.path.exists(all_logs):
+            os.remove(all_logs)
+        if os.path.exists(cleaned_logs):
+            os.remove(cleaned_logs)
+
+        # Create new log files with header
+        from ..utils import gt_header
+
+        header = gt_header()
+        with open(all_logs, "w") as fp:
+            fp.write(header)
+            fp.write("\n")
+        with open(cleaned_logs, "w") as fp:
+            pass
+
+    def _convert_input_format(self) -> None:
+        """Convert input format to pfiles if needed."""
+        input_format = self.args.input.input_format
+
+        if input_format == "bfile":
+            from ..utils import bfiles_to_pfiles
+
+            bfiles_to_pfiles(bfile_path=str(self.args.input.bfile))
+        elif input_format == "vcf":
+            from ..utils import vcf_to_pfiles
+
+            vcf_to_pfiles(vcf_path=str(self.args.input.vcf))
+
+        # Run upfront validation
+        if not self.args.output.skip_fails:
+            from ..utils import upfront_check
+
+            legacy_dict = self.args.to_legacy_dict()
+            upfront_check(str(self.args.geno_path), legacy_dict)
+
+    def _run_with_ancestry(self, steps: List[str]) -> PipelineOutput:
+        """Run pipeline with ancestry prediction.
+
+        Args:
+            steps: List of QC steps to run after ancestry split.
+
+        Returns:
+            PipelineOutput with results.
+        """
+        assert self.state is not None
+
+        # Run ancestry prediction
+        ancestry_result = self._run_ancestry_prediction()
+        self.state.ancestry_result = ancestry_result
+        self.state.labels_list = ancestry_result["data"]["labels_list"]
+
+        # If no QC steps, just return ancestry results
+        if not steps:
+            return self._build_output()
+
+        # Run QC for each ancestry group
+        het_value = [self.args.sample_qc.het_lower, self.args.sample_qc.het_upper]
+
+        for label in self.state.labels_list:
+            # Set up paths for this ancestry
+            geno_path = f"{self.args.out_path}_ancestry_{label}"
+            out_path = f"{self.args.out_path}_{label}"
+
+            # Handle AMR heterozygosity
+            current_het = het_value
+            if self.args.sample_qc.amr_het and label == "AMR":
+                current_het = [-1.0, -1.0]
+
+            # Create modified args for this ancestry
+            self._run_qc_pipeline(
+                steps=steps,
+                geno_path=geno_path,
+                out_path=out_path,
+                het_values=current_het,
+                ancestry_label=label,
+            )
+
+        return self._build_output()
+
+    def _run_qc_only(self, steps: List[str]) -> PipelineOutput:
+        """Run QC pipeline without ancestry prediction.
+
+        Args:
+            steps: List of QC steps to run.
+
+        Returns:
+            PipelineOutput with results.
+        """
+        assert self.state is not None
+
+        self._run_qc_pipeline(
+            steps=steps,
+            geno_path=str(self.state.geno_path),
+            out_path=str(self.state.out_path),
+        )
+
+        return self._build_output()
+
+    def _run_ancestry_prediction(self) -> Dict[str, Any]:
+        """Run ancestry prediction.
+
+        Returns:
+            Ancestry result dictionary.
+        """
+        assert self.state is not None
+
+        # Determine output path
+        has_qc_steps = self.args.has_any_qc_steps()
+        if has_qc_steps:
+            out_path = f"{self.state.out_path}_ancestry"
+        else:
+            out_path = str(self.state.out_path)
+
+        # Use temporary directory if not full output
+        if not self.args.full_output:
+            out_name = pathlib.PurePath(out_path).name
+            actual_out = f"{self.state.tmp_dir.name}/{out_name}"  # type: ignore[union-attr]
+        else:
+            actual_out = out_path
+
+        # Configure ancestry object
+        self._ancestry.geno_path = str(self.state.geno_path)
+        self._ancestry.out_path = actual_out
+        self._ancestry.final_out_path = out_path
+        self._ancestry.ref_panel = (
+            str(self.args.ancestry.ref_panel)
+            if self.args.ancestry.ref_panel
+            else None
+        )
+        self._ancestry.ref_labels = (
+            str(self.args.ancestry.ref_labels)
+            if self.args.ancestry.ref_labels
+            else None
+        )
+        self._ancestry.model_path = (
+            str(self.args.ancestry.model_path)
+            if self.args.ancestry.model_path
+            else None
+        )
+        self._ancestry.containerized = self.args.ancestry.use_container
+        self._ancestry.singularity = self.args.ancestry.use_singularity
+        self._ancestry.subset = self.args.ancestry.subset_ancestry
+        self._ancestry.min_samples = self.args.ancestry.min_samples
+
+        # Run prediction
+        result = self._ancestry.run_ancestry()
+
+        # Move files if ancestry-only and not full output
+        if not has_qc_steps and not self.args.full_output:
+            self._move_ancestry_files(result)
+
+        return result
+
+    def _move_ancestry_files(self, ancestry_result: Dict[str, Any]) -> None:
+        """Move ancestry output files from tmp to final location."""
+        assert self.state is not None
+        assert self.state.tmp_dir is not None
+
+        out_dir = str(self.state.out_path.parent)
+        out_name = self.state.out_path.name
+
+        for label in ancestry_result["data"]["labels_list"]:
+            pgen = f"{self.state.tmp_dir.name}/{out_name}_{label}.pgen"
+            if os.path.isfile(pgen):
+                os.rename(pgen, f"{out_dir}/{out_name}_{label}.pgen")
+                os.rename(
+                    f"{self.state.tmp_dir.name}/{out_name}_{label}.psam",
+                    f"{out_dir}/{out_name}_{label}.psam",
+                )
+                os.rename(
+                    f"{self.state.tmp_dir.name}/{out_name}_{label}.pvar",
+                    f"{out_dir}/{out_name}_{label}.pvar",
+                )
+
+    def _run_qc_pipeline(
+        self,
+        steps: List[str],
+        geno_path: str,
+        out_path: str,
+        het_values: Optional[List[float]] = None,
+        ancestry_label: str = "all",
+    ) -> Dict[str, Any]:
+        """Run QC pipeline for a single dataset.
+
+        Args:
+            steps: List of QC steps to run.
+            geno_path: Input genotype path.
+            out_path: Output path.
+            het_values: Optional heterozygosity thresholds.
+            ancestry_label: Ancestry label for this run.
+
+        Returns:
+            Dictionary with step results and pass/fail status.
+        """
+        assert self.state is not None
+
+        # Set up working paths
+        if self.args.full_output:
+            working_geno = geno_path
+            working_out = out_path
+        else:
+            geno_name = pathlib.PurePath(geno_path).name
+            out_name = pathlib.PurePath(out_path).name
+            working_geno = f"{self.state.tmp_dir.name}/{geno_name}"  # type: ignore[union-attr]
+            working_out = f"{self.state.tmp_dir.name}/{out_name}"  # type: ignore[union-attr]
+
+        # Initialize tracking
+        step_paths = [working_out]
+        pass_fail: Dict[str, PassFailRecord] = {}
+        out_dict: Dict[str, Any] = {}
+
+        # Get legacy args for parameter passing
+        legacy_args = self.args.to_legacy_dict()
+        if het_values is not None:
+            legacy_args["het"] = het_values
+
+        # Run each step
+        for i, step in enumerate(steps):
+            step_input, step_output = self._compute_step_paths(
+                step=step,
+                step_index=i,
+                steps=steps,
+                pass_fail=pass_fail,
+                geno_path=geno_path if self.args.full_output else working_geno,
+                out_path=out_path,
+                working_out=working_out,
+            )
+
+            step_paths.append(step_output)
+            logger.info(
+                f"Running: {step} with input {step_input} and output: {step_output}"
+            )
+            print(f"Running: {step} with input {step_input} and output: {step_output}")
+
+            # Check if input exists
+            if self.args.warn_only and not os.path.isfile(f"{step_input}.pgen"):
+                print(
+                    f"Step {step} cannot be run! "
+                    "All samples or variants were pruned in a previous step!"
+                )
+                pass_fail[step] = PassFailRecord(
+                    status=False, input_path=step_input, output_path=step_output
+                )
+                continue
+
+            # Run the step
+            result = self._run_single_step(
+                step=step,
+                step_input=step_input,
+                step_output=step_output,
+                legacy_args=legacy_args,
+            )
+
+            if result is not None:
+                out_dict[step] = result
+                pass_fail[step] = PassFailRecord(
+                    status=result.get("pass", False),
+                    input_path=step_input,
+                    output_path=step_output,
+                )
+
+                # Clean up intermediate files
+                self._cleanup_intermediate_files(
+                    step=step,
+                    pass_fail=pass_fail,
+                    out_dict=out_dict,
+                    out_path=out_path,
+                    geno_path=geno_path,
+                )
+
+        # Handle final step failure with --warn
+        self._handle_final_step_failure(steps, pass_fail, out_path, geno_path, working_geno)
+
+        out_dict["paths"] = step_paths
+        out_dict["pass_fail"] = {
+            k: {"status": v.status, "input": v.input_path, "output": v.output_path}
+            for k, v in pass_fail.items()
+        }
+
+        # Store results by ancestry label
+        if ancestry_label == "all":
+            self.state.step_results = {
+                k: StepResult.from_legacy_dict(k, v)
+                for k, v in out_dict.items()
+                if k not in ("paths", "pass_fail")
+            }
+            self.state.pass_fail = pass_fail
+        else:
+            # Store per-ancestry results
+            if not hasattr(self.state, "ancestry_results"):
+                self.state.ancestry_results = {}  # type: ignore[attr-defined]
+            self.state.ancestry_results[ancestry_label] = out_dict  # type: ignore[attr-defined]
+
+        return out_dict
+
+    def _compute_step_paths(
+        self,
+        step: str,
+        step_index: int,
+        steps: List[str],
+        pass_fail: Dict[str, PassFailRecord],
+        geno_path: str,
+        out_path: str,
+        working_out: str,
+    ) -> tuple[str, str]:
+        """Compute input and output paths for a step.
+
+        Args:
+            step: Current step name.
+            step_index: Index in steps list.
+            steps: Full list of steps.
+            pass_fail: Pass/fail tracking dictionary.
+            geno_path: Original genotype path.
+            out_path: Final output path.
+            working_out: Working directory output path.
+
+        Returns:
+            Tuple of (step_input, step_output).
+        """
+        is_last = step_index == len(steps) - 1
+
+        if self.args.warn_only:
+            # Find last passed step
+            last_passed_output = None
+            for completed_step, record in pass_fail.items():
+                if record.status:
+                    last_passed_output = record.output_path
+
+            if last_passed_output:
+                step_input = last_passed_output
+                step_output = f"{last_passed_output}_{step}"
+            else:
+                step_input = geno_path
+                step_output = (
+                    f"{out_path}_{step}"
+                    if self.args.full_output
+                    else f"{working_out}_{step}"
+                )
+
+            if is_last:
+                step_output = out_path
+        else:
+            # Sequential processing
+            if step_index == 0:
+                step_input = geno_path
+            else:
+                prev_step = steps[step_index - 1]
+                if prev_step in pass_fail:
+                    step_input = pass_fail[prev_step].output_path
+                else:
+                    step_input = (
+                        f"{out_path}_{steps[step_index - 1]}"
+                        if self.args.full_output
+                        else f"{working_out}_{steps[step_index - 1]}"
+                    )
+
+            if is_last:
+                step_output = out_path
+            else:
+                step_output = (
+                    f"{out_path}_{step}"
+                    if self.args.full_output
+                    else f"{working_out}_{step}"
+                )
+
+        return step_input, step_output
+
+    def _run_single_step(
+        self,
+        step: str,
+        step_input: str,
+        step_output: str,
+        legacy_args: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Run a single QC step.
+
+        Args:
+            step: Step name.
+            step_input: Input path.
+            step_output: Output path.
+            legacy_args: Legacy argument dictionary.
+
+        Returns:
+            Step result dictionary or None if step skipped.
+        """
+        if step in self.SAMPLE_STEPS:
+            self._samp_qc.geno_path = step_input
+            self._samp_qc.out_path = step_output
+
+            if step == "related":
+                return self._steps_dict[step](
+                    related_cutoff=legacy_args["related_cutoff"],
+                    duplicated_cutoff=legacy_args["duplicated_cutoff"],
+                    prune_related=legacy_args["prune_related"],
+                    prune_duplicated=legacy_args["prune_duplicated"],
+                )
+            elif step == "kinship_check":
+                if platform.system() != "Linux":
+                    print("Relatedness Assessment can only run on a Linux OS!")
+                    return None
+                return self._steps_dict[step]()
+            else:
+                return self._steps_dict[step](legacy_args[step])
+
+        elif step in self.VARIANT_STEPS:
+            self._var_qc.geno_path = step_input
+            self._var_qc.out_path = step_output
+
+            if step == "hwe":
+                return self._steps_dict[step](
+                    hwe_threshold=legacy_args["hwe"],
+                    filter_controls=legacy_args["filter_controls"],
+                )
+            elif step == "ld":
+                return self._steps_dict[step](
+                    window_size=legacy_args["ld"][0],
+                    step_size=legacy_args["ld"][1],
+                    r2_threshold=legacy_args["ld"][2],
+                )
+            else:
+                return self._steps_dict[step](legacy_args[step])
+
+        elif step == "assoc":
+            self._assoc.geno_path = step_input
+            self._assoc.out_path = step_output
+            self._assoc.pca = legacy_args["pca"]
+            self._assoc.build = legacy_args["build"]
+            self._assoc.gwas = legacy_args["gwas"]
+            self._assoc.covar_path = legacy_args["covars"]
+            self._assoc.covar_names = legacy_args["covar_names"]
+            self._assoc.maf_lambdas = legacy_args["maf_lambdas"]
+            return self._steps_dict[step]()
+
+        return None
+
+    def _cleanup_intermediate_files(
+        self,
+        step: str,
+        pass_fail: Dict[str, PassFailRecord],
+        out_dict: Dict[str, Any],
+        out_path: str,
+        geno_path: str,
+    ) -> None:
+        """Clean up intermediate pfiles if not needed.
+
+        Args:
+            step: Current step name.
+            pass_fail: Pass/fail tracking dictionary.
+            out_dict: Step output dictionary.
+            out_path: Final output path.
+            geno_path: Original genotype path.
+        """
+        if self.args.full_output:
+            return
+        if self.args.warn_only:
+            return
+        if step in ("assoc", "ancestry", "kinship_check"):
+            return
+
+        # Don't remove if step failed with warn mode
+        if (
+            self.args.warn_only
+            and "pass" in out_dict.get(step, {})
+            and not out_dict[step]["pass"]
+        ):
+            return
+
+        remove_path = pass_fail[step].input_path
+        if (
+            os.path.isfile(f"{remove_path}.pgen")
+            and remove_path != out_path
+            and remove_path != geno_path
+        ):
+            os.remove(f"{remove_path}.pgen")
+            os.remove(f"{remove_path}.psam")
+            os.remove(f"{remove_path}.pvar")
+
+    def _handle_final_step_failure(
+        self,
+        steps: List[str],
+        pass_fail: Dict[str, PassFailRecord],
+        out_path: str,
+        geno_path: str,
+        working_geno: str,
+    ) -> None:
+        """Handle case where final step fails with --warn.
+
+        Args:
+            steps: List of steps.
+            pass_fail: Pass/fail tracking dictionary.
+            out_path: Final output path.
+            geno_path: Original genotype path.
+            working_geno: Working directory genotype path.
+        """
+        if not self.args.warn_only:
+            return
+        if len(steps) <= 1:
+            return
+        if steps[-1] not in pass_fail:
+            return
+        if pass_fail[steps[-1]].status:
+            return
+
+        # Find last passed output
+        last_passed_output = None
+        for step_name in steps[:-1]:
+            if step_name in pass_fail and pass_fail[step_name].status:
+                last_passed_output = pass_fail[step_name].output_path
+
+        if last_passed_output and os.path.isfile(f"{last_passed_output}.pgen"):
+            os.rename(f"{last_passed_output}.pgen", f"{out_path}.pgen")
+            os.rename(f"{last_passed_output}.psam", f"{out_path}.psam")
+            os.rename(f"{last_passed_output}.pvar", f"{out_path}.pvar")
+        elif last_passed_output:
+            # All samples/variants pruned
+            input_path = pass_fail[last_passed_output].input_path
+            if os.path.isfile(f"{input_path}.pgen"):
+                os.rename(f"{input_path}.pgen", f"{out_path}.pgen")
+                os.rename(f"{input_path}.psam", f"{out_path}.psam")
+                os.rename(f"{input_path}.pvar", f"{out_path}.pvar")
+        else:
+            # No steps passed - use original input
+            move_path = (
+                geno_path
+                if self.args.full_output or not self.args.ancestry.run_ancestry
+                else working_geno
+            )
+            if os.path.isfile(f"{move_path}.pgen"):
+                os.rename(f"{move_path}.pgen", f"{out_path}.pgen")
+                os.rename(f"{move_path}.psam", f"{out_path}.psam")
+                os.rename(f"{move_path}.pvar", f"{out_path}.pvar")
+
+    def _build_output(self) -> PipelineOutput:
+        """Build the final pipeline output.
+
+        Returns:
+            PipelineOutput containing all results.
+        """
+        assert self.state is not None
+
+        return PipelineOutput.from_runner_state(
+            args=self.args,
+            state=self.state,
+        )
+
+
+def run_pipeline(args: PipelineArgs) -> PipelineOutput:
+    """Run the GenoTools pipeline.
+
+    This is the main entry point for running the pipeline programmatically.
+
+    Args:
+        args: Validated pipeline arguments.
+
+    Returns:
+        PipelineOutput containing all results.
+    """
+    runner = PipelineRunner(args)
+    return runner.run()

--- a/tests/unit/test_cli/__init__.py
+++ b/tests/unit/test_cli/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Unit tests for CLI module."""

--- a/tests/unit/test_cli/test_output.py
+++ b/tests/unit/test_cli/test_output.py
@@ -1,0 +1,326 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for CLI output formatting."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from genotools.cli.output import (
+    QCMetrics,
+    GWASMetrics,
+    PipelineOutput,
+    write_results,
+    build_metrics_dataframe,
+    build_gwas_dataframe,
+)
+
+
+class TestQCMetrics:
+    """Tests for QCMetrics dataclass."""
+
+    def test_create_metrics(self) -> None:
+        """QCMetrics can be created."""
+        metrics = QCMetrics(
+            step="callrate_prune",
+            pruned_count=10,
+            metric="outlier_count",
+            ancestry="EUR",
+            level="sample",
+            passed=True,
+        )
+        assert metrics.step == "callrate_prune"
+        assert metrics.pruned_count == 10
+        assert metrics.ancestry == "EUR"
+
+    def test_default_values(self) -> None:
+        """QCMetrics has correct defaults."""
+        metrics = QCMetrics(
+            step="test",
+            pruned_count=5,
+            metric="count",
+        )
+        assert metrics.ancestry == "all"
+        assert metrics.level == "sample"
+        assert metrics.passed is True
+
+
+class TestGWASMetrics:
+    """Tests for GWASMetrics dataclass."""
+
+    def test_create_metrics(self) -> None:
+        """GWASMetrics can be created."""
+        metrics = GWASMetrics(
+            value=1.02,
+            metric="lambda",
+            ancestry="EUR",
+        )
+        assert metrics.value == 1.02
+        assert metrics.metric == "lambda"
+        assert metrics.ancestry == "EUR"
+
+    def test_default_ancestry(self) -> None:
+        """GWASMetrics defaults to 'all' ancestry."""
+        metrics = GWASMetrics(value=1.0, metric="lambda")
+        assert metrics.ancestry == "all"
+
+
+class TestPipelineOutput:
+    """Tests for PipelineOutput class."""
+
+    @pytest.fixture
+    def sample_output(self) -> PipelineOutput:
+        """Create sample pipeline output."""
+        return PipelineOutput(
+            input_samples=pd.DataFrame({
+                "#FID": ["FAM1", "FAM2"],
+                "IID": ["SAMP1", "SAMP2"],
+                "SEX": [1, 2],
+            }),
+            ancestry_counts=pd.DataFrame({
+                "label": ["EUR", "AFR"],
+                "count": [100, 50],
+            }),
+            qc_metrics=[
+                QCMetrics(
+                    step="callrate_prune",
+                    pruned_count=5,
+                    metric="outlier_count",
+                    ancestry="EUR",
+                    level="sample",
+                    passed=True,
+                ),
+                QCMetrics(
+                    step="geno_prune",
+                    pruned_count=100,
+                    metric="variant_count",
+                    ancestry="EUR",
+                    level="variant",
+                    passed=True,
+                ),
+            ],
+            gwas_metrics=[
+                GWASMetrics(value=1.02, metric="lambda", ancestry="EUR"),
+            ],
+            pass_fail={
+                "pass_fail": {
+                    "callrate": {"status": True, "input": "/in", "output": "/out"},
+                }
+            },
+        )
+
+    def test_to_dict_structure(self, sample_output: PipelineOutput) -> None:
+        """to_dict returns expected structure."""
+        result = sample_output.to_dict()
+
+        assert "input_samples" in result
+        assert "ancestry_counts" in result
+        assert "QC" in result
+        assert "GWAS" in result
+        assert "pass_fail" in result
+
+    def test_to_dict_qc_format(self, sample_output: PipelineOutput) -> None:
+        """to_dict QC section has correct format."""
+        result = sample_output.to_dict()
+        qc = result["QC"]
+
+        # Should be dict format from DataFrame
+        assert "step" in qc
+        assert "pruned_count" in qc
+        assert "metric" in qc
+        assert "ancestry" in qc
+        assert "level" in qc
+
+    def test_to_dict_gwas_format(self, sample_output: PipelineOutput) -> None:
+        """to_dict GWAS section has correct format."""
+        result = sample_output.to_dict()
+        gwas = result["GWAS"]
+
+        assert "value" in gwas
+        assert "metric" in gwas
+        assert "ancestry" in gwas
+
+    def test_to_json(self, sample_output: PipelineOutput) -> None:
+        """to_json produces valid JSON."""
+        json_str = sample_output.to_json()
+        parsed = json.loads(json_str)
+
+        assert "input_samples" in parsed
+        assert "ancestry_counts" in parsed
+
+    def test_to_json_with_indent(self, sample_output: PipelineOutput) -> None:
+        """to_json with indent produces formatted JSON."""
+        json_str = sample_output.to_json(indent=2)
+        # Indented JSON has newlines
+        assert "\n" in json_str
+
+    def test_save(self, sample_output: PipelineOutput, tmp_path: Path) -> None:
+        """save writes to file correctly."""
+        output_path = tmp_path / "output.json"
+        sample_output.save(output_path)
+
+        assert output_path.exists()
+
+        with open(output_path) as f:
+            loaded = json.load(f)
+
+        assert "input_samples" in loaded
+        assert "ancestry_counts" in loaded
+
+    def test_empty_output(self) -> None:
+        """Empty output converts correctly."""
+        output = PipelineOutput()
+        result = output.to_dict()
+
+        # Should not include empty sections
+        assert "input_samples" not in result
+        assert "ancestry_counts" not in result
+        assert "QC" not in result
+        assert "GWAS" not in result
+
+    def test_with_pruned_samples(self) -> None:
+        """Output with pruned samples includes them."""
+        output = PipelineOutput(
+            pruned_samples=pd.DataFrame({
+                "FID": ["FAM1", "FAM2"],
+                "IID": ["SAMP1", "SAMP2"],
+                "step": ["callrate", "het"],
+            }),
+        )
+        result = output.to_dict()
+
+        assert "pruned_samples" in result
+        pruned = result["pruned_samples"]
+        assert "FID" in pruned
+        assert "IID" in pruned
+        assert "step" in pruned
+
+    def test_with_related_samples(self) -> None:
+        """Output with related samples includes them."""
+        output = PipelineOutput(
+            related_samples=pd.DataFrame({
+                "ID1": ["SAMP1"],
+                "ID2": ["SAMP2"],
+                "KINSHIP": [0.25],
+            }),
+        )
+        result = output.to_dict()
+
+        assert "related_samples" in result
+
+    def test_empty_dataframe_not_included(self) -> None:
+        """Empty DataFrames are not included in output."""
+        output = PipelineOutput(
+            pruned_samples=pd.DataFrame(),  # Empty
+            related_samples=pd.DataFrame(),  # Empty
+        )
+        result = output.to_dict()
+
+        assert "pruned_samples" not in result
+        assert "related_samples" not in result
+
+
+class TestWriteResults:
+    """Tests for write_results function."""
+
+    def test_write_results(self, tmp_path: Path) -> None:
+        """write_results creates JSON file."""
+        output = PipelineOutput(
+            qc_metrics=[
+                QCMetrics(step="test", pruned_count=5, metric="count"),
+            ],
+        )
+        out_path = tmp_path / "results"
+        write_results(output, out_path)
+
+        json_path = tmp_path / "results.json"
+        assert json_path.exists()
+
+
+class TestBuildMetricsDataframe:
+    """Tests for build_metrics_dataframe function."""
+
+    def test_empty_list(self) -> None:
+        """Empty list returns empty DataFrame."""
+        df = build_metrics_dataframe([])
+        assert df.empty
+
+    def test_single_metric(self) -> None:
+        """Single metric creates correct DataFrame."""
+        metrics = [
+            QCMetrics(
+                step="callrate_prune",
+                pruned_count=10,
+                metric="outlier_count",
+                ancestry="EUR",
+                level="sample",
+                passed=True,
+            ),
+        ]
+        df = build_metrics_dataframe(metrics)
+
+        assert len(df) == 1
+        assert df.iloc[0]["step"] == "callrate_prune"
+        assert df.iloc[0]["pruned_count"] == 10
+        assert df.iloc[0]["ancestry"] == "EUR"
+
+    def test_multiple_metrics(self) -> None:
+        """Multiple metrics create correct DataFrame."""
+        metrics = [
+            QCMetrics(step="callrate", pruned_count=5, metric="count"),
+            QCMetrics(step="sex", pruned_count=3, metric="count"),
+            QCMetrics(step="het", pruned_count=2, metric="count"),
+        ]
+        df = build_metrics_dataframe(metrics)
+
+        assert len(df) == 3
+        assert list(df["step"]) == ["callrate", "sex", "het"]
+
+
+class TestBuildGwasDataframe:
+    """Tests for build_gwas_dataframe function."""
+
+    def test_empty_list(self) -> None:
+        """Empty list returns empty DataFrame."""
+        df = build_gwas_dataframe([])
+        assert df.empty
+
+    def test_single_metric(self) -> None:
+        """Single metric creates correct DataFrame."""
+        metrics = [
+            GWASMetrics(value=1.02, metric="lambda", ancestry="EUR"),
+        ]
+        df = build_gwas_dataframe(metrics)
+
+        assert len(df) == 1
+        assert df.iloc[0]["value"] == 1.02
+        assert df.iloc[0]["metric"] == "lambda"
+        assert df.iloc[0]["ancestry"] == "EUR"
+
+    def test_multiple_metrics(self) -> None:
+        """Multiple metrics create correct DataFrame."""
+        metrics = [
+            GWASMetrics(value=1.02, metric="lambda", ancestry="EUR"),
+            GWASMetrics(value=1.05, metric="lambda", ancestry="AFR"),
+        ]
+        df = build_gwas_dataframe(metrics)
+
+        assert len(df) == 2
+        assert list(df["ancestry"]) == ["EUR", "AFR"]

--- a/tests/unit/test_cli/test_parser.py
+++ b/tests/unit/test_cli/test_parser.py
@@ -1,0 +1,541 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for CLI argument parsing."""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from genotools.cli.parser import (
+    InputArgs,
+    SampleQCArgs,
+    VariantQCArgs,
+    AncestryArgs,
+    GWASArgs,
+    OutputArgs,
+    PipelineArgs,
+    create_parser,
+    parse_args,
+    _parse_sex_args,
+    _parse_het_args,
+    _parse_ld_args,
+)
+from genotools.ancestry.config import InferenceMode
+
+
+class TestInputArgs:
+    """Tests for InputArgs dataclass."""
+
+    def test_pfile_input(self) -> None:
+        """InputArgs accepts pfile input."""
+        args = InputArgs(pfile=Path("/data/test"))
+        assert args.geno_path == Path("/data/test")
+        assert args.input_format == "pfile"
+
+    def test_bfile_input(self) -> None:
+        """InputArgs accepts bfile input."""
+        args = InputArgs(bfile=Path("/data/test"))
+        assert args.geno_path == Path("/data/test")
+        assert args.input_format == "bfile"
+
+    def test_vcf_input(self) -> None:
+        """InputArgs accepts vcf input."""
+        args = InputArgs(vcf=Path("/data/test.vcf"))
+        assert args.geno_path == Path("/data/test")
+        assert args.input_format == "vcf"
+
+    def test_vcf_gz_input(self) -> None:
+        """InputArgs handles .vcf.gz input."""
+        args = InputArgs(vcf=Path("/data/test.vcf.gz"))
+        assert args.geno_path == Path("/data/test")
+
+    def test_no_input_raises(self) -> None:
+        """InputArgs raises without any input."""
+        with pytest.raises(ValueError, match="At least one input"):
+            InputArgs()
+
+    def test_pfile_takes_precedence(self) -> None:
+        """pfile takes precedence over bfile."""
+        args = InputArgs(pfile=Path("/data/pfile"), bfile=Path("/data/bfile"))
+        assert args.geno_path == Path("/data/pfile")
+        assert args.input_format == "pfile"
+
+
+class TestSampleQCArgs:
+    """Tests for SampleQCArgs dataclass."""
+
+    def test_default_values(self) -> None:
+        """SampleQCArgs has correct defaults."""
+        args = SampleQCArgs()
+        assert args.run_callrate is False
+        assert args.callrate_threshold == 0.02
+        assert args.run_sex is False
+        assert args.female_max_f == 0.25
+        assert args.male_min_f == 0.75
+        assert args.run_het is False
+        assert args.het_lower == -0.15
+        assert args.het_upper == 0.15
+        assert args.run_related is False
+        assert args.related_cutoff == 0.0884
+        assert args.duplicated_cutoff == 0.354
+
+    def test_to_callrate_config(self) -> None:
+        """to_callrate_config creates correct config."""
+        args = SampleQCArgs(callrate_threshold=0.05)
+        config = args.to_callrate_config()
+        assert config.mind == 0.05
+
+    def test_to_sex_config(self) -> None:
+        """to_sex_config creates correct config."""
+        args = SampleQCArgs(female_max_f=0.2, male_min_f=0.8)
+        config = args.to_sex_config()
+        assert config.female_max_f == 0.2
+        assert config.male_min_f == 0.8
+
+    def test_to_het_config(self) -> None:
+        """to_het_config creates correct config."""
+        args = SampleQCArgs(het_lower=-0.2, het_upper=0.2)
+        config = args.to_het_config()
+        assert config.f_lower == -0.2
+        assert config.f_upper == 0.2
+
+    def test_to_related_config(self) -> None:
+        """to_related_config creates correct config."""
+        args = SampleQCArgs(
+            related_cutoff=0.1,
+            duplicated_cutoff=0.4,
+            prune_related=True,
+            prune_duplicated=True,
+        )
+        config = args.to_related_config()
+        assert config.related_cutoff == 0.1
+        assert config.duplicated_cutoff == 0.4
+        assert config.prune_related is True
+        assert config.prune_duplicated is True
+
+
+class TestVariantQCArgs:
+    """Tests for VariantQCArgs dataclass."""
+
+    def test_default_values(self) -> None:
+        """VariantQCArgs has correct defaults."""
+        args = VariantQCArgs()
+        assert args.run_geno is False
+        assert args.geno_threshold == 0.05
+        assert args.run_case_control is False
+        assert args.run_haplotype is False
+        assert args.run_hwe is False
+        assert args.filter_controls is False
+        assert args.run_ld is False
+        assert args.ld_window_size == 50
+        assert args.ld_step_size == 5
+        assert args.ld_r2_threshold == 0.5
+
+    def test_to_geno_config(self) -> None:
+        """to_geno_config creates correct config."""
+        args = VariantQCArgs(geno_threshold=0.02)
+        config = args.to_geno_config()
+        assert config.geno == 0.02
+
+    def test_to_ld_config(self) -> None:
+        """to_ld_config creates correct config."""
+        args = VariantQCArgs(ld_window_size=100, ld_step_size=10, ld_r2_threshold=0.2)
+        config = args.to_ld_config()
+        assert config.window_size == 100
+        assert config.step_size == 10
+        assert config.r2_threshold == 0.2
+
+
+class TestAncestryArgs:
+    """Tests for AncestryArgs dataclass."""
+
+    def test_default_values(self) -> None:
+        """AncestryArgs has correct defaults."""
+        args = AncestryArgs()
+        assert args.run_ancestry is False
+        assert args.ref_panel is None
+        assert args.use_container is False
+        assert args.use_singularity is False
+        assert args.use_cloud is False
+        assert args.inference_mode == InferenceMode.LOCAL
+
+    def test_container_mode(self) -> None:
+        """Container mode is detected correctly."""
+        args = AncestryArgs(use_container=True)
+        assert args.inference_mode == InferenceMode.CONTAINER
+
+    def test_singularity_mode(self) -> None:
+        """Singularity mode is detected correctly."""
+        args = AncestryArgs(use_singularity=True)
+        assert args.inference_mode == InferenceMode.SINGULARITY
+
+    def test_cloud_mode(self) -> None:
+        """Cloud mode is detected correctly."""
+        args = AncestryArgs(use_cloud=True)
+        assert args.inference_mode == InferenceMode.CLOUD
+
+    def test_container_with_model_raises(self) -> None:
+        """Using container with model path raises error."""
+        with pytest.raises(ValueError, match="Cannot use both"):
+            AncestryArgs(use_container=True, model_path=Path("/path/to/model.pkl"))
+
+
+class TestGWASArgs:
+    """Tests for GWASArgs dataclass."""
+
+    def test_default_values(self) -> None:
+        """GWASArgs has correct defaults."""
+        args = GWASArgs()
+        assert args.run_pca is False
+        assert args.n_pcs == 10
+        assert args.build == "hg38"
+        assert args.run_gwas is False
+
+
+class TestOutputArgs:
+    """Tests for OutputArgs dataclass."""
+
+    def test_default_values(self) -> None:
+        """OutputArgs has correct defaults."""
+        args = OutputArgs()
+        assert args.full_output is False
+        assert args.skip_fails is False
+        assert args.warn_only is True
+
+
+class TestPipelineArgs:
+    """Tests for PipelineArgs dataclass."""
+
+    @pytest.fixture
+    def basic_args(self) -> PipelineArgs:
+        """Create basic pipeline args."""
+        return PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+        )
+
+    def test_geno_path_property(self, basic_args: PipelineArgs) -> None:
+        """geno_path property returns correct path."""
+        assert basic_args.geno_path == Path("/data/test")
+
+    def test_out_path_property(self, basic_args: PipelineArgs) -> None:
+        """out_path property returns correct path."""
+        assert basic_args.out_path == Path("/output/test")
+
+    def test_get_enabled_sample_steps(self) -> None:
+        """get_enabled_sample_steps returns enabled steps."""
+        args = PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+            sample_qc=SampleQCArgs(run_callrate=True, run_sex=True),
+        )
+        steps = args.get_enabled_sample_steps()
+        assert steps == ["callrate", "sex"]
+
+    def test_get_enabled_variant_steps(self) -> None:
+        """get_enabled_variant_steps returns enabled steps."""
+        args = PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+            variant_qc=VariantQCArgs(run_geno=True, run_hwe=True),
+        )
+        steps = args.get_enabled_variant_steps()
+        assert steps == ["hwe", "geno"]
+
+    def test_get_all_enabled_steps_with_assoc(self) -> None:
+        """get_all_enabled_steps includes assoc when PCA/GWAS enabled."""
+        args = PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+            gwas=GWASArgs(run_pca=True),
+        )
+        steps = args.get_all_enabled_steps()
+        assert "assoc" in steps
+
+    def test_has_any_qc_steps(self) -> None:
+        """has_any_qc_steps returns correct value."""
+        args_no_qc = PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+        )
+        assert args_no_qc.has_any_qc_steps() is False
+
+        args_with_qc = PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+            sample_qc=SampleQCArgs(run_callrate=True),
+        )
+        assert args_with_qc.has_any_qc_steps() is True
+
+    def test_to_legacy_dict(self, basic_args: PipelineArgs) -> None:
+        """to_legacy_dict produces correct format."""
+        legacy = basic_args.to_legacy_dict()
+        assert legacy["pfile"] == "/data/test"
+        assert legacy["out"] == "/output/test"
+        assert legacy["warn"] is True
+        assert legacy["callrate"] is None  # Not enabled
+        assert legacy["ancestry"] is False
+
+
+class TestParseSexArgs:
+    """Tests for _parse_sex_args helper."""
+
+    def test_none_input(self) -> None:
+        """None input returns disabled state."""
+        run, female, male = _parse_sex_args(None)
+        assert run is False
+        assert female == 0.25
+        assert male == 0.75
+
+    def test_empty_list(self) -> None:
+        """Empty list enables with defaults."""
+        run, female, male = _parse_sex_args([])
+        assert run is True
+        assert female == 0.25
+        assert male == 0.75
+
+    def test_two_values(self) -> None:
+        """Two values are parsed correctly."""
+        run, female, male = _parse_sex_args([0.2, 0.8])
+        assert run is True
+        assert female == 0.2
+        assert male == 0.8
+
+    def test_wrong_count_raises(self) -> None:
+        """Wrong value count raises error."""
+        with pytest.raises(ValueError, match="requires 0 or 2 values"):
+            _parse_sex_args([0.2])
+
+
+class TestParseHetArgs:
+    """Tests for _parse_het_args helper."""
+
+    def test_none_input(self) -> None:
+        """None input returns disabled state."""
+        run, lower, upper = _parse_het_args(None)
+        assert run is False
+        assert lower == -0.15
+        assert upper == 0.15
+
+    def test_empty_list(self) -> None:
+        """Empty list enables with defaults."""
+        run, lower, upper = _parse_het_args([])
+        assert run is True
+        assert lower == -0.15
+        assert upper == 0.15
+
+    def test_two_values(self) -> None:
+        """Two values are parsed correctly."""
+        run, lower, upper = _parse_het_args([-0.2, 0.2])
+        assert run is True
+        assert lower == -0.2
+        assert upper == 0.2
+
+
+class TestParseLdArgs:
+    """Tests for _parse_ld_args helper."""
+
+    def test_none_input(self) -> None:
+        """None input returns disabled state."""
+        run, window, step, r2 = _parse_ld_args(None)
+        assert run is False
+        assert window == 50
+        assert step == 5
+        assert r2 == 0.5
+
+    def test_empty_list(self) -> None:
+        """Empty list enables with defaults."""
+        run, window, step, r2 = _parse_ld_args([])
+        assert run is True
+        assert window == 50
+        assert step == 5
+        assert r2 == 0.5
+
+    def test_three_values(self) -> None:
+        """Three values are parsed correctly."""
+        run, window, step, r2 = _parse_ld_args([100.0, 10.0, 0.2])
+        assert run is True
+        assert window == 100
+        assert step == 10
+        assert r2 == 0.2
+
+    def test_wrong_count_raises(self) -> None:
+        """Wrong value count raises error."""
+        with pytest.raises(ValueError, match="requires 0 or 3 values"):
+            _parse_ld_args([50.0, 5.0])
+
+
+class TestCreateParser:
+    """Tests for create_parser function."""
+
+    def test_parser_created(self) -> None:
+        """Parser is created successfully."""
+        parser = create_parser()
+        assert parser.prog == "genotools"
+
+    def test_help_shows_groups(self) -> None:
+        """Parser has expected argument groups."""
+        parser = create_parser()
+        group_names = [g.title for g in parser._action_groups]
+        assert "Input files" in group_names
+        assert "Output configuration" in group_names
+        assert "Sample-level QC" in group_names
+        assert "Variant-level QC" in group_names
+        assert "Ancestry prediction" in group_names
+        assert "GWAS and PCA" in group_names
+
+
+class TestParseArgs:
+    """Tests for parse_args function."""
+
+    def test_minimal_args(self) -> None:
+        """Minimal args are parsed correctly."""
+        args = parse_args(["--pfile", "/data/test", "--out", "/output/test"])
+        assert args.geno_path == Path("/data/test")
+        assert args.out_path == Path("/output/test")
+
+    def test_no_input_raises(self) -> None:
+        """Missing input raises error."""
+        with pytest.raises(SystemExit):
+            parse_args(["--out", "/output/test"])
+
+    def test_callrate_flag_only(self) -> None:
+        """--callrate without value uses default."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--callrate",
+        ])
+        assert args.sample_qc.run_callrate is True
+        assert args.sample_qc.callrate_threshold == 0.02
+
+    def test_callrate_with_value(self) -> None:
+        """--callrate with value uses provided value."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--callrate", "0.05",
+        ])
+        assert args.sample_qc.run_callrate is True
+        assert args.sample_qc.callrate_threshold == 0.05
+
+    def test_all_sample_flag(self) -> None:
+        """--all-sample enables all sample QC."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--all-sample",
+        ])
+        assert args.sample_qc.run_callrate is True
+        assert args.sample_qc.run_sex is True
+        assert args.sample_qc.run_het is True
+        assert args.sample_qc.run_related is True
+        # all_sample uses different default
+        assert args.sample_qc.callrate_threshold == 0.05
+
+    def test_all_variant_flag(self) -> None:
+        """--all-variant enables variant QC (except LD)."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--all-variant",
+        ])
+        assert args.variant_qc.run_geno is True
+        assert args.variant_qc.run_case_control is True
+        assert args.variant_qc.run_haplotype is True
+        assert args.variant_qc.run_hwe is True
+        assert args.variant_qc.run_ld is False  # LD not included
+
+    def test_sex_with_values(self) -> None:
+        """--sex with values parses correctly."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--sex", "0.2", "0.8",
+        ])
+        assert args.sample_qc.run_sex is True
+        assert args.sample_qc.female_max_f == 0.2
+        assert args.sample_qc.male_min_f == 0.8
+
+    def test_ld_with_values(self) -> None:
+        """--ld with values parses correctly."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--ld", "100", "10", "0.2",
+        ])
+        assert args.variant_qc.run_ld is True
+        assert args.variant_qc.ld_window_size == 100
+        assert args.variant_qc.ld_step_size == 10
+        assert args.variant_qc.ld_r2_threshold == 0.2
+
+    def test_ancestry_flag(self) -> None:
+        """--ancestry enables ancestry prediction."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--ancestry",
+        ])
+        assert args.ancestry.run_ancestry is True
+
+    def test_container_flag(self) -> None:
+        """--container sets container mode."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--ancestry",
+            "--container",
+        ])
+        assert args.ancestry.use_container is True
+        assert args.ancestry.inference_mode == InferenceMode.CONTAINER
+
+    def test_warn_default(self) -> None:
+        """warn_only defaults to True."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+        ])
+        assert args.warn_only is True
+
+    def test_no_warn_flag(self) -> None:
+        """--no-warn disables warn mode."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--no-warn",
+        ])
+        assert args.warn_only is False
+
+    def test_pca_flag(self) -> None:
+        """--pca enables PCA with default components."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--pca",
+        ])
+        assert args.gwas.run_pca is True
+        assert args.gwas.n_pcs == 10
+
+    def test_pca_with_value(self) -> None:
+        """--pca with value sets custom components."""
+        args = parse_args([
+            "--pfile", "/data/test",
+            "--out", "/output/test",
+            "--pca", "20",
+        ])
+        assert args.gwas.run_pca is True
+        assert args.gwas.n_pcs == 20

--- a/tests/unit/test_cli/test_runner.py
+++ b/tests/unit/test_cli/test_runner.py
@@ -1,0 +1,283 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for CLI pipeline runner."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from genotools.cli.parser import (
+    InputArgs,
+    SampleQCArgs,
+    VariantQCArgs,
+    AncestryArgs,
+    OutputArgs,
+    PipelineArgs,
+)
+from genotools.cli.runner import (
+    StepResult,
+    PassFailRecord,
+    PipelineState,
+    PipelineRunner,
+)
+
+
+class TestStepResult:
+    """Tests for StepResult dataclass."""
+
+    def test_create_result(self) -> None:
+        """StepResult can be created."""
+        result = StepResult(
+            step="callrate_prune",
+            passed=True,
+            metrics={"outlier_count": 5},
+            output={"pruned_samples": "/path/to/file"},
+        )
+        assert result.step == "callrate_prune"
+        assert result.passed is True
+        assert result.metrics["outlier_count"] == 5
+
+    def test_from_legacy_dict(self) -> None:
+        """from_legacy_dict creates result correctly."""
+        legacy = {
+            "pass": True,
+            "step": "callrate_prune",
+            "metrics": {"outlier_count": 5},
+            "output": {"plink_out": "/path/to/out"},
+        }
+        result = StepResult.from_legacy_dict("callrate", legacy)
+
+        assert result.step == "callrate"
+        assert result.passed is True
+        assert result.metrics["outlier_count"] == 5
+
+    def test_from_legacy_dict_missing_fields(self) -> None:
+        """from_legacy_dict handles missing fields."""
+        legacy: Dict[str, Any] = {}
+        result = StepResult.from_legacy_dict("test", legacy)
+
+        assert result.step == "test"
+        assert result.passed is False
+        assert result.metrics == {}
+
+
+class TestPassFailRecord:
+    """Tests for PassFailRecord dataclass."""
+
+    def test_create_record(self) -> None:
+        """PassFailRecord can be created."""
+        record = PassFailRecord(
+            status=True,
+            input_path="/input",
+            output_path="/output",
+        )
+        assert record.status is True
+        assert record.input_path == "/input"
+        assert record.output_path == "/output"
+        assert record.error is None
+
+    def test_with_error(self) -> None:
+        """PassFailRecord can include error."""
+        record = PassFailRecord(
+            status=False,
+            input_path="/input",
+            output_path="/output",
+            error="Something went wrong",
+        )
+        assert record.status is False
+        assert record.error == "Something went wrong"
+
+
+class TestPipelineState:
+    """Tests for PipelineState dataclass."""
+
+    def test_create_state(self) -> None:
+        """PipelineState can be created."""
+        state = PipelineState(
+            geno_path=Path("/data/test"),
+            out_path=Path("/output/test"),
+        )
+        assert state.geno_path == Path("/data/test")
+        assert state.out_path == Path("/output/test")
+        assert state.tmp_dir is None
+        assert state.pass_fail == {}
+        assert state.step_results == {}
+
+    def test_get_last_passed_output_empty(self) -> None:
+        """get_last_passed_output returns None when empty."""
+        state = PipelineState(
+            geno_path=Path("/data/test"),
+            out_path=Path("/output/test"),
+        )
+        assert state.get_last_passed_output() is None
+
+    def test_get_last_passed_output(self) -> None:
+        """get_last_passed_output returns correct path."""
+        state = PipelineState(
+            geno_path=Path("/data/test"),
+            out_path=Path("/output/test"),
+        )
+        state.pass_fail["callrate"] = PassFailRecord(
+            status=True, input_path="/in1", output_path="/out1"
+        )
+        state.pass_fail["sex"] = PassFailRecord(
+            status=True, input_path="/out1", output_path="/out2"
+        )
+        state.pass_fail["het"] = PassFailRecord(
+            status=False, input_path="/out2", output_path="/out3"
+        )
+
+        assert state.get_last_passed_output() == "/out2"
+
+
+class TestPipelineRunner:
+    """Tests for PipelineRunner class."""
+
+    @pytest.fixture
+    def basic_args(self) -> PipelineArgs:
+        """Create basic pipeline args."""
+        return PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+        )
+
+    def test_init(self, basic_args: PipelineArgs) -> None:
+        """PipelineRunner initializes correctly."""
+        runner = PipelineRunner(basic_args)
+        assert runner.args == basic_args
+        assert runner.state is None
+
+    def test_step_categories(self) -> None:
+        """Step categories are defined correctly."""
+        assert "callrate" in PipelineRunner.SAMPLE_STEPS
+        assert "sex" in PipelineRunner.SAMPLE_STEPS
+        assert "het" in PipelineRunner.SAMPLE_STEPS
+        assert "related" in PipelineRunner.SAMPLE_STEPS
+        assert "kinship_check" in PipelineRunner.SAMPLE_STEPS
+
+        assert "geno" in PipelineRunner.VARIANT_STEPS
+        assert "case_control" in PipelineRunner.VARIANT_STEPS
+        assert "haplotype" in PipelineRunner.VARIANT_STEPS
+        assert "hwe" in PipelineRunner.VARIANT_STEPS
+        assert "ld" in PipelineRunner.VARIANT_STEPS
+
+    def test_compute_step_paths_first_step(self, basic_args: PipelineArgs) -> None:
+        """_compute_step_paths handles first step correctly."""
+        runner = PipelineRunner(basic_args)
+        runner.state = PipelineState(
+            geno_path=Path("/data/test"),
+            out_path=Path("/output/test"),
+        )
+
+        step_input, step_output = runner._compute_step_paths(
+            step="callrate",
+            step_index=0,
+            steps=["callrate", "sex"],
+            pass_fail={},
+            geno_path="/data/test",
+            out_path="/output/test",
+            working_out="/tmp/test",
+        )
+
+        assert step_input == "/data/test"
+        # Not last step, so gets step suffix
+        assert step_output == "/tmp/test_callrate"
+
+    def test_compute_step_paths_last_step(self, basic_args: PipelineArgs) -> None:
+        """_compute_step_paths handles last step correctly."""
+        basic_args.output.full_output = True
+        runner = PipelineRunner(basic_args)
+        runner.state = PipelineState(
+            geno_path=Path("/data/test"),
+            out_path=Path("/output/test"),
+        )
+
+        step_input, step_output = runner._compute_step_paths(
+            step="sex",
+            step_index=1,
+            steps=["callrate", "sex"],
+            pass_fail={
+                "callrate": PassFailRecord(
+                    status=True,
+                    input_path="/data/test",
+                    output_path="/output/test_callrate",
+                )
+            },
+            geno_path="/data/test",
+            out_path="/output/test",
+            working_out="/tmp/test",
+        )
+
+        # Last step outputs to final out_path
+        assert step_output == "/output/test"
+
+    def test_compute_step_paths_warn_mode(self) -> None:
+        """_compute_step_paths in warn mode finds last passed."""
+        args = PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test"), warn_only=True),
+        )
+        runner = PipelineRunner(args)
+        runner.state = PipelineState(
+            geno_path=Path("/data/test"),
+            out_path=Path("/output/test"),
+        )
+
+        pass_fail = {
+            "callrate": PassFailRecord(
+                status=True,
+                input_path="/data/test",
+                output_path="/tmp/test_callrate",
+            ),
+            "sex": PassFailRecord(
+                status=False,
+                input_path="/tmp/test_callrate",
+                output_path="/tmp/test_callrate_sex",
+            ),
+        }
+
+        step_input, step_output = runner._compute_step_paths(
+            step="het",
+            step_index=2,
+            steps=["callrate", "sex", "het"],
+            pass_fail=pass_fail,
+            geno_path="/data/test",
+            out_path="/output/test",
+            working_out="/tmp/test",
+        )
+
+        # Should use last passed output (callrate)
+        assert step_input == "/tmp/test_callrate"
+
+
+class TestPipelineRunnerValidation:
+    """Tests for PipelineRunner validation."""
+
+    def test_no_steps_no_ancestry_raises(self) -> None:
+        """Running with no steps and no ancestry raises error."""
+        args = PipelineArgs(
+            input=InputArgs(pfile=Path("/data/test")),
+            output=OutputArgs(out_path=Path("/output/test")),
+            # No QC steps enabled, no ancestry
+        )
+        runner = PipelineRunner(args)
+
+        # The run method would fail because there's nothing to do
+        # This tests the validation logic indirectly
+        steps = args.get_all_enabled_steps()
+        assert steps == []
+        assert args.ancestry.run_ancestry is False


### PR DESCRIPTION
## Summary

- Add new `genotools/cli/` module with typed argument parsing, pipeline orchestration, and result formatting
- Replace string-based boolean parsing (`--warn True/False`) with proper argparse flags (`--no-warn`)
- Implement `PipelineArgs` dataclass with `to_legacy_dict()` for backward compatibility during cutover
- Add 90 unit tests covering parser, runner, and output modules

## Test plan

- [x] Verify `pytest tests/unit/test_cli/` passes (90 tests)
- [x] Verify `mypy genotools/cli/ --ignore-missing-imports` passes
- [x] Confirm `parse_args()` returns typed `PipelineArgs` dataclass
- [x] Test `to_legacy_dict()` produces output compatible with existing pipeline code
- [x] Verify `--all-sample` and `--all-variant` convenience flags work correctly