### PR TITLE
fix: thread PCA n_pcs and external covariates into GWAS assoc step

### DIFF
--- a/REFACTOR_HARDENING.md
+++ b/REFACTOR_HARDENING.md
@@ -142,6 +142,36 @@ pytest tests/regression/test_parity.py -v             # old vs new
    CLIs across QC / full-pipeline / GWAS scenarios, prints a PASS/FAIL report and
    exits non-zero on divergence).
 
+### Round 3 (`refactor/hardening-round-3-gwas-args`)
+
+1. **GWAS arg threading fixed** — `cli/runner.py::_run_single_step` (assoc branch).
+   The assoc branch built `AssocConfig` threading only `build` and `maf_lambdas`.
+   It silently dropped three user-supplied GWAS args:
+   - `--pca N` (the requested PC count): `PCAConfig` was built without `n_pcs`,
+     so PCA **always ran the default 10 PCs** regardless of `--pca N`.
+   - `--covars` / `--covar-names`: never reached `AssocConfig.covariates`, so
+     external covariates were **silently ignored** and GWAS fell back to the PCA
+     eigenvectors as covariates.
+
+   Now threads `n_pcs` into `PCAConfig` and builds a `CovariateConfig` from the
+   covar path/names when given; `run_pca`/`run_gwas` normalized to bool to match
+   the dataclass field types. Added `CovariateConfig` to the runner's
+   config-class map. Regression tests
+   (`tests/unit/test_cli/test_runner_regression.py`): n_pcs + external covariates
+   reach `AssocConfig` (hermetic capture), `build` threading preserved, and an
+   end-to-end `--pca 3 → 3-PC eigenvec` via real PLINK2 (was 10).
+
+2. **Parity harness extended** — `tests/regression/test_parity.py`:
+   - `test_old_vs_new_pca_ncount_parity`: `--pca 20` yields a 20-PC eigenvec in
+     both CLIs (new previously always wrote 10).
+   - `test_old_vs_new_gwas_external_covars_parity`: with `--pca --gwas --covars
+     --covar-names`, both CLIs discard the PCA eigenvectors and use the external
+     covariate file, so **decision B does not apply** and per-variant p-values
+     agree tightly. Before the fix the new CLI ignored `--covars` and fell back to
+     PCA covariates (40500 p-mismatches, lambda 0.978 vs 1.007); now they match.
+   Both verified to fail against the pre-fix runner and pass after; they skip
+   cleanly without `.venv-stable`/plink2. Suite: 391 → 397 tests.
+
 ### ✅ Resolved (decision B): PCA region exclusion is an intentional fix
 
 The GWAS parity run surfaced a **real old-vs-new scientific difference** in PCA
@@ -197,8 +227,8 @@ Priority order for making the refactor mergeable to `main`:
    `ancestry.py` via an importlib file-path hack. Blocks legacy removal (Phase 5/6).
 7. **Retire dead abstractions** — `QCPipeline` (unused; runner reimplements
    orchestration), unused `ReferencePanel`/results, `container/run.py`.
-8. **GWAS arg parity** — confirm covariate/`n_pcs` args reach the assoc step
-   (`AssocConfig` build appears to thread only `build` + `maf_lambdas`).
+8. ✅ **GWAS arg parity** — DONE in round 3 (see above). `n_pcs`, `--covars`,
+   and `--covar-names` now reach the assoc step; parity harness guards both.
 9. **Tier 2 — parallelize per-ancestry groups** (perf): process pool over the
    `runner.py:337-354` loop; per-group log files; `--threads` cap. Cheap now that
    steps are pure functions.

--- a/TESTING.md
+++ b/TESTING.md
@@ -40,7 +40,7 @@ PLINK/PLINK2 are downloaded automatically the first time a step needs them
   parity, to the pre-refactor CLI. Tests that need something absent (PLINK, the
   `.venv-stable` baseline, golden files) **skip cleanly** rather than fail.
 
-Everything green today: **391 passed** with `.venv-stable` present.
+Everything green today: **397 passed** with `.venv-stable` present.
 
 ---
 
@@ -92,6 +92,8 @@ What it covers (all on `tests/data/synthetic/`):
 | `test_old_vs_new_multiword_qc_parity` | case_control / haplotype / ld | identical IDs **and** genotype content |
 | `test_old_vs_new_full_pipeline_parity` | all_sample + all_variant | identical IDs **and** genotype content |
 | `test_old_vs_new_gwas_parity` | pca + gwas | same tested-variant set + lambda within tolerance (see [decision B](#decision-b-gwaspca-region-exclusion)) |
+| `test_old_vs_new_pca_ncount_parity` | pca 20 | both CLIs write a 20-PC eigenvec (non-default PC count reaches PLINK2) |
+| `test_old_vs_new_gwas_external_covars_parity` | pca + gwas + covars | external covariates used identically; per-variant p-values agree (decision B N/A — PCA eigenvectors discarded for external covars) |
 
 Note the old CLI uses **underscore** flags (`--case_control`, `--full_output`,
 `--all_sample`) while the new CLI uses **hyphen** flags (`--case-control`,

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -209,7 +209,13 @@ class PipelineRunner:
         from ..core.genotypes import GenotypeData
 
         # Import GWAS module
-        from ..gwas import run_association as run_gwas_association, AssocConfig, PCAConfig, GWASConfig
+        from ..gwas import (
+            run_association as run_gwas_association,
+            AssocConfig,
+            PCAConfig,
+            GWASConfig,
+            CovariateConfig,
+        )
 
         # Import Ancestry module
         from ..ancestry import AncestryModel, ReferencePanel, AncestryConfig
@@ -246,6 +252,7 @@ class PipelineRunner:
             "AssocConfig": AssocConfig,
             "PCAConfig": PCAConfig,
             "GWASConfig": GWASConfig,
+            "CovariateConfig": CovariateConfig,
             "AncestryConfig": AncestryConfig,
         }
 
@@ -1050,15 +1057,30 @@ class PipelineRunner:
             return result.to_dict()
 
         elif step == "assoc":
+            # legacy_args["pca"] is the requested PC count (or None); it doubles as
+            # the run-PCA flag. Thread it into PCAConfig so a non-default --pca N is
+            # honored instead of silently defaulting to 10.
+            n_pcs = legacy_args.get("pca")
+            covar_path = legacy_args.get("covars")
+            covariates = (
+                self._config_classes["CovariateConfig"](
+                    covar_path=covar_path,
+                    covar_names=legacy_args.get("covar_names"),
+                )
+                if covar_path
+                else self._config_classes["CovariateConfig"]()
+            )
             config = self._config_classes["AssocConfig"](
                 pca=self._config_classes["PCAConfig"](
+                    n_pcs=n_pcs,
                     build=legacy_args.get("build", "hg38"),
-                ) if legacy_args.get("pca") else None,
+                ) if n_pcs else None,
                 gwas=self._config_classes["GWASConfig"](
                     maf_lambdas=legacy_args.get("maf_lambdas", False),
                 ) if legacy_args.get("gwas") else None,
-                run_pca=legacy_args.get("pca", False),
-                run_gwas=legacy_args.get("gwas", False),
+                covariates=covariates,
+                run_pca=bool(n_pcs),
+                run_gwas=bool(legacy_args.get("gwas", False)),
             )
             result = self._new_modules["run_gwas_association"](data, Path(step_output), config)
             return result.to_dict()

--- a/tests/regression/test_parity.py
+++ b/tests/regression/test_parity.py
@@ -34,12 +34,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from tests.regression.compare import (
     compare_pfiles,
     compare_genotypes,
+    compare_gwas,
     find_gwas_output,
     _lambda_gc,
     _resolve_plink2,
@@ -253,4 +255,137 @@ def test_old_vs_new_gwas_parity(
     assert abs(lambda_old - lambda_new) <= 0.05, (
         f"Genomic-inflation lambda differs beyond tolerance: "
         f"old={lambda_old:.5f}, new={lambda_new:.5f}"
+    )
+
+
+def _find_eigenvec(out_prefix: Path) -> Path | None:
+    """Locate a PLINK2 .eigenvec file for a run output prefix."""
+    out_prefix = Path(out_prefix)
+    matches = sorted(out_prefix.parent.glob(f"{out_prefix.name}*.eigenvec"))
+    return matches[0] if matches else None
+
+
+def _count_pc_columns(eigenvec_path: Path) -> int:
+    """Count the PC columns (PC1, PC2, ...) in a PLINK2 .eigenvec header."""
+    with open(eigenvec_path) as f:
+        header = f.readline().strip().split("\t")
+    return sum(1 for col in header if col.upper().startswith("PC"))
+
+
+def test_old_vs_new_pca_ncount_parity(
+    stable_venv_genotools,
+    test_geno_path: Path,
+    tmp_path: Path,
+) -> None:
+    """A non-default `--pca N` must produce an N-PC eigenvec in BOTH CLIs.
+
+    The new runner previously dropped the requested PC count and PLINK2 always
+    wrote the default 10 PCs; the old CLI honored it. This asserts they now
+    agree on the eigenvector dimensionality for a non-default count (20).
+    """
+    stable_bin, _ = _require_parity_env(stable_venv_genotools)
+
+    n_pcs = 20
+    old_out = tmp_path / "old"
+    new_out = tmp_path / "new"
+    old_res = _run(
+        [str(stable_bin), "--pfile", str(test_geno_path), "--out", str(old_out),
+         "--pca", str(n_pcs)]
+    )
+    new_res = _run(
+        [sys.executable, "-m", "genotools", "--pfile", str(test_geno_path),
+         "--out", str(new_out), "--pca", str(n_pcs)],
+        cwd=str(REPO_ROOT),
+    )
+
+    old_ev = _find_eigenvec(old_out)
+    new_ev = _find_eigenvec(new_out)
+    assert old_ev is not None, (
+        f"Old CLI produced no eigenvec.\nSTDOUT:\n{old_res.stdout}\nSTDERR:\n{old_res.stderr}"
+    )
+    assert new_ev is not None, (
+        f"New CLI produced no eigenvec.\nSTDOUT:\n{new_res.stdout}\nSTDERR:\n{new_res.stderr}"
+    )
+
+    old_n = _count_pc_columns(old_ev)
+    new_n = _count_pc_columns(new_ev)
+    assert old_n == n_pcs, f"Old CLI wrote {old_n} PCs, expected {n_pcs}"
+    assert new_n == n_pcs, f"New CLI wrote {new_n} PCs, expected {n_pcs} (was silently 10)"
+
+
+def _write_covariate_file(psam_path: Path, covar_path: Path) -> str:
+    """Write an external covariate file (#FID IID COV1 COV2) for a psam's samples.
+
+    Returns the comma-separated covariate names. Values are deterministic (fixed
+    seed) so the same file feeds both CLIs and the run is reproducible.
+    """
+    psam = pd.read_csv(psam_path, sep=r"\s+")
+    fid_col = "#FID" if "#FID" in psam.columns else "#IID"
+    rng = np.random.default_rng(42)
+    n = len(psam)
+    cov = pd.DataFrame({
+        "#FID": psam[fid_col].to_numpy(),
+        "IID": psam["IID"].to_numpy(),
+        "COV1": rng.normal(size=n),
+        "COV2": rng.normal(size=n),
+    })
+    cov.to_csv(covar_path, sep="\t", index=False)
+    return "COV1,COV2"
+
+
+def test_old_vs_new_gwas_external_covars_parity(
+    stable_venv_genotools,
+    test_geno_path: Path,
+    tmp_path: Path,
+) -> None:
+    """External `--covars`/`--covar-names` must reach GWAS identically in both CLIs.
+
+    The new runner previously dropped `--covars`/`--covar-names`, so GWAS fell
+    back to the PCA eigenvectors as covariates while the old CLI used the external
+    file -- different covariates, so p-values diverged. With `--pca --gwas
+    --covars`, BOTH CLIs discard the PCA eigenvectors and use the external file
+    (PLINK2's `--covar`), so decision B's PCA-region-exclusion divergence does NOT
+    apply here: the GWAS uses byte-identical `--glm` options and the same covariate
+    file, so per-variant p-values must agree tightly. This proves the external
+    covariates are actually used (and used identically) by the new CLI.
+    """
+    stable_bin, _ = _require_parity_env(stable_venv_genotools)
+
+    # Copy input into tmp: GWAS writes {input}.pheno next to the input.
+    geno = tmp_path / "input"
+    for ext in (".pgen", ".pvar", ".psam"):
+        shutil.copy2(test_geno_path.with_suffix(ext), geno.with_suffix(ext))
+
+    covar_file = tmp_path / "external.cov"
+    covar_names = _write_covariate_file(geno.with_suffix(".psam"), covar_file)
+
+    old_out = tmp_path / "old"
+    new_out = tmp_path / "new"
+    old_res = _run(
+        [str(stable_bin), "--pfile", str(geno), "--out", str(old_out),
+         "--pca", "10", "--gwas", "--covars", str(covar_file),
+         "--covar_names", covar_names]
+    )
+    new_res = _run(
+        [sys.executable, "-m", "genotools", "--pfile", str(geno), "--out", str(new_out),
+         "--pca", "10", "--gwas", "--covars", str(covar_file),
+         "--covar-names", covar_names],
+        cwd=str(REPO_ROOT),
+    )
+
+    old_glm = find_gwas_output(old_out)
+    new_glm = find_gwas_output(new_out)
+    assert old_glm is not None, (
+        f"Old CLI produced no GWAS output.\nSTDOUT:\n{old_res.stdout}\nSTDERR:\n{old_res.stderr}"
+    )
+    assert new_glm is not None, (
+        f"New CLI produced no GWAS output.\nSTDOUT:\n{new_res.stdout}\nSTDERR:\n{new_res.stderr}"
+    )
+
+    # External covars are used identically by both -> per-variant p-values agree.
+    result = compare_gwas(old_out, new_out, p_tolerance=1e-6, lambda_tolerance=1e-3)
+    assert result.equal, (
+        f"GWAS with external covariates diverged old-vs-new: {result.message}\n"
+        f"If the new CLI dropped --covars it would fall back to PCA covariates and "
+        f"diverge here. First mismatches: {result.mismatched_variants[:10]}"
     )

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -15,6 +15,7 @@
 
 """Regression tests for CLI runner bugs found in the refactor hardening audit."""
 
+import shutil
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -23,6 +24,16 @@ import pytest
 from genotools.core.exceptions import QCError
 from genotools.cli.parser import InputArgs, OutputArgs, PipelineArgs
 from genotools.cli.runner import PipelineRunner, PipelineState
+
+SYNTHETIC = (
+    Path(__file__).resolve().parents[2] / "data" / "synthetic" / "genotools_test"
+)
+
+
+def _plink2_available() -> bool:
+    if shutil.which("plink2"):
+        return True
+    return (Path.home() / ".genotools" / "misc" / "executables" / "plink2").exists()
 
 
 def _touch_pfiles(prefix: Path) -> None:
@@ -178,3 +189,134 @@ class TestWarnModeFinalStepFailurePromotesLastPassedOutput:
                 geno_path=str(geno),
                 out_path=str(out),
             )
+
+
+class _CapturingAssoc:
+    """Stand-in for run_association that records the AssocConfig it received."""
+
+    def __init__(self) -> None:
+        self.config: Any = None
+
+    def __call__(self, data: Any, out_path: Path, config: Any) -> Any:
+        self.config = config
+
+        class _Result:
+            def to_dict(self_inner) -> Dict[str, Any]:
+                return {"pass": True, "step": "assoc", "metrics": {}, "output": {}}
+
+        return _Result()
+
+
+def _gwas_legacy_args(**overrides: Any) -> Dict[str, Any]:
+    """Legacy args dict with the GWAS-relevant keys (mirrors to_legacy_dict)."""
+    base: Dict[str, Any] = {
+        "pca": None,
+        "build": "hg38",
+        "gwas": False,
+        "covars": None,
+        "covar_names": None,
+        "maf_lambdas": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestAssocStepThreadsPcaAndCovariateArgs:
+    """Regression: the assoc branch of _run_single_step threaded only `build` and
+    `maf_lambdas` into the config. It silently dropped the requested PC count
+    (`pca`), so PCA always ran the default 10 PCs, and dropped external covariates
+    (`covars`/`covar_names`), so `--covars` was ignored and GWAS fell back to PCA
+    covariates. These assert the args reach AssocConfig.
+    """
+
+    def test_n_pcs_reaches_pca_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner, geno, out = _make_runner(tmp_path, warn_only=True)
+        runner._initialize_modules()
+        capture = _CapturingAssoc()
+        monkeypatch.setitem(runner._new_modules, "run_gwas_association", capture)
+
+        runner._run_single_step(
+            "assoc", str(geno), f"{out}_assoc", _gwas_legacy_args(pca=3)
+        )
+
+        assert capture.config.run_pca is True
+        assert capture.config.pca is not None
+        assert capture.config.pca.n_pcs == 3  # was silently 10
+
+    def test_external_covariates_reach_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner, geno, out = _make_runner(tmp_path, warn_only=True)
+        runner._initialize_modules()
+        capture = _CapturingAssoc()
+        monkeypatch.setitem(runner._new_modules, "run_gwas_association", capture)
+
+        covar_file = tmp_path / "external.cov"
+        covar_file.write_text("#FID\tIID\tAGE\tSEX\n")
+
+        runner._run_single_step(
+            "assoc",
+            str(geno),
+            f"{out}_assoc",
+            _gwas_legacy_args(gwas=True, covars=str(covar_file), covar_names="AGE,SEX"),
+        )
+
+        assert capture.config.covariates.covar_path == str(covar_file)
+        assert capture.config.covariates.covar_names == "AGE,SEX"
+        assert capture.config.covariates.has_external_covariates() is True
+
+    def test_build_still_threaded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard the pre-existing `build` threading isn't lost in the fix."""
+        runner, geno, out = _make_runner(tmp_path, warn_only=True)
+        runner._initialize_modules()
+        capture = _CapturingAssoc()
+        monkeypatch.setitem(runner._new_modules, "run_gwas_association", capture)
+
+        runner._run_single_step(
+            "assoc", str(geno), f"{out}_assoc", _gwas_legacy_args(pca=10, build="hg19")
+        )
+
+        assert capture.config.pca.build == "hg19"
+
+
+def _count_pc_columns(eigenvec_path: Path) -> int:
+    """Count the PC columns (PC1, PC2, ...) in a PLINK2 .eigenvec header."""
+    with open(eigenvec_path) as f:
+        header = f.readline().strip().split("\t")
+    return sum(1 for col in header if col.upper().startswith("PC"))
+
+
+class TestAssocStepPcaProducesRequestedPcs:
+    """End-to-end regression: --pca 3 must produce a 3-PC eigenvec. Before the fix
+    the runner ignored the requested count and PLINK2 always wrote 10 PCs.
+    """
+
+    @pytest.mark.skipif(not _plink2_available(), reason="plink2 not available")
+    def test_pca_3_produces_3_pc_eigenvec(self, tmp_path: Path) -> None:
+        if not SYNTHETIC.with_suffix(".pgen").exists():
+            pytest.skip("synthetic test data not found")
+
+        local = tmp_path / "cohort"
+        for ext in (".pgen", ".pvar", ".psam"):
+            shutil.copy2(SYNTHETIC.with_suffix(ext), local.with_suffix(ext))
+
+        args = PipelineArgs(
+            input=InputArgs(pfile=local),
+            output=OutputArgs(out_path=tmp_path / "out", full_output=True),
+        )
+        runner = PipelineRunner(args)
+        runner._initialize_modules()
+
+        out_assoc = tmp_path / "out_assoc"
+        result = runner._run_single_step(
+            "assoc", str(local), str(out_assoc), _gwas_legacy_args(pca=3)
+        )
+
+        assert result is not None and result["pass"] is True
+        eigenvec = out_assoc.with_suffix(".eigenvec")
+        assert eigenvec.exists(), "PCA did not write an eigenvec file"
+        assert _count_pc_columns(eigenvec) == 3  # was 10


### PR DESCRIPTION
## Summary
- Fix `PipelineRunner._run_single_step` (assoc branch), which threaded only `build` and `maf_lambdas` into `AssocConfig` and silently dropped three user-supplied GWAS args:
  - `--pca N` (requested PC count): `PCAConfig` was built without `n_pcs`, so PCA **always ran the default 10 PCs** regardless of `--pca N`.
  - `--covars` / `--covar-names`: never reached `AssocConfig.covariates`, so external covariates were **silently ignored** and GWAS fell back to PCA eigenvectors as covariates.
- Now threads `n_pcs` into `PCAConfig` and builds a `CovariateConfig` from the covar path/names when given; normalizes `run_pca`/`run_gwas` to bool. Adds `CovariateConfig` to the runner's config-class map.
- Extends the old-vs-new parity harness to guard both args.
- Updates `REFACTOR_HARDENING.md` (item 8 done) and `TESTING.md`.

This directly affects real-cohort GWAS: before the fix, `--pca N` and external `--covars` were ignored by the new CLI.

## What changed
- `genotools/cli/runner.py` — assoc branch threads `n_pcs` + covariates; `CovariateConfig` added to config-class map.
- `tests/unit/test_cli/test_runner_regression.py` — new `TestAssocStepThreadsPcaAndCovariateArgs` (hermetic capture of the config passed to `run_association`: n_pcs + external covars reach `AssocConfig`, `build` preserved) and `TestAssocStepPcaProducesRequestedPcs` (end-to-end `--pca 3 → 3-PC eigenvec` via real PLINK2, was 10).
- `tests/regression/test_parity.py` — `test_old_vs_new_pca_ncount_parity` (`--pca 20` → 20-PC eigenvec in both CLIs) and `test_old_vs_new_gwas_external_covars_parity` (external covars used identically → p-values agree; decision B does not apply because the PCA eigenvectors are discarded for external covars).

## Test plan
- [x] Unit + regression suite green: **397 passed** (391 → 397) with `.venv-stable` present.
- [x] New unit tests fail RED against the pre-fix runner, pass after (n_pcs=10 vs 3; covar_path=None).
- [x] Both new parity tests verified to fail against the pre-fix runner (n_pcs 10 vs 20; 40500 p-mismatches + lambda 0.978 vs 1.007) and pass after.
- [x] Parity tests skip cleanly without `.venv-stable`/plink2.
- [ ] Real-cohort parity (separate gate, run by dev before `refactor/main` → `main`).

## Notes
- Targets `refactor/main`, not `main`.
- Decision B unaffected: the external-covars parity test intentionally exercises the path where PCA eigenvectors are discarded, so the ratified PCA region-exclusion divergence does not apply and per-variant p-values must match.