### PR TITLE
refactor(logging): pipeline visibility redesign (round 7)

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -12,9 +12,10 @@ before merging to `main`.
 Workflow: feature branch → PR to `refactor/main` → one final test on real data →
 PR to `main`. **Never commit to `main`.**
 
-> **▶ Start here (next session):** the next work item is **#0 — Logging /
-> pipeline-visibility redesign** in [Remaining work](#remaining-work-tracked-not-yet-done).
-> It has the full audit, the settled decision, and the still-open questions.
+> **▶ Start here (next session):** item #0 (logging/pipeline-visibility redesign)
+> is **DONE** (round 7, below). The next work item is **#1 — Prove parity on real
+> data** in [Remaining work](#remaining-work-tracked-not-yet-done): the gate before
+> merging to `main`.
 
 ---
 
@@ -32,7 +33,7 @@ Tier list is the "easy wins" audit against `origin/refactor/main`.
 | 1e — stop destroying input files | ✅ Done | Guarded deletes; `shutil.copy2` not `os.rename`. |
 | 2 — parallelize per-ancestry groups | ❌ Open | Still a serial loop (`cli/runner.py:337-354`). Pure-function design makes it cheap to add. |
 | 3 — cache ancestry PCA | 🟡 Partial | `--model` inference reuses fitted PCA; no `(ref_panel, common_snps)` auto-cache; `get_raw_files` still re-extracts. |
-| logging (structured) | ✅ Wired here | `_setup_logging()` now calls `core.logging.setup_logging(log_file={out}_all_logs.log)` after `upfront_check`; step `logger.info`/`error` (with `[step]` markers) land in the consolidated log. Test: `tests/regression/test_logging.py`. |
+| logging (structured) | ✅ Wired here | `_setup_logging()` now calls `core.logging.setup_logging(log_file={out}_all_logs.log)` after `upfront_check`; step `logger.info`/`error` (with `[step]` markers) land in the consolidated log. Test: `tests/regression/test_logging.py`. **Superseded by round 7** (full visibility redesign — see below). |
 | tests | ✅ / parity unverified | 343→346 unit tests pass; golden = new-vs-new (self-consistency), not old-vs-new. |
 | CI | ✅ Added here | `.github/workflows/ci.yml`: (1) unit+regression on Python 3.11 with PLINK/PLINK2 auto-downloaded; (2) parity job builds `.venv-stable` and runs `test_parity.py`. |
 
@@ -351,55 +352,74 @@ Implications for the harness:
   `tests/unit/test_gwas/test_steps_regression.py::TestPcaExcludesHighLdRegions`
   asserts PCA pruning removes every variant inside the exclusion ranges.
 
+### Round 7 (`refactor/logging-visibility-redesign`, item #0)
+
+Redesigned logging so **each pipeline step's behavior is clearly visible** — on
+the terminal during a run and on disk afterwards. Resolves item #0 (the 6.5/10
+audit: raw PLINK output dropped from disk, dead 0-byte `cleaned_logs.log`, three
+uncoordinated `print`/`logging`/`warnings.warn` channels). Design + plan:
+`docs/superpowers/specs/2026-07-23-logging-visibility-redesign-design.md`,
+`docs/superpowers/plans/2026-07-23-logging-visibility-redesign.md`. The two open
+questions were settled with the maintainer via a grill session (see the spec's
+"Settled decisions").
+
+**1 — `RunLog` consolidated writer (`core/logging.py`).** A single `RunLog` object
+owns `{out}_all_logs.log`: banner → one `===== step =====` section per step
+(structured `[step]` summary lines written live via a thin `_RunLogHandler`, then
+the verbatim harvested PLINK output for that step, flushed at section end) → an
+end-of-run summary table. `install_run_logging(out)` wires the handler + a concise
+step-tagged console stream and registers the run-scoped `raw_sink` ContextVar.
+
+**2 — Executor harvests PLINK's native `.log` (`core/executors.py`).**
+`run_command` now harvests `{--out}.log` (KING: `{--prefix}.log`) after **every**
+invocation into the `raw_sink` — so compound steps (GWAS/PCA, ancestry
+preprocessing) are fully captured, not just their last call. Best-effort (never
+breaks a run); a no-op when no sink is registered (library/unit callers).
+
+**3 — Per-step raw files + logs always persist.** Each step's raw PLINK output is
+also written to `{out}_{step}.log` (`{out}_{label}_{step}.log` under `--ancestry`),
+harvested out of the temp dir **before** cleanup, so logs survive even without
+`--full_output` (which now governs only intermediate pfiles). `cleaned_logs.log`
+is **deleted** (file + all references in `genotools/`; the deferred `utils.py`
+still references the legacy name).
+
+**4 — Channels unified + guard decoupled (`cli/runner.py`, `core/validation.py`).**
+`print()`/`warnings.warn` on the pipeline path are retired → routed through
+`logging` (curated console = concise `[step] message`, `!` prefix on WARN+; raw
+PLINK is file-only). The re-run guard moved out of `validate_input` into
+`guard_output_not_exists`, which runs **before** logging setup so `validate_input`
+(now pure) logs its data breakdown + skip decisions into the fresh consolidated
+log. `run()` reordered: guard → `_setup_logging` (build `RunLog`) → sectioned
+input-prep/QC/ancestry. End-of-run **summary table** to console + log.
+`logging.getLogger(__name__)` standardized to `get_logger(__name__)` across 13
+pipeline modules.
+
+**Verification:** full suite **437 passed** (unit + regression; +34 new: `RunLog`,
+`_harvest_raw_log`, guard/validation-logging, runner sectioning + summary, logging
+hygiene, and the rewritten `test_logging.py` asserting the sectioned/raw/summary
+contract); old-vs-new **parity 8/8** (logging changes don't touch genotype output);
+static gates clean (no `cleaned_logs`/`warnings.warn`/pipeline-path `print(` left in
+new code). Real end-to-end `--callrate --geno` and `--ancestry` runs on synthetic
+data produce the sectioned consolidated log, per-step raw files, summary table, and
+no `cleaned_logs.log`. **Follow-up (non-blocking):** the per-ancestry consolidated
+log is single-file/sectioned; item #9 parallelization will need per-group log files.
+
 ---
 
 ## Remaining work (tracked, not yet done)
 
 Priority order for making the refactor mergeable to `main`:
 
-0. **⭐ NEXT — Logging / pipeline-visibility redesign (do this before #1 and the
-   perf items).** Maintainer decision (2026-07-20): before adding features or
-   running the real-data parity push, redesign logging so each pipeline step's
-   behavior is clearly visible. The current logging **scored 6.5/10** in a
-   session audit — a well-built structured core (`core/logging.py`:
-   `ContextVar` step context + `StepContextFilter`, `step_context` used across
-   all 10 QC steps + GWAS steps; `all_logs.log` gets banner + structured
-   records) let down by an incomplete integration:
-   - **Raw PLINK output is dropped from disk.** `FilterResult.log` captures
-     `result.stderr` (exact variant/sample counts, PLINK warnings) but the runner
-     never persists it — it lives only in the in-memory result dict. The legacy
-     `concat_logs` used to aggregate every PLINK `.log`.
-   - **`cleaned_logs.log` is created 0-byte and never populated** (legacy filled
-     it via `process_log`); it's a misleading dead artifact.
-   - **Three uncoordinated user-facing channels** — `print()` (runner
-     "Running: step…", the `validate_input` data breakdown), `logging`
-     (structured), and `warnings.warn` (round-6 skip decisions). At runtime
-     `setup_logging(..., console=False)`, so the polished `[step]` structured
-     records **never reach the terminal**; the screen shows scattered prints +
-     warnings while the good stream is file-only.
-   - Minor: `logging.getLogger(__name__)` (steps) vs `get_logger(__name__)`
-     (executors) — two idioms.
+0. ✅ **Logging / pipeline-visibility redesign** — DONE in **round 7** (see above).
+   `RunLog` consolidated writer (banner → per-step sections with structured
+   summary + inlined raw PLINK → run summary table); executor harvests PLINK's
+   native `.log` for every invocation; per-step raw `{out}_{step}.log` files that
+   persist regardless of `--full_output`; `cleaned_logs.log` deleted; `print`/
+   `warnings.warn` unified into a curated console + file logging stream; re-run
+   guard decoupled so `validate_input` logs into the consolidated log.
+   `tests/regression/test_logging.py` rewritten to lock the new contract.
 
-   **Decision already taken this session:** raw PLINK output → **per-step raw
-   `.log` files** on disk **plus** the structured consolidated summary (keep both,
-   cleanly separated). **Still open:** `cleaned_logs.log` fate (remove as
-   redundant vs. populate a distilled view) and console-mirroring behavior — a
-   fresh brainstorm should resolve these.
-
-   **Design freedom / constraints:** the only log-format test is
-   `tests/regression/test_logging.py` (asserts `all_logs.log` exists, is >400
-   chars, contains `[callrate_prune]`/`[geno_prune]` markers + "filtering
-   complete"); the parity harness does **not** compare logs; there is no exact
-   legacy format to preserve. `concat_logs`/`process_log` live in the
-   deferred-for-deletion `utils.py`, so this pairs naturally with the eventual
-   `utils.py` removal. **This is its own round** (design not yet finalized):
-   settle the two open questions with the maintainer → write a short spec + a
-   test-first, task-by-task plan → implement with tests per task → review the
-   whole diff → PR into `refactor/main`. Also add/adjust
-   `tests/regression/test_logging.py` to lock the new behavior (per-step raw
-   `.log` files carry PLINK output; consolidated log still step-tagged).
-
-1. **Prove parity on real data** — run `test_parity.py` on representative real
+1. **⭐ NEXT — Prove parity on real data** — run `test_parity.py` on representative real
    cohorts (not just synthetic), across the full QC set and, ideally, ancestry +
    GWAS. This is the gate before merging to `main`. (Harness extended in round 2:
    multi-word QC steps, `--all_sample --all_variant`, and GWAS+lambda. Per

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -479,9 +479,14 @@ failure boundary end-to-end).
   (`--callrate 1.5`) fails *after* logging is installed, leaving a consolidated log
   that blocks the prefix on the corrected re-run. Validating configs during
   pre-flight would fail before any artifact exists.
-- `docs/cli_args.md` still documents the legacy flag spellings (`--full_output`,
-  `--warn`) instead of the new parser's (`--full-output`, `--no-warn`); the flags
-  added in round 7 are documented correctly.
+- ~~`docs/cli_args.md` documents legacy flag spellings~~ — **done**: rewritten
+  against `genotools/cli/parser.py`. All 42 flags documented and parse-checked
+  (`--cloud_model` never existed in the new parser; `--prune_duplicated` is now
+  `--no-prune-duplicated`; `--warn` is now the default with `--no-warn` to opt
+  out). Added the previously-undocumented `--amr-het`, `--min-samples`,
+  `--maf-lambdas`, `--all-variant`'s LD exclusion, the data-driven auto-skip
+  table, `--skip-fails`'s second effect (it also disables those auto-skips), and
+  `--all-sample`'s callrate threshold of 0.05 (vs 0.02 for a bare `--callrate`).
 
 ---
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -427,21 +427,61 @@ no `cleaned_logs.log`. After the part-5 polish pass the suite is **456 passed**
 summary-not-duplicated, step-path line file-only) and parity is still 8/8; a real
 3661-sample × 1.95M-variant run gives a console of only step lines + summary.
 
+**6 — Failure-boundary + artifact cleanup (second review pass).** Cleared the four
+blemishes the part-5 pass had only recorded:
+
+1. **One logging API, two honest entry points.** `setup_logging` and
+   `install_run_logging` now share `_reset_genotools_logger` (level coercion,
+   handler close+clear, `propagate=False`), and the docstrings state the split:
+   `install_run_logging` is the pipeline's (RunLog, sections, raw harvest, curated
+   console); `setup_logging` is for **library/embedded** callers driving the step
+   functions directly. Previously untested, it now has a functional test
+   (step-tagged records reach the file; no raw sink registered) plus one pinning
+   that either call replaces the other's handlers.
+2. **Clean CLI failures.** `cli/__init__.py::main` catches `GenoToolsError`,
+   `FileNotFoundError`, and config-validation `ValueError`/`TypeError` → a one-line
+   `ERROR: <message>` on stderr with exit 1 instead of a traceback; `--debug`
+   re-raises, so the traceback is one flag away. Other exception types are bugs and
+   keep their traceback. The runner's "No QC steps" raise became a
+   `ValidationError` (was a bare `ValueError`) so it routes through that path.
+   Writing the tests surfaced two cases beyond the guard: a missing `--pfile`
+   (`FileNotFoundError`) and an out-of-range value like `--callrate 1.5` (range
+   checks live in the step config, not the parser) both used to traceback. Also
+   fixed the guard's own message, which told users to rerun with `--skip_fails` —
+   a spelling argparse **rejects** (it is `--skip-fails`).
+3. **Re-runs no longer destroy the prior log.** `RunLog` rotates an existing
+   consolidated log to the next free `{path}.N` instead of truncating it, and
+   announces it (`! An existing log was found …; the previous run's log is
+   preserved as …`). Only reachable via `--skip-fails`, the one path that bypasses
+   the guard. On a pre-flight failure `_teardown_logging` calls
+   `restore_rotated()`, so a failed re-run leaves the directory exactly as it found
+   it. Per-step raw files are still overwritten — their content is a subset of the
+   rotated consolidated log.
+4. **No stray tool logs.** `_harvest_raw_log` removes each `{prefix}.log` after
+   harvesting it (mirroring what `GenotypeData.to_pfile` already did, and what
+   legacy `concat_logs` did to the files it consumed), so `{out}.log`,
+   `{out}_{label}.log`, and the ancestry-preprocessing strays no longer sit beside
+   the real outputs duplicating `{out}_{step}.log`. Skipped when no sink is
+   registered, so library callers keep their tool logs. This made the 8 step error
+   messages that named a now-deleted `{tmp}.log`/`{out}.log` wrong, so they were
+   replaced with a shared `RAW_LOG_HINT` constant pointing at the consolidated +
+   per-step logs (several were **already** wrong pre-round-7, naming temp files the
+   cleanup had deleted).
+
+Suite **456 → 475 passed** (+19: rotation/restore, library-path `setup_logging`,
+harvest removal, and a new `tests/regression/test_cli_errors.py` covering the
+failure boundary end-to-end).
+
 **Follow-ups (non-blocking):**
 - The per-ancestry consolidated log is single-file/sectioned; item #9
   parallelization will need per-group log files.
-- `core.logging.setup_logging()` is now a second, unused logging entry point
-  (exported from `core/__init__`, referenced only by tests) that no longer
-  describes how the pipeline logs — collapse it into `install_run_logging` or
-  mark it library-only.
-- Uncaught `GenoToolsError`s still reach the user as raw tracebacks: `cli/__init__.py::main`
-  has no `try/except`, so e.g. the re-run guard prints 15 lines of stack for what
-  should be a one-line message (exit code is correct).
-- A re-run with `--skip_fails` **truncates** the prior consolidated log
-  (`RunLog` opens `"w"`; legacy appended) — silent log loss on the one path that
-  bypasses the guard.
-- PLINK's native `{out}.log` from the final step is left beside the per-step logs,
-  duplicating `{out}_{last_step}.log`.
+- Step configs are constructed inside the step loop, so an out-of-range value
+  (`--callrate 1.5`) fails *after* logging is installed, leaving a consolidated log
+  that blocks the prefix on the corrected re-run. Validating configs during
+  pre-flight would fail before any artifact exists.
+- `docs/cli_args.md` still documents the legacy flag spellings (`--full_output`,
+  `--warn`) instead of the new parser's (`--full-output`, `--no-warn`); the flags
+  added in round 7 are documented correctly.
 
 ---
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -394,6 +394,27 @@ input-prep/QC/ancestry. End-of-run **summary table** to console + log.
 `logging.getLogger(__name__)` standardized to `get_logger(__name__)` across 13
 pipeline modules.
 
+**5 — Console/verbosity polish (review pass).** Three blemishes found by re-reading
+the round-7 output on a real cohort:
+- The summary was written **twice** to the consolidated log (`logger.info` rows
+  landed at the tail of the last step's section, then `write_summary`'s table).
+- The `Running: {step} with input … and output: …` line put two absolute temp-dir
+  paths on the console — the longest and least useful line there.
+- Level/console were hardcoded (`"INFO"`, `console=True`): no way to quiet a
+  cluster job or widen output when debugging.
+
+Fixed with two `extra` routing markers on the `genotools` logger — `file_only`
+(dropped by a new `_ConsoleFilter` on the console handler) and `console_only`
+(dropped by `_RunLogHandler`) — so a record can target one destination without a
+second logging path. The step-path line is now `file_only` (full paths preserved
+in the log); the summary rows are `console_only` (the file keeps only the aligned
+table); a per-group `Ancestry group {label}: running N QC step(s)` console line
+replaces what the file-only line used to convey under `--ancestry`. New
+`--quiet` (drop the console stream; **all log files still written**) and
+`--debug` (DEBUG level on both streams) thread through `OutputArgs` into
+`install_run_logging`'s existing `level`/`console` params. Documented in
+`docs/cli_args.md`.
+
 **Verification:** full suite **437 passed** (unit + regression; +34 new: `RunLog`,
 `_harvest_raw_log`, guard/validation-logging, runner sectioning + summary, logging
 hygiene, and the rewritten `test_logging.py` asserting the sectioned/raw/summary
@@ -401,8 +422,26 @@ contract); old-vs-new **parity 8/8** (logging changes don't touch genotype outpu
 static gates clean (no `cleaned_logs`/`warnings.warn`/pipeline-path `print(` left in
 new code). Real end-to-end `--callrate --geno` and `--ancestry` runs on synthetic
 data produce the sectioned consolidated log, per-step raw files, summary table, and
-no `cleaned_logs.log`. **Follow-up (non-blocking):** the per-ancestry consolidated
-log is single-file/sectioned; item #9 parallelization will need per-group log files.
+no `cleaned_logs.log`. After the part-5 polish pass the suite is **456 passed**
+(+9: console/file record routing, `--quiet`/`--debug` parsing + behavior,
+summary-not-duplicated, step-path line file-only) and parity is still 8/8; a real
+3661-sample × 1.95M-variant run gives a console of only step lines + summary.
+
+**Follow-ups (non-blocking):**
+- The per-ancestry consolidated log is single-file/sectioned; item #9
+  parallelization will need per-group log files.
+- `core.logging.setup_logging()` is now a second, unused logging entry point
+  (exported from `core/__init__`, referenced only by tests) that no longer
+  describes how the pipeline logs — collapse it into `install_run_logging` or
+  mark it library-only.
+- Uncaught `GenoToolsError`s still reach the user as raw tracebacks: `cli/__init__.py::main`
+  has no `try/except`, so e.g. the re-run guard prints 15 lines of stack for what
+  should be a one-line message (exit code is correct).
+- A re-run with `--skip_fails` **truncates** the prior consolidated log
+  (`RunLog` opens `"w"`; legacy appended) — silent log loss on the one path that
+  bypasses the guard.
+- PLINK's native `{out}.log` from the final step is left beside the per-step logs,
+  duplicating `{out}_{last_step}.log`.
 
 ---
 

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -1,227 +1,340 @@
 # GenoTools Command Line Arguments Documentation
 
 ## Overview
-This documentation provides detailed descriptions of the command-line arguments for the `GenoTools` package, a comprehensive tool for genetic data analysis. These arguments enable users to specify various inputs, outputs, and settings for processes like quality control (QC), ancestry analysis, and genome-wide association studies (GWAS).
+
+Detailed reference for the `genotools` command-line arguments, covering input,
+output, quality control (QC), ancestry prediction, and GWAS.
+
+Flags use **hyphens**, not underscores (`--full-output`, not `--full_output`).
+`genotools --help` is the authoritative list; this document covers the same flags
+in more detail and is kept in sync with `genotools/cli/parser.py`.
+
+**Threshold flags are optional-argument flags.** `--callrate`, `--geno`,
+`--case-control`, `--haplotype`, `--hwe`, and `--pca` each run their step with a
+default when passed bare, and accept a value to override it: `--callrate` uses
+0.02, `--callrate 0.05` uses 0.05. Omitting the flag entirely skips the step.
 
 ---
 
 ### File I/O Arguments
 
+Exactly one input format is required. If more than one is given, `--pfile` wins
+over `--bfile`, which wins over `--vcf`.
+
 - **`--bfile`**
-  - *Type*: `str`
+  - *Type*: `path`
   - *Default*: `None`
-  - *Description*: Path to PLINK 1.9 format genotype file (before the *.bed/bim/fam). Used for specifying genotype data input.
+  - *Description*: PLINK 1.9 format genotype file path, without the
+    `.bed`/`.bim`/`.fam` extension. Converted to PLINK 2 pfiles at pipeline start.
 
 - **`--pfile`**
-  - *Type*: `str`
+  - *Type*: `path`
   - *Default*: `None`
-  - *Description*: Path to PLINK 2 format genotype file (before the *.pgen/pvar/psam). Another format for genotype data input.
+  - *Description*: PLINK 2 format genotype file path, without the
+    `.pgen`/`.pvar`/`.psam` extension. The pipeline's native format.
 
 - **`--vcf`**
-  - *Type*: `str`
+  - *Type*: `path`
   - *Default*: `None`
-  - *Description*: Path to VCF format genotype file. An alternative format for genotype data input.
+  - *Description*: VCF format genotype file path (`.vcf` or `.vcf.gz`). Converted
+    to PLINK 2 pfiles at pipeline start.
 
 - **`--out`** *(required)*
-  - *Type*: `str`
+  - *Type*: `path`
   - *Default*: `None`
   - *Description*: Prefix for output files, including the path.
 
-- **`--full_output`**
-  - *Type*: `str`
-  - *Default*: `True`
-  - *Description*: If set to true, outputs all results. Otherwise, outputs a subset.
+---
 
-- **`--skip_fails`**
-  - *Type*: `str`
-  - *Default*: `False`
-  - *Description*: If true, skips checks for input file errors.
+### Output and Logging Arguments
 
-- **`--warn`**
-  - *Type*: `str`
+- **`--full-output`**
+  - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: If true, provides warnings on errors but continues the pipeline.
+  - *Description*: Keep every intermediate pfile instead of only the final
+    output. Does **not** affect logs — the consolidated and per-step logs are
+    always written.
+
+- **`--skip-fails`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Bypass the up-front checks. Two effects: (1) re-running over an
+    already-used output prefix is allowed — the previous run's consolidated log is
+    rotated to `{out}_all_logs.log.N` rather than overwritten (per-step logs are
+    replaced); and (2) the data-driven step auto-skips described below are
+    **disabled**, so a step runs even when the input can't support it.
+
+- **`--no-warn`**
+  - *Type*: `flag`
+  - *Default*: `False` (warn-and-continue is the default behavior)
+  - *Description*: Stop the pipeline at the first failing step. Without this
+    flag, a failing step is recorded as failed and the pipeline continues from
+    the last step that passed.
 
 - **`--quiet`**
   - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: Suppresses the console progress stream. The log files are still
+  - *Description*: Suppress the console progress stream. Log files are still
     written in full: the consolidated `{out}_all_logs.log` and the per-step
     `{out}_{step}.log` raw PLINK logs. Useful for batch/cluster jobs.
 
 - **`--debug`**
   - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: Logs at `DEBUG` level instead of `INFO`, on both the console
-    and the consolidated log, and re-raises errors so the full Python traceback
-    is shown (without it, expected failures print a one-line `ERROR:` message).
+  - *Description*: Log at `DEBUG` level instead of `INFO`, on both the console
+    and the consolidated log, and re-raise errors so the full Python traceback is
+    shown (without it, expected failures print a one-line `ERROR:` message).
     Combine with `--quiet` for verbose file-only logs.
+
+---
+
+### Data-Driven Step Auto-Skips
+
+A requested step is **skipped automatically** when the input can't support it.
+`--skip-fails` disables these checks, forcing the step to run anyway.
+
+| Step | Skipped when |
+|------|--------------|
+| `--sex` | No sample sex data (no males and no females recorded), or no X chromosome in the input |
+| `--het` | The input has fewer than 50 variants |
+| `--case-control` | Cases or controls are missing (both are required) |
+| `--filter-controls` | No controls present — the HWE filter runs on everyone instead |
+
+Each skip is logged as a `!` warning on the console and recorded in the
+consolidated run log.
+
+---
+
+### Sample-Level QC Arguments
+
+- **`--callrate [THRESHOLD]`**
+  - *Type*: `float`
+  - *Default*: `0.02` when the flag is passed bare; step skipped if omitted
+  - *Description*: Maximum per-sample missingness (PLINK `--mind`). Samples above
+    the threshold are pruned.
+
+- **`--sex [FEMALE_MAX_F MALE_MIN_F]`**
+  - *Type*: `float` (zero or two values)
+  - *Default*: `0.25 0.75` when the flag is passed bare; step skipped if omitted
+  - *Description*: Sex-check F-statistic cutoffs. Samples whose genetic sex is
+    discordant with the recorded sex are pruned. Requires 0 or exactly 2 values.
+    Subject to auto-skip (see above).
+
+- **`--het [LOWER UPPER]`**
+  - *Type*: `float` (zero or two values)
+  - *Default*: `-0.15 0.15` when the flag is passed bare; step skipped if omitted
+  - *Description*: Heterozygosity rate (F coefficient) bounds. Samples outside
+    the range are pruned. Requires 0 or exactly 2 values. Subject to auto-skip
+    (see above).
+
+- **`--amr-het`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Use auto-detected heterozygosity bounds for the AMR ancestry
+    group instead of the fixed `--het` values. Only meaningful with `--ancestry`.
+
+- **`--related`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Run relatedness analysis (KING). By default it reports and
+    prunes duplicates but retains related samples — see `--prune-related` and
+    `--no-prune-duplicated`.
+
+- **`--related-cutoff`**
+  - *Type*: `float`
+  - *Default*: `0.0884`
+  - *Description*: Kinship coefficient above which a pair counts as related.
+
+- **`--duplicated-cutoff`**
+  - *Type*: `float`
+  - *Default*: `0.354`
+  - *Description*: Kinship coefficient above which a pair counts as duplicated.
+
+- **`--prune-related`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Also prune related (not just duplicated) samples.
+
+- **`--no-prune-duplicated`**
+  - *Type*: `flag`
+  - *Default*: `False` (duplicates are pruned by default)
+  - *Description*: Report duplicated samples without pruning them.
+
+- **`--kinship-check`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Confirm reported family relationships against genotype-derived
+    kinship. **Linux only** (requires KING).
+
+- **`--all-sample`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Run callrate, sex, het, and related with default thresholds.
+    Note that the callrate threshold under this flag is **0.05**, not the 0.02
+    used by a bare `--callrate`. Does not include `--kinship-check`.
+
+---
+
+### Variant-Level QC Arguments
+
+- **`--geno [THRESHOLD]`**
+  - *Type*: `float`
+  - *Default*: `0.05` when the flag is passed bare; step skipped if omitted
+  - *Description*: Maximum per-variant missingness. Variants above the threshold
+    are pruned.
+
+- **`--case-control [P_THRESHOLD]`**
+  - *Type*: `float`
+  - *Default*: `1e-4` when the flag is passed bare; step skipped if omitted
+  - *Description*: P-value threshold for the case/control missingness
+    differential test. Subject to auto-skip (see above).
+
+- **`--haplotype [P_THRESHOLD]`**
+  - *Type*: `float`
+  - *Default*: `1e-4` when the flag is passed bare; step skipped if omitted
+  - *Description*: P-value threshold for the missingness-by-haplotype test.
+
+- **`--hwe [P_THRESHOLD]`**
+  - *Type*: `float`
+  - *Default*: `1e-4` when the flag is passed bare; step skipped if omitted
+  - *Description*: Hardy-Weinberg equilibrium p-value threshold.
+
+- **`--filter-controls`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Apply the HWE filter using controls only. Subject to
+    auto-disable (see above).
+
+- **`--ld [WINDOW_SIZE STEP_SIZE R2_THRESHOLD]`**
+  - *Type*: `float` (zero or three values)
+  - *Default*: `50 5 0.5` when the flag is passed bare; step skipped if omitted
+  - *Description*: Linkage-disequilibrium pruning parameters. Requires 0 or
+    exactly 3 values.
+
+- **`--all-variant`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Run every variant-level QC step with default thresholds
+    (geno, case-control, haplotype, hwe) — **excluding** LD pruning, which must
+    be requested explicitly with `--ld`.
 
 ---
 
 ### Ancestry Arguments
 
 - **`--ancestry`**
-  - *Type*: `str`
+  - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: Splits the analysis by ancestry if set to true.
+  - *Description*: Run ancestry prediction and split the cohort by predicted
+    ancestry, then run the requested QC steps once per ancestry group. Requires
+    either `--ref-panel` + `--ref-labels` (train a new model) or `--model` (use a
+    pre-trained one).
 
-- **`--ref_panel`**
-  - *Type*: `str`
+- **`--ref-panel`**
+  - *Type*: `path`
   - *Default*: `None`
-  - *Description*: Path to the PLINK format reference genotype file for ancestry analysis.
+  - *Description*: Reference panel genotype file path (PLINK format, without
+    extension), used to train the ancestry model.
 
-- **`--ref_labels`**
-  - *Type*: `str`
+- **`--ref-labels`**
+  - *Type*: `path`
   - *Default*: `None`
-  - *Description*: File with tab-separated PLINK-style IDs and ancestry labels, without a header.
+  - *Description*: Reference panel ancestry labels file: tab-separated
+    `FID IID label`, no header.
 
 - **`--model`**
-  - *Type*: `str`
+  - *Type*: `path`
   - *Default*: `None`
-  - *Description*: Path to the pickle file with a trained ancestry model.
+  - *Description*: Pre-trained ancestry model directory (or a legacy `.pkl`
+    file). Runs inference instead of training.
 
 - **`--container`**
-  - *Type*: `str`
+  - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: Enables running predictions in a container.
+  - *Description*: Run ancestry prediction inside a Docker container. Mutually
+    exclusive with `--model`.
 
 - **`--singularity`**
-  - *Type*: `str`
+  - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: If true, runs containerized predictions using Singularity.
+  - *Description*: Run ancestry prediction inside a Singularity container.
 
 - **`--cloud`**
-  - *Type*: `str`
+  - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: Enables running predictions in Google Cloud.
+  - *Description*: Run ancestry prediction on Google Cloud AI Platform.
 
-- **`--cloud_model`**
-  - *Type*: `str`
-  - *Default*: `NeuroBooster`
-  - *Description*: Specifies the model for Google Cloud predictions.
+- **`--subset-ancestry [LABEL ...]`**
+  - *Type*: `str` (zero or more labels)
+  - *Default*: `None` (all predicted groups)
+  - *Description*: Restrict downstream QC to the named ancestry labels, e.g.
+    `--subset-ancestry EUR AFR`.
 
-- **`--subset_ancestry`**
-  - *Type*: `None`
-  - *Description*: Subsets the analysis for specified ancestries.
-
----
-
-### Sample-Level QC Arguments
-
-- **`--callrate`**
-  - *Type*: `float`
-  - *Default*: 0.02
-  - *Description*: Minimum call rate threshold for sample-level QC.
-
-- **`--sex`**
-  - *Type*: `None`
-  - *Description*: Specifies sex prune cutoffs.
-
-- **`--related`**
-  - *Type*: `str`
-  - *Default*: `False`
-  - *Description*: Enables relatedness pruning if set to true.
-
-- **`--related_cutoff`**
-  - *Type*: `float`
-  - *Default*: `0.0884`
-  - *Description*: Cutoff for relatedness pruning.
-
-- **`--duplicated_cutoff`**
-  - *Type*: `float`
-  - *Default*: `0.354`
-  - *Description*: Cutoff for duplicated samples pruning.
-
-- **`--prune_related`**
-  - *Type*: `str`
-  - *Default*: `False`
-  - *Description*: If true, prunes related samples.
-
-- **`--prune_duplicated`**
-  - *Type*: `str`
-  - *Default*: `True`
-  - *Description*: If true, prunes duplicated samples.
-
-- **`--kinship_check`**
-  - *Description*: No arguments.
-
-- **`--het`**
-  - *Type*: `None`
-  - *Description*: Specifies heterozygosity prune cutoffs.
-
-- **`--all_sample`**
-  - *Type*: `str`
-  - *Default*: `False`
-  - *Description*: If true, runs all sample-level QC.
-
----
-
-### Variant-Level QC Arguments
-
-- **`--geno`**
-  - *Type*: `float`
-  - *Default*: `None`
-  - *Description*: Minimum missingness threshold for variant-level QC.
-
-- **`--case_control`**
-  - *Type*: `float`
-  - *Default*: `None`
-  - *Description*: Threshold for case-control prune.
-
-- **`--haplotype`**
-  - *Type*: `float`
-  - *Default*: `None`
-  - *Description*: Threshold for haplotype prune.
-
-- **`--hwe`**
-  - *Type*: `float`
-  - *Default*: `None`
-  - *Description*: Threshold for Hardy-Weinberg Equilibrium pruning.
-
-- **`--filter_controls`**
-  - *Type*: `str`
-  - *Default*: `False`
-  - *Description*: If true, filters controls during HWE pruning.
-
-- **`--ld`**
-  - *Type*: `None`
-  - *Description*: Specifies parameters for linkage disequilibrium pruning.
-
-- **`--all_variant`**
-  - *Type*: `str`
-  - *Default*: `False`
-  - *Description*: If true, runs all variant-level QC.
+- **`--min-samples`**
+  - *Type*: `int`
+  - *Default*: `0`
+  - *Description*: Minimum samples an ancestry group needs to be carried
+    forward. Groups below the threshold get no split pfiles at all; their samples
+    are recorded in the pruned-samples output with the step
+    `insufficient_ancestry_sample_n`.
 
 ---
 
 ### GWAS and PCA Arguments
 
-- **`--pca`**
+- **`--pca [N_PCS]`**
   - *Type*: `int`
-  - *Default*: `None`
-  - *Description*: Number of principal components for PCA analysis.
+  - *Default*: `10` when the flag is passed bare; PCA skipped if omitted
+  - *Description*: Run PCA with N principal components. High-LD and MHC regions
+    are excluded before pruning.
 
 - **`--build`**
-  - *Type*: `str`
+  - *Type*: `str` (`hg19` or `hg38`)
   - *Default*: `hg38`
-  - *Description*: Genome build used for PCA.
+  - *Description*: Genome build, which selects the PCA exclusion-region file.
 
 - **`--gwas`**
-  - *Type*: `str`
+  - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: Enables running GWAS if set to true.
+  - *Description*: Run the association test. Uses the PCA eigenvectors as
+    covariates unless `--covars` is given.
 
 - **`--covars`**
-  - *Type*: `str`
+  - *Type*: `path`
   - *Default*: `None`
-  - *Description*: Path to external covariates file.
+  - *Description*: External covariates file. When supplied, it replaces the PCA
+    eigenvectors as the covariate set.
 
-- **`--covar_names`**
+- **`--covar-names`**
   - *Type*: `str`
   - *Default*: `None`
-  - *Description*: Names of covariates to use from the external file.
+  - *Description*: Comma-separated covariate column names to use from the
+    external covariates file.
+
+- **`--maf-lambdas`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Apply a MAF prune before computing genomic-inflation lambdas.
 
 ---
 
-This documentation provides a comprehensive overview of the available command-line arguments for `GenoTools`. It is designed to assist users in effectively utilizing the tool for their genetic data analysis needs.
+### Examples
+
+```bash
+# All sample-level QC with defaults
+genotools --pfile data/mydata --out results/output --all-sample
+
+# Ancestry prediction only
+genotools --pfile data/mydata --out results/output --ancestry \
+          --ref-panel refs/panel --ref-labels refs/labels.txt
+
+# Full pipeline, split by ancestry
+genotools --pfile data/mydata --out results/output --ancestry \
+          --ref-panel refs/panel --ref-labels refs/labels.txt \
+          --all-sample --all-variant
+
+# Custom thresholds, PCA + GWAS, quiet console
+genotools --pfile data/mydata --out results/output \
+          --callrate 0.05 --geno 0.01 --hwe 1e-6 \
+          --pca 20 --gwas --quiet
+```

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -53,7 +53,9 @@ This documentation provides detailed descriptions of the command-line arguments 
   - *Type*: `flag`
   - *Default*: `False`
   - *Description*: Logs at `DEBUG` level instead of `INFO`, on both the console
-    and the consolidated log. Combine with `--quiet` for verbose file-only logs.
+    and the consolidated log, and re-raises errors so the full Python traceback
+    is shown (without it, expected failures print a one-line `ERROR:` message).
+    Combine with `--quiet` for verbose file-only logs.
 
 ---
 

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -42,6 +42,19 @@ This documentation provides detailed descriptions of the command-line arguments 
   - *Default*: `False`
   - *Description*: If true, provides warnings on errors but continues the pipeline.
 
+- **`--quiet`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Suppresses the console progress stream. The log files are still
+    written in full: the consolidated `{out}_all_logs.log` and the per-step
+    `{out}_{step}.log` raw PLINK logs. Useful for batch/cluster jobs.
+
+- **`--debug`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Logs at `DEBUG` level instead of `INFO`, on both the console
+    and the consolidated log. Combine with `--quiet` for verbose file-only logs.
+
 ---
 
 ### Ancestry Arguments

--- a/docs/superpowers/plans/2026-07-23-logging-visibility-redesign.md
+++ b/docs/superpowers/plans/2026-07-23-logging-visibility-redesign.md
@@ -1,0 +1,132 @@
+# Plan: Logging / pipeline-visibility redesign (round 7)
+
+Test-first, task-by-task. Each task: write/adjust tests → implement → run the
+task's tests green → move on. Whole-diff review + full suite + e2e at the end,
+then PR into `refactor/main`. Spec:
+`docs/superpowers/specs/2026-07-23-logging-visibility-redesign-design.md`.
+
+Run tests with `.venv/bin/python -m pytest`. Branch:
+`refactor/logging-visibility-redesign`.
+
+---
+
+## Task 1 — `RunLog` writer + custom handler (`core/logging.py`)
+
+**Tests** (`tests/unit/test_core.py::TestRunLog`, new):
+- `write_banner` then `begin_section("callrate_prune")` writes the `===== callrate_prune =====` header.
+- `write_record` (INFO record with a `.step`) appends a full-format structured line inside the open section.
+- `append_raw` buffers; nothing hits disk until `end_section`; `end_section(raw_path)` appends the buffered raw to the consolidated file **after** the structured lines AND writes the same raw to `raw_path`.
+- Ordering is deterministic: banner < header < structured < raw (assert byte order in the file).
+- `end_section(None)` writes raw into the consolidated only (no per-step file).
+- `write_summary([...])` appends a recognizable summary block.
+- `close()` is idempotent; re-`install` doesn't leak FDs (reuse existing pattern).
+
+**Implement:** `RunLog`, `_RunLogHandler`, `raw_sink` ContextVar,
+`install_run_logging(out_path, level, console) -> RunLog`, concise console
+`Formatter` (with `! ` WARNING+ prefix). Keep `setup_logging` and all existing
+exports intact. Update `core/__init__` / `core/logging` exports as needed.
+
+---
+
+## Task 2 — Universal raw harvest in `run_command` (`core/executors.py`)
+
+**Tests** (`tests/unit/test_executors.py` or `test_core.py`):
+- `_harvest_raw_log`: given a cmd list with `--out /p/x` and an existing `/p/x.log`, calls `sink.append_raw` with the file text; with `--prefix` (KING) likewise; with no `--out`/no `.log`, no-op; with `raw_sink` unset, no-op; never raises if the file read fails.
+- Integration: with a `RunLog` installed as the sink and a real `run_plink2` call (real PLINK2, skip if absent), the harvested text contains a known PLINK phrase.
+
+**Implement:** `_harvest_raw_log(cmd_list, cmd_str)` called in `run_command`
+after building `cmd_result`, before the `check` raise, in try/except. Reads
+`raw_sink.get()`.
+
+---
+
+## Task 3 — Pure `validate_input` + decoupled guard (`core/validation.py`)
+
+**Tests** (`tests/unit/test_core.py::TestValidation`):
+- `validate_input` no longer raises on an existing `{out}_all_logs.log` (guard moved); still raises on missing pgen / missing SEX / missing PHENO1.
+- Skip decisions now emitted via logging: use `caplog` to assert a WARNING record (not `warnings.warn`) for each of the 4 skip conditions; decisions dataclass unchanged.
+- Breakdown emitted via `logger.info` (assert a "breakdown"/"Genetic Sex" INFO record via `caplog`).
+- New `guard_output_not_exists(out, skip_fails)`: raises `ValidationError` when the log exists and not `skip_fails`; returns quietly otherwise. (Adjust the two existing `test_raises_when_log_exists` / `test_skip_fails_ignores_existing_log` to target the guard.)
+
+**Implement:** move the guard out; swap `print`→`logger.info`,
+`warnings.warn`→`logger.warning`; `logger = get_logger(__name__)`; drop `import
+warnings`.
+
+---
+
+## Task 4 — Runner reorder, sectioning, channel migration (`cli/runner.py`)
+
+**Tests** (`tests/unit/test_cli/test_runner_regression.py`):
+- `run()` calls `guard_output_not_exists` before logging setup (assert via ordering spy / monkeypatch, or that a pre-existing log raises before any handler is installed).
+- `_setup_logging` no longer creates `{out}_cleaned_logs.log` (assert it does not exist after a run) and installs a `RunLog` (assert `self._runlog` is set / banner present).
+- No pipeline-path `print(` remains in `runner.py` (static assert via source scan in the test, or capture stdout and assert the old "Running: …" line is absent from stdout while present as a log record).
+- Existing `--warn` / final-step-failure / GWAS-arg-threading regression tests still pass unchanged.
+
+**Implement:** reorder `run()`; wrap `_convert_input_format` in an
+`input_preparation` section; per-step `begin_section`/`end_section` with
+`raw_log_path`; ancestry section + `step_context("ancestry")`; migrate the 4
+`print`s; `logger = get_logger(__name__)`; store/close `self._runlog`.
+
+---
+
+## Task 5 — End-of-run summary table (`cli/runner.py`)
+
+**Tests** (`test_runner_regression.py`):
+- After a 2-step QC run (hermetic or real-PLINK), `runlog.write_summary` receives rows with step name + removed count + PASS; per-ancestry runs produce per-label rows.
+- The summary appears in the consolidated log tail and as console/log records.
+
+**Implement:** `SummaryRow` (or a plain tuple/dict), a
+`_emit_run_summary()` helper reading `state.pass_fail`/`step_results` (+ ancestry
+results), called once at the end of `run()`.
+
+---
+
+## Task 6 — `print`→log in ancestry preprocessing + `get_logger` sweep
+
+**Tests:** light — `caplog` asserts `get_common_snps`/`get_raw_files` emit an
+INFO record where they used to print (real-PLINK differential/golden tests already
+cover behavior; assert no stdout leak). Static: a test scanning the touched
+modules asserts they bind `get_logger(__name__)`.
+
+**Implement:** `ancestry/preprocessing.py` prints → `logger.info`; standardize
+`logging.getLogger(__name__)` → `get_logger(__name__)` across the 11 sites in the
+spec. Pure-refactor; no behavior change.
+
+---
+
+## Task 7 — Rewrite `tests/regression/test_logging.py` (lock the new behavior)
+
+**Tests** (rewrite; real CLI, skip without PLINK2/data):
+- Consolidated `{out}_all_logs.log`: banner + `===== ` section headers + `[callrate_prune]`/`[geno_prune]` markers + "filtering complete" + **harvested PLINK content** (a known count/warning phrase) + a summary-table marker.
+- Per-step raw files `{out}_callrate.log` / `{out}_geno.log` exist and contain PLINK output; they are NOT the consolidated file.
+- `{out}_cleaned_logs.log` does **not** exist.
+- Logs persist without `--full_output` (default run).
+- Console: captured stdout/stderr contains a concise `[callrate_prune]` line and does not dump raw PLINK.
+- (If cheap) an `--ancestry` smoke asserts `{out}_{label}_{step}.log` naming.
+
+---
+
+## Task 8 — Wrap-up
+
+- Full suite: `.venv/bin/python -m pytest tests/unit tests/regression -q` green.
+- Parity (if `.venv-stable` present): `test_parity.py` 8/8.
+- Static gates (spec): no `cleaned_logs` in `genotools/` except `utils.py`; no
+  `warnings.warn` in `core/validation.py`; no pipeline-path `print(`.
+- E2e (background): `--callrate --geno` run + `--ancestry` run; eyeball the
+  consolidated log top-to-bottom.
+- Whole-diff self-review (or `code-reviewer` subagent).
+- Add a **Round 7** section to `REFACTOR.md`; flip item #0 to resolved; update the
+  "Start here" pointer to item #1 (real-data parity).
+- PR into `refactor/main` (markdown body, no attribution).
+
+---
+
+## Notes / faithful-port guardrails
+
+- No genotype-affecting changes; `psam-cols=fid,parents,sex,pheno1,phenos` stays.
+- Harvest is best-effort and must never break a run (try/except around file read +
+  sink call).
+- `raw_sink` unset ⇒ harvesting is a silent no-op, so library/unit callers and the
+  existing step unit tests are unaffected.
+- Keep `FilterResult.log` / `GWASResult.log` fields as-is (still carry stderr);
+  they're orthogonal to the disk harvest.

--- a/docs/superpowers/specs/2026-07-23-logging-visibility-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-23-logging-visibility-redesign-design.md
@@ -1,0 +1,229 @@
+# Design: Logging / pipeline-visibility redesign (refactor hardening, round 7)
+
+**Date:** 2026-07-23
+**Branch:** `refactor/logging-visibility-redesign` (feature branch → PR/merge into
+`refactor/main`; **never `main`**).
+**Tracker item:** REFACTOR.md item **#0** — "Logging / pipeline-visibility
+redesign" (do this before item #1 real-data parity and the perf items).
+
+## Goal
+
+Make each pipeline step's behavior **clearly visible** — on the terminal while a
+run is in progress, and on disk afterwards. The current logging scored 6.5/10: a
+well-built structured core (`core/logging.py`) let down by incomplete integration
+(raw PLINK output dropped from disk, a dead 0-byte `cleaned_logs.log`, and three
+uncoordinated user-facing channels — `print`, `logging` file-only, and
+`warnings.warn`).
+
+## Settled decisions (from the grill session)
+
+1. **Console = curated progress stream.** One logging stream. The console shows a
+   concise, step-tagged progress narrative at INFO; raw PLINK output never reaches
+   the terminal. `print()` and `warnings.warn` in the pipeline path are retired
+   and routed through `logging`.
+2. **`{out}_cleaned_logs.log` is deleted** (file + all references). Replaced by a
+   genuinely good consolidated log.
+3. **Consolidated log = per-step sections, summary then raw.** `{out}_all_logs.log`
+   is banner header → one section per step (`===== step =====` header, structured
+   summary lines, then the verbatim harvested PLINK output for that step) → an
+   end-of-run summary table.
+4. **Raw source = PLINK's native `.log`.** We harvest the `{--out}.log` file PLINK
+   writes automatically (authoritative: counts + warnings + command line + timing),
+   not the incomplete captured `stderr`.
+5. **Harvest is executor-level, every invocation.** `run_command` harvests the
+   native `.log` after *every* PLINK/KING call so compound steps (GWAS/PCA,
+   ancestry preprocessing) are fully captured, not just their last invocation.
+6. **Logs always persist at `{out}`** regardless of `--full_output` (which now
+   governs only intermediate pfiles). Raw `.log` files are harvested out of the
+   temp dir before it is cleaned.
+7. **Single consolidated file for everything** under `--ancestry`, sectioned by
+   label; per-step raw files are `{out}_{label}_{step}.log`. (Item #9
+   parallelization will revisit this; accepted.)
+8. **Guard decoupled; logging set up first.** The "output already exists" re-run
+   guard becomes a standalone pre-check; then logging is configured; then
+   `validate_input` (now pure) logs the data breakdown + skip decisions into the
+   consolidated log.
+9. **Single `RunLog` writer object** owns the consolidated file handle. Structured
+   records reach it via a thin custom `logging.Handler`; section headers, buffered
+   raw, and the summary table go through explicit methods. One owner → deterministic
+   ordering + explicit flush; unit-testable without logging globals.
+10. **End-of-run summary table** (step → removed → PASS/FAIL, per ancestry group)
+    to both the console and the tail of the consolidated log.
+11. **Console format = concise step-tagged**: `[callrate_prune] complete: 5 samples
+    removed`, with a `! ` prefix on WARNING/ERROR. No timestamp/level/logger-name.
+    The file keeps the full detailed format.
+
+### Smaller defaults (ratified)
+
+- No new `--verbose`/`--quiet` flag this round; console is always the curated INFO
+  stream.
+- The consolidated file captures INFO+ structured records; the executor's
+  per-command DEBUG line stays out of the file (the raw `.log` already carries the
+  exact command).
+- Pre-split & compound phases get their own sections (`input_preparation`,
+  `ancestry_prediction`, and the PCA/GWAS sub-phases already have `step_context`),
+  so their PLINK calls are attributed, not dumped into an empty-step bucket.
+- Standardize on `get_logger(__name__)` (retire the bare `logging.getLogger`
+  idiom in steps/runner/gwas/ancestry-model — 11 sites).
+- Do **not** touch third-party warnings (sklearn/pandas) or
+  `logging.captureWarnings`; only GenoTools' own `print`/`warn` in the pipeline
+  path migrate.
+- Out of scope: `genotools/utils.py`, `imputation.py`, `download_refs.py`,
+  `dependencies.py`, `container/` (deferred/other entry points). Module-docstring
+  `print(...)` examples are not touched.
+
+## Architecture
+
+### `core/logging.py` — new `RunLog` + wiring
+
+```python
+class RunLog:
+    """Owns the consolidated {out}_all_logs.log file handle.
+
+    Single writer for: the banner header, per-step section headers, live
+    structured records (via _RunLogHandler), buffered raw PLINK blocks flushed
+    at section end (also written to per-step raw files), and the final summary.
+    """
+    def __init__(self, path: Path) -> None: ...
+    def write_banner(self) -> None: ...
+    def begin_section(self, title: str) -> None: ...          # writes "===== title ====="
+    def append_raw(self, command: str, text: str) -> None: ... # buffers into current section
+    def end_section(self, raw_log_path: Path | None) -> None: ...# flush buffered raw → file + per-step
+    def write_record(self, record: logging.LogRecord) -> None: ...# live structured line (full format)
+    def write_summary(self, rows: list[SummaryRow]) -> None: ...
+    def close(self) -> None: ...
+
+class _RunLogHandler(logging.Handler):
+    """Routes genotools structured records into a RunLog (INFO+)."""
+    def __init__(self, runlog: RunLog): ...
+    def emit(self, record): self.runlog.write_record(record)
+```
+
+- **Raw sink ContextVar.** `raw_sink: ContextVar[Optional[RunLog]]` (mirrors the
+  existing `current_step`). Set when run-logging is installed; read by the executor.
+  `None` → harvesting is a no-op (library/unit use).
+- **`install_run_logging(out_path, level="INFO", console=True) -> RunLog`.** Builds
+  the `RunLog`, writes the banner, attaches `_RunLogHandler` + a console
+  `StreamHandler` (concise formatter) to the `"genotools"` logger, sets `raw_sink`,
+  returns the `RunLog`. Closes/clears prior handlers first (FD-leak safe, like
+  today's `setup_logging`).
+- **Formatters.** File/full: reuse today's
+  `"%(asctime)s [%(levelname)s] %(step)s %(name)s: %(message)s"`. Console/concise:
+  a custom `Formatter` producing `"[step] message"` (from the `record.step` the
+  existing `StepContextFilter` sets), prefixed `"! "` for `levelno >= WARNING`.
+- **`setup_logging(...)` retained** for existing/simple callers (e.g. `test_core`
+  `TestLogging`); the runtime uses `install_run_logging` instead of the plain
+  `FileHandler`. Keep `banner()`, `step_context`, `current_step`,
+  `StepContextFilter`, `get_logger`, `set_step`/`clear_step`.
+
+### `core/executors.py` — universal raw harvest in `run_command`
+
+After the subprocess returns and `cmd_result` is built, **before** the
+`check`/raise branch (so a failing step's PLINK log is still captured):
+
+```python
+_harvest_raw_log(cmd_list, cmd_str)   # best-effort; never raises
+```
+
+`_harvest_raw_log`:
+- Find the output prefix: token after `--out`, or after `--prefix` (KING).
+- `log_path = f"{prefix}.log"`; if it exists, read it (`errors="replace"`).
+- `sink = raw_sink.get()`; if `sink is not None: sink.append_raw(cmd_str, text)`.
+- Wrapped in try/except → harvesting must never break execution.
+
+Every PLINK/PLINK2 call in the codebase passes `--out <prefix>` (QC via
+`run_plink2`, PCA/assoc via `run_command`, ancestry preprocessing via
+`run_command`, conversions in `genotypes.py`); KING passes `--prefix`. So one hook
+in `run_command` captures all invocations. Attribution to a section is by the
+currently-open `RunLog` section (opened by the runner), not by parsing.
+
+### `core/validation.py` — pure validation, logged
+
+- **Remove** the `{out}_all_logs.log`-exists guard from `validate_input` (moves to
+  the runner pre-check). `validate_input` keeps: pgen-exists check, SEX/PHENO1
+  column checks, the data breakdown, and the skip decisions.
+- Replace the breakdown `print(...)` (lines 76–93) with `logger.info(...)` and the
+  five `warnings.warn(...)` skip messages (103–129) with `logger.warning(...)`
+  (same text). `logger = get_logger(__name__)`.
+- **New** `guard_output_not_exists(out_path, skip_fails)` (module-level): raises
+  `ValidationError` if `{out}_all_logs.log` exists and not `skip_fails`. Called by
+  the runner *before* logging setup.
+
+### `cli/runner.py` — orchestration, sectioning, summary
+
+- **`run()` reorder:** `guard_output_not_exists(...)` → `_setup_logging()` (build
+  `RunLog`, install handlers, write banner) → `_convert_input_format()` (wrapped in
+  a `input_preparation` section so conversion + `validate_input` land in the log) →
+  steps.
+- **`_setup_logging()`** becomes: delete any stale `{out}_all_logs.log`; **stop
+  creating `cleaned_logs.log`**; `self._runlog = install_run_logging(out_path,
+  console=True)`. Store `self._runlog` on the runner (and clean up / `close()` in
+  the `finally`).
+- **`_run_qc_pipeline`** per step: compute `raw_log_path`
+  (`{out}_{step}.log` or `{out}_{label}_{step}.log`), wrap the run in
+  `runlog.begin_section(section_title)` / `runlog.end_section(raw_log_path)`. Replace
+  `print("Running: …")` / `print("cannot be run")` / `print("failed but
+  continuing")` with `logger.info`/`logger.warning`. Section title is label-aware
+  under ancestry (e.g. `EUR / callrate_prune`); the console `[step]` tag likewise.
+- **`_run_single_step`** kinship "Relatedness … Linux only" `print` → `logger.warning`.
+- **`_run_ancestry_prediction_new`**: wrap in `begin_section("ancestry_prediction")`
+  + a `step_context("ancestry")` so the ported preprocessing logs + PLINK raw are
+  attributed. `end_section({out}_ancestry.log)`.
+- **End-of-run summary:** a helper assembles `SummaryRow`s from `state.pass_fail` +
+  `state.step_results` (+ per-ancestry results) and calls
+  `runlog.write_summary(...)`; the same rows print to the console via `logger.info`.
+
+### `ancestry/preprocessing.py` — logged, not printed
+
+Replace `print("Getting Common SNPs")` and the "Labeled Reference Ancestry
+Counts" block (lines 18, 141–146) with `logger.info(...)`
+(`logger = get_logger(__name__)`). No behavior change.
+
+### `get_logger` standardization
+
+Change `logger = logging.getLogger(__name__)` → `logger = get_logger(__name__)`
+(and drop now-unused `import logging` where only used for that) in: the 8 QC steps,
+`gwas/steps/association.py`, `gwas/steps/pca.py`, `gwas/pipeline.py`,
+`cli/runner.py`, `ancestry/model.py`. Keeps every module under the `genotools.*`
+namespace so records reach the `RunLog` handler.
+
+## Resulting artifacts (after any run)
+
+| File | Contents |
+|------|----------|
+| `{out}_all_logs.log` | banner → per-step sections (header, structured summary, raw PLINK) → summary table |
+| `{out}_{step}.log` (`{out}_{label}_{step}.log`) | isolated verbatim PLINK output for that step (all its invocations) |
+| `{out}_cleaned_logs.log` | **gone** |
+
+Console: concise step-tagged progress + final summary table. No raw PLINK.
+
+## Verification gates
+
+- `.venv/bin/python -m pytest tests/unit tests/regression -q` → green.
+- `tests/regression/test_logging.py` (rewritten) asserts: consolidated log has
+  section headers + structured `[callrate_prune]`/`[geno_prune]` markers +
+  "filtering complete" + **real PLINK content** (e.g. a variant/sample count phrase
+  from the harvested `.log`); per-step raw files exist and contain PLINK output; **no**
+  `cleaned_logs.log`; a summary table line is present; console (captured
+  stdout/stderr) shows a concise `[step]` line and no full-format timestamp noise.
+- Unit: `RunLog` section/raw/summary ordering (no disk-race, deterministic bytes);
+  `_harvest_raw_log` parses `--out`/`--prefix` and no-ops without a sink;
+  `validate_input` emits `logger.warning` (via `caplog`) instead of `warnings.warn`;
+  `guard_output_not_exists` raises/skips correctly.
+- Parity unaffected: `tests/regression/test_parity.py` compares genotype content +
+  IDs + lambda, **not** logs, and shells out to `.venv-stable`. Still 8/8 with
+  `.venv-stable` present.
+- End-to-end (background): a `--callrate --geno` run and an `--ancestry` run produce
+  the expected files; eyeball the consolidated log reads cleanly top-to-bottom.
+- Static: no `cleaned_logs` references left in `genotools/` (except deferred
+  `utils.py`); no `warnings.warn` in `core/validation.py`; no pipeline-path
+  `print(` outside module-docstring examples.
+
+## Environment / workflow
+
+- Use `.venv/bin/python` from repo root.
+- Feature branch off `refactor/main` → PR/merge to `refactor/main`. NEVER touch `main`.
+- Conventional commits, no `Co-Authored-By`/attribution (CLAUDE.md).
+- Faithful-port rule preserved: `psam-cols=fid,parents,sex,pheno1,phenos` stays;
+  no genotype-affecting changes.
+- Add a round-7 section to `REFACTOR.md` when done; mark item #0 resolved.

--- a/genotools/ancestry/model.py
+++ b/genotools/ancestry/model.py
@@ -40,7 +40,6 @@ Example:
 """
 
 import json
-import logging
 import os
 import pickle
 from dataclasses import dataclass, field
@@ -74,9 +73,10 @@ from genotools.ancestry.results import (
 )
 from genotools.core.exceptions import AncestryError
 from genotools.core.genotypes import GenotypeData
+from genotools.core.logging import get_logger
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/genotools/ancestry/preprocessing.py
+++ b/genotools/ancestry/preprocessing.py
@@ -11,11 +11,14 @@ import numpy as np
 import pandas as pd
 
 from genotools.core.executors import run_command, get_plink, get_plink2
+from genotools.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_common_snps(geno_path1: str, geno_path2: str, out_name: str) -> dict:
     """Extract SNPs common to two bfiles from geno_path1. Returns output paths."""
-    print("Getting Common SNPs")
+    logger.info("Getting Common SNPs")
     plink = get_plink()
     plink2 = get_plink2()
 
@@ -138,12 +141,8 @@ def get_raw_files(
     labeled_ref_raw = ref_raw.merge(ref_labeled, how="left", on=["FID", "IID"])
     labeled_ref_raw.drop(columns=[0, 1, 2, 3, 4, 5], inplace=True)
 
-    print()
-    print()
-    print("Labeled Reference Ancestry Counts:")
-    print(labeled_ref_raw.label.value_counts())
-    print()
-    print()
+    logger.info("Labeled Reference Ancestry Counts:")
+    logger.info(f"\n{labeled_ref_raw.label.value_counts()}")
 
     # get reference alleles from ref_common_snps
     ref_common_snps_ref_alleles = f"{ref_common_snps}.ref_allele"

--- a/genotools/cli/__init__.py
+++ b/genotools/cli/__init__.py
@@ -84,15 +84,41 @@ __all__ = [
 
 
 def main():
-    """Main entry point for the genotools CLI."""
+    """Main entry point for the genotools CLI.
+
+    Failures a user can act on are reported as a one-line ``ERROR:`` message on
+    stderr with exit 1, not a Python traceback -- the detail belongs in the
+    consolidated run log. That covers ``GenoToolsError`` (bad input, a failing
+    external tool, a blocked output prefix), ``FileNotFoundError`` (the
+    codebase-wide signal for a missing file), and the ``ValueError``/``TypeError``
+    raised by config validation for out-of-range arguments.
+
+    Any other exception is a bug and keeps its traceback. ``--debug`` re-raises
+    everything, so the traceback is always one flag away.
+    """
     import sys
 
-    args = parse_args()
-    result = run_pipeline(args)
+    from genotools.core.exceptions import GenoToolsError
 
-    # Save output JSON
-    out_path = args.output.out_path
-    result.save(out_path.with_suffix(".json"))
+    # Outside the try: argparse reports its own errors and exits.
+    args = parse_args()
+    debug = args.output.debug
+
+    try:
+        result = run_pipeline(args)
+
+        # Save output JSON
+        out_path = args.output.out_path
+        result.save(out_path.with_suffix(".json"))
+    except (GenoToolsError, FileNotFoundError, ValueError, TypeError) as e:
+        if debug:
+            raise
+        print(f"ERROR: {e}", file=sys.stderr)
+        print("Re-run with --debug for the full traceback.", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        sys.exit(130)
 
     # Return appropriate exit code
     sys.exit(0 if result.success else 1)

--- a/genotools/cli/parser.py
+++ b/genotools/cli/parser.py
@@ -252,6 +252,8 @@ class OutputArgs:
     full_output: bool = False
     skip_fails: bool = False
     warn_only: bool = True  # Continue on step failure
+    quiet: bool = False  # Suppress the console stream (log files still written)
+    debug: bool = False  # Widen both streams to DEBUG level
 
 
 @dataclass
@@ -480,6 +482,16 @@ Examples:
         "--no-warn",
         action="store_true",
         help="Stop pipeline on first error (default: continue with warnings)",
+    )
+    output_group.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress console progress output (log files are still written)",
+    )
+    output_group.add_argument(
+        "--debug",
+        action="store_true",
+        help="Log at DEBUG level (console and consolidated log)",
     )
 
     # Sample QC group
@@ -861,6 +873,8 @@ def parse_args(args: Optional[Sequence[str]] = None) -> PipelineArgs:
         full_output=ns.full_output,
         skip_fails=ns.skip_fails,
         warn_only=not ns.no_warn,
+        quiet=ns.quiet,
+        debug=ns.debug,
     )
 
     sample_qc_args = SampleQCArgs(

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -34,7 +34,7 @@ import pandas as pd
 
 from .parser import PipelineArgs
 from .output import PipelineOutput, write_results
-from ..core.exceptions import GenoToolsError
+from ..core.exceptions import GenoToolsError, ValidationError
 from ..core.logging import RunLog, get_logger, install_run_logging, step_context
 from ..core.validation import ValidationDecisions, guard_output_not_exists
 
@@ -131,7 +131,8 @@ class PipelineRunner:
             PipelineOutput containing all results.
 
         Raises:
-            ValueError: If no input files or steps are specified.
+            ValidationError: If no steps are specified, the output prefix is
+                already used, or the input fails validation.
         """
         # Initialize state
         self._initialize_state()
@@ -162,7 +163,9 @@ class PipelineRunner:
 
             steps = self._filter_steps_by_decisions(self.args.get_all_enabled_steps())
             if not steps and not self.args.ancestry.run_ancestry:
-                raise ValueError("No QC steps or ancestry prediction requested")
+                # A ValidationError (not a bare ValueError) so main() reports it
+                # as a one-line message instead of a traceback.
+                raise ValidationError("No QC steps or ancestry prediction requested")
         except Exception:
             self._teardown_logging(remove_logs=True)
             if self.state and self.state.tmp_dir:
@@ -303,14 +306,16 @@ class PipelineRunner:
 
         With ``remove_logs=True`` (pre-flight failure), also delete the
         freshly-created consolidated + input-prep logs so the output prefix is
-        not left poisoned for the next run.
+        not left poisoned for the next run -- and put back any log this run
+        rotated aside, so a failed re-run leaves the directory as it found it.
         """
         from ..core.logging import raw_sink
 
         if self._runlog is None:
             return
-        log_path = self._runlog.path
-        self._runlog.close()
+        runlog = self._runlog
+        log_path = runlog.path
+        runlog.close()
         self._runlog = None
         raw_sink.set(None)
         if remove_logs:
@@ -319,6 +324,7 @@ class PipelineRunner:
                     p.unlink(missing_ok=True)
                 except OSError:
                     pass
+            runlog.restore_rotated()
 
     def _begin_section(self, title: str) -> None:
         """Open a consolidated-log section (no-op when logging isn't installed)."""

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -286,10 +286,17 @@ class PipelineRunner:
         re-run guard (which checks the log does not already exist) and before any
         step, so every ``logger.info``/``warning``/``error`` — including the
         input breakdown — is captured.
+
+        ``--debug`` widens both streams to DEBUG; ``--quiet`` drops the console
+        handler (the consolidated + per-step log files are still written).
         """
         assert self.state is not None
         out_path = str(self.state.out_path)
-        self._runlog = install_run_logging(out_path, level="INFO", console=True)
+        self._runlog = install_run_logging(
+            out_path,
+            level="DEBUG" if self.args.output.debug else "INFO",
+            console=not self.args.output.quiet,
+        )
 
     def _teardown_logging(self, remove_logs: bool = False) -> None:
         """Close the RunLog and unregister the raw sink.
@@ -329,10 +336,15 @@ class PipelineRunner:
         rows = self._collect_summary_rows()
         if not rows:
             return
-        logger.info("Run summary:")
+        # Console-only records: the RunLog writes its own aligned table below, so
+        # emitting these to the file too would duplicate the summary.
+        logger.info("Run summary:", extra={"console_only": True})
         for label, removed, passed in rows:
             status = "PASS" if passed else "FAIL"
-            logger.info(f"  {label}: {removed} removed [{status}]")
+            logger.info(
+                f"  {label}: {removed} removed [{status}]",
+                extra={"console_only": True},
+            )
         if self._runlog is not None:
             self._runlog.write_summary(rows)
 
@@ -436,6 +448,10 @@ class PipelineRunner:
             current_het = het_value
             if self.args.sample_qc.amr_het and label == "AMR":
                 current_het = [-1.0, -1.0]
+
+            # Announce the group so the console (where per-step "Running:" lines
+            # are file-only) still shows which ancestry the step lines belong to.
+            logger.info(f"Ancestry group {label}: running {len(steps)} QC step(s)")
 
             # Create modified args for this ancestry
             self._run_qc_pipeline(
@@ -837,8 +853,13 @@ class PipelineRunner:
             raw_log_path = f"{out_path}_{step}.log"
             self._begin_section(section_title)
             try:
+                # File-only: the absolute temp-dir paths are essential for
+                # debugging but pure noise on the console, where the step's own
+                # first log line (and, under --ancestry, the group header)
+                # already announces what is running.
                 logger.info(
-                    f"Running: {step} with input {step_input} and output: {step_output}"
+                    f"Running: {step} with input {step_input} and output: {step_output}",
+                    extra={"file_only": True},
                 )
 
                 # Check if input exists

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -147,21 +147,30 @@ class PipelineRunner:
         # Set up logging (builds the RunLog, installs handlers, writes banner).
         self._setup_logging()
 
-        # Convert input format if needed + run input validation, inside a section
-        # so conversion PLINK output and the data breakdown land in the log.
-        self._begin_section("input_preparation")
+        # Pre-flight: convert input + validate (logged into the consolidated log),
+        # then confirm there is work to do. A failure here happens *before* any
+        # output is produced, so tear down and REMOVE the freshly-created log so
+        # the output prefix isn't poisoned for the next run (restores the
+        # pre-redesign behavior where a failed validation left no log behind).
         try:
-            with step_context("input"):
-                self._convert_input_format()
-        finally:
-            self._end_section(f"{self.args.out_path}_input_preparation.log")
+            self._begin_section("input_preparation")
+            try:
+                with step_context("input"):
+                    self._convert_input_format()
+            finally:
+                self._end_section(f"{self.args.out_path}_input_preparation.log")
 
-        # Validate we have something to do
-        steps = self._filter_steps_by_decisions(self.args.get_all_enabled_steps())
-        if not steps and not self.args.ancestry.run_ancestry:
-            raise ValueError("No QC steps or ancestry prediction requested")
+            steps = self._filter_steps_by_decisions(self.args.get_all_enabled_steps())
+            if not steps and not self.args.ancestry.run_ancestry:
+                raise ValueError("No QC steps or ancestry prediction requested")
+        except Exception:
+            self._teardown_logging(remove_logs=True)
+            if self.state and self.state.tmp_dir:
+                self.state.tmp_dir.cleanup()
+            raise
 
-        # Run the pipeline
+        # Run the pipeline. From here the consolidated log persists even on
+        # failure (partial output may exist), matching the re-run guard's intent.
         try:
             if self.args.ancestry.run_ancestry:
                 result = self._run_with_ancestry(steps)
@@ -174,8 +183,7 @@ class PipelineRunner:
             # Cleanup temporary directory
             if self.state and self.state.tmp_dir:
                 self.state.tmp_dir.cleanup()
-            if self._runlog is not None:
-                self._runlog.close()
+            self._teardown_logging(remove_logs=False)
 
     def _initialize_state(self) -> None:
         """Initialize pipeline state."""
@@ -282,6 +290,28 @@ class PipelineRunner:
         assert self.state is not None
         out_path = str(self.state.out_path)
         self._runlog = install_run_logging(out_path, level="INFO", console=True)
+
+    def _teardown_logging(self, remove_logs: bool = False) -> None:
+        """Close the RunLog and unregister the raw sink.
+
+        With ``remove_logs=True`` (pre-flight failure), also delete the
+        freshly-created consolidated + input-prep logs so the output prefix is
+        not left poisoned for the next run.
+        """
+        from ..core.logging import raw_sink
+
+        if self._runlog is None:
+            return
+        log_path = self._runlog.path
+        self._runlog.close()
+        self._runlog = None
+        raw_sink.set(None)
+        if remove_logs:
+            for p in (log_path, Path(f"{self.args.out_path}_input_preparation.log")):
+                try:
+                    p.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
     def _begin_section(self, title: str) -> None:
         """Open a consolidated-log section (no-op when logging isn't installed)."""

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -21,7 +21,6 @@ QC steps, ancestry prediction, and GWAS analysis.
 
 from __future__ import annotations
 
-import logging
 import os
 import pathlib
 import platform
@@ -36,9 +35,10 @@ import pandas as pd
 from .parser import PipelineArgs
 from .output import PipelineOutput, write_results
 from ..core.exceptions import GenoToolsError
-from ..core.validation import ValidationDecisions
+from ..core.logging import RunLog, get_logger, install_run_logging, step_context
+from ..core.validation import ValidationDecisions, guard_output_not_exists
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -118,6 +118,7 @@ class PipelineRunner:
         self.args = args
         self.state: Optional[PipelineState] = None
         self._validation_decisions = ValidationDecisions()
+        self._runlog: Optional[RunLog] = None
 
         # These will be set up during run()
         self._new_modules: Dict[str, Any] = {}
@@ -138,12 +139,22 @@ class PipelineRunner:
         # Initialize modules
         self._initialize_modules()
 
-        # Convert input format if needed (must happen before logging setup
-        # because validate_input validates that log files don't exist)
-        self._convert_input_format()
+        # Re-run guard runs *before* logging setup, since setup creates the
+        # consolidated log file the guard checks for. (Decoupled from
+        # validate_input so validate_input can log into the fresh log.)
+        guard_output_not_exists(self.args.out_path, self.args.output.skip_fails)
 
-        # Set up logging (after validate_input so log file creation doesn't trigger error)
+        # Set up logging (builds the RunLog, installs handlers, writes banner).
         self._setup_logging()
+
+        # Convert input format if needed + run input validation, inside a section
+        # so conversion PLINK output and the data breakdown land in the log.
+        self._begin_section("input_preparation")
+        try:
+            with step_context("input"):
+                self._convert_input_format()
+        finally:
+            self._end_section(f"{self.args.out_path}_input_preparation.log")
 
         # Validate we have something to do
         steps = self._filter_steps_by_decisions(self.args.get_all_enabled_steps())
@@ -157,11 +168,14 @@ class PipelineRunner:
             else:
                 result = self._run_qc_only(steps)
 
+            self._emit_run_summary()
             return result
         finally:
             # Cleanup temporary directory
             if self.state and self.state.tmp_dir:
                 self.state.tmp_dir.cleanup()
+            if self._runlog is not None:
+                self._runlog.close()
 
     def _initialize_state(self) -> None:
         """Initialize pipeline state."""
@@ -255,44 +269,78 @@ class PipelineRunner:
         }
 
     def _setup_logging(self) -> None:
-        """Set up the consolidated run log.
+        """Build the consolidated run log and install logging handlers.
 
-        Runs *after* validate_input (which errors if ``{out}_all_logs.log``
-        already exists), so it can safely (re)create the log. Beyond creating
-        the legacy-named files, this attaches the structured logging file
-        handler so every step's ``logger.info``/``error`` is aggregated into
-        ``{out}_all_logs.log``. Without this call ``setup_logging`` is never
-        invoked at runtime and the root logger's WARNING default drops all step
-        logs, leaving the consolidated log header-only.
+        Installs a :class:`RunLog` that owns ``{out}_all_logs.log`` (banner +
+        per-step sections + summary) and registers it as the run-scoped raw sink
+        so the executor harvests each PLINK/KING ``.log`` into it. Also attaches
+        a concise console handler for the curated progress stream. Runs after the
+        re-run guard (which checks the log does not already exist) and before any
+        step, so every ``logger.info``/``warning``/``error`` — including the
+        input breakdown — is captured.
         """
         assert self.state is not None
         out_path = str(self.state.out_path)
+        self._runlog = install_run_logging(out_path, level="INFO", console=True)
 
-        # Clear existing log files
-        all_logs = f"{out_path}_all_logs.log"
-        cleaned_logs = f"{out_path}_cleaned_logs.log"
+    def _begin_section(self, title: str) -> None:
+        """Open a consolidated-log section (no-op when logging isn't installed)."""
+        if self._runlog is not None:
+            self._runlog.begin_section(title)
 
-        if os.path.exists(all_logs):
-            os.remove(all_logs)
-        if os.path.exists(cleaned_logs):
-            os.remove(cleaned_logs)
+    def _end_section(self, raw_log_path: Optional[str] = None) -> None:
+        """Flush a section's buffered raw output (no-op without a RunLog)."""
+        if self._runlog is not None:
+            self._runlog.end_section(raw_log_path)
 
-        # Create new log files with header
-        from ..core.logging import banner
+    def _emit_run_summary(self) -> None:
+        """Emit the end-of-run summary table to the console and consolidated log."""
+        assert self.state is not None
+        rows = self._collect_summary_rows()
+        if not rows:
+            return
+        logger.info("Run summary:")
+        for label, removed, passed in rows:
+            status = "PASS" if passed else "FAIL"
+            logger.info(f"  {label}: {removed} removed [{status}]")
+        if self._runlog is not None:
+            self._runlog.write_summary(rows)
 
-        header = banner()
-        with open(all_logs, "w") as fp:
-            fp.write(header)
-            fp.write("\n")
-        with open(cleaned_logs, "w") as fp:
-            pass
+    def _collect_summary_rows(self) -> List[tuple]:
+        """Assemble (label, outliers_removed, passed) rows from pipeline state.
 
-        # Route all genotools step/runner logs into the consolidated log file.
-        # setup_logging() opens the file in append mode, so the banner header
-        # written above stays at the top and structured records follow it.
-        from ..core.logging import setup_logging
+        Covers the plain QC path (``state.pass_fail`` + ``state.step_results``)
+        and the per-ancestry path (``state.ancestry_results``), labeling
+        per-ancestry rows ``{label}/{step}``.
+        """
+        assert self.state is not None
 
-        setup_logging(level="INFO", log_file=Path(all_logs), console=False)
+        def _removed(metrics: Dict[str, Any]) -> int:
+            metrics = metrics or {}
+            if "outlier_count" in metrics:
+                return int(metrics["outlier_count"])
+            return int(
+                metrics.get("related_count", 0)
+                + metrics.get("duplicated_count", 0)
+            )
+
+        rows: List[tuple] = []
+        # Plain QC path.
+        for step, record in self.state.pass_fail.items():
+            result = self.state.step_results.get(step)
+            removed = _removed(result.metrics) if result else 0
+            rows.append((step, removed, record.status))
+
+        # Per-ancestry path.
+        ancestry_results = getattr(self.state, "ancestry_results", {})
+        for label, out_dict in ancestry_results.items():
+            pf = out_dict.get("pass_fail", {})
+            for step, rec in pf.items():
+                step_result = out_dict.get(step, {})
+                removed = _removed(step_result.get("metrics", {}))
+                rows.append((f"{label}/{step}", removed, rec.get("status", False)))
+
+        return rows
 
     def _convert_input_format(self) -> None:
         """Convert input format to pfiles if needed."""
@@ -331,8 +379,14 @@ class PipelineRunner:
         """
         assert self.state is not None
 
-        # Run ancestry prediction
-        ancestry_result = self._run_ancestry_prediction_new()
+        # Run ancestry prediction (sectioned; the ported preprocessing runs many
+        # PLINK invocations, all harvested under the "ancestry" step context).
+        self._begin_section("ancestry_prediction")
+        try:
+            with step_context("ancestry"):
+                ancestry_result = self._run_ancestry_prediction_new()
+        finally:
+            self._end_section(f"{self.args.out_path}_ancestry_prediction.log")
         self.state.ancestry_result = ancestry_result
         self.state.labels_list = ancestry_result["data"]["labels_list"]
 
@@ -744,62 +798,72 @@ class PipelineRunner:
             )
 
             step_paths.append(step_output)
-            logger.info(
-                f"Running: {step} with input {step_input} and output: {step_output}"
-            )
-            print(f"Running: {step} with input {step_input} and output: {step_output}")
 
-            # Check if input exists
-            if self.args.warn_only and not os.path.isfile(f"{step_input}.pgen"):
-                print(
-                    f"Step {step} cannot be run! "
-                    "All samples or variants were pruned in a previous step!"
-                )
-                pass_fail[step] = PassFailRecord(
-                    status=False, input_path=step_input, output_path=step_output
-                )
-                continue
-
-            # Run the step. Refactored steps signal failure by raising a
-            # GenoToolsError (QCError/ExternalToolError/...). Under --warn we
-            # record the failure and continue from the last passed output;
-            # otherwise we fail fast.
+            # Open a consolidated-log section for this step. Raw PLINK output
+            # harvested during the step is buffered and flushed (to the section
+            # and to a per-step {out}_{step}.log) by _end_section. Logs always
+            # persist at the stable out_path location regardless of full_output.
+            section_title = step if ancestry_label == "all" else f"{ancestry_label} / {step}"
+            raw_log_path = f"{out_path}_{step}.log"
+            self._begin_section(section_title)
             try:
-                result = self._run_single_step(
-                    step=step,
-                    step_input=step_input,
-                    step_output=step_output,
-                    legacy_args=legacy_args,
-                )
-            except GenoToolsError as e:
-                logger.error(f"Step {step} failed: {e}")
-                if not self.args.warn_only:
-                    raise
-                print(f"Step {step} failed but continuing (--warn): {e}")
-                pass_fail[step] = PassFailRecord(
-                    status=False,
-                    input_path=step_input,
-                    output_path=step_output,
-                    error=str(e),
-                )
-                continue
-
-            if result is not None:
-                out_dict[step] = result
-                pass_fail[step] = PassFailRecord(
-                    status=result.get("pass", False),
-                    input_path=step_input,
-                    output_path=step_output,
+                logger.info(
+                    f"Running: {step} with input {step_input} and output: {step_output}"
                 )
 
-                # Clean up intermediate files
-                self._cleanup_intermediate_files(
-                    step=step,
-                    pass_fail=pass_fail,
-                    out_dict=out_dict,
-                    out_path=out_path,
-                    geno_path=geno_path,
-                )
+                # Check if input exists
+                if self.args.warn_only and not os.path.isfile(f"{step_input}.pgen"):
+                    logger.warning(
+                        f"Step {step} cannot be run! "
+                        "All samples or variants were pruned in a previous step!"
+                    )
+                    pass_fail[step] = PassFailRecord(
+                        status=False, input_path=step_input, output_path=step_output
+                    )
+                    continue
+
+                # Run the step. Refactored steps signal failure by raising a
+                # GenoToolsError (QCError/ExternalToolError/...). Under --warn we
+                # record the failure and continue from the last passed output;
+                # otherwise we fail fast.
+                try:
+                    result = self._run_single_step(
+                        step=step,
+                        step_input=step_input,
+                        step_output=step_output,
+                        legacy_args=legacy_args,
+                    )
+                except GenoToolsError as e:
+                    logger.error(f"Step {step} failed: {e}")
+                    if not self.args.warn_only:
+                        raise
+                    logger.warning(f"Step {step} failed but continuing (--warn): {e}")
+                    pass_fail[step] = PassFailRecord(
+                        status=False,
+                        input_path=step_input,
+                        output_path=step_output,
+                        error=str(e),
+                    )
+                    continue
+
+                if result is not None:
+                    out_dict[step] = result
+                    pass_fail[step] = PassFailRecord(
+                        status=result.get("pass", False),
+                        input_path=step_input,
+                        output_path=step_output,
+                    )
+
+                    # Clean up intermediate files
+                    self._cleanup_intermediate_files(
+                        step=step,
+                        pass_fail=pass_fail,
+                        out_dict=out_dict,
+                        out_path=out_path,
+                        geno_path=geno_path,
+                    )
+            finally:
+                self._end_section(raw_log_path)
 
         # Handle final step failure with --warn
         self._handle_final_step_failure(steps, pass_fail, out_path, geno_path, working_geno)
@@ -951,7 +1015,7 @@ class PipelineRunner:
 
         elif step == "kinship_check":
             if platform.system() != "Linux":
-                print("Relatedness Assessment can only run on a Linux OS!")
+                logger.warning("Relatedness Assessment can only run on a Linux OS!")
                 return None
             result = self._new_modules["verify_kinship"](data, Path(step_output))
             return result.to_dict()

--- a/genotools/core/__init__.py
+++ b/genotools/core/__init__.py
@@ -48,6 +48,9 @@ from .logging import (
     step_context,
     current_step,
     banner,
+    RunLog,
+    install_run_logging,
+    raw_sink,
 )
 
 # External tool execution
@@ -94,6 +97,9 @@ __all__ = [
     "step_context",
     "current_step",
     "banner",
+    "RunLog",
+    "install_run_logging",
+    "raw_sink",
     # Executors
     "get_plink",
     "get_plink2",

--- a/genotools/core/executors.py
+++ b/genotools/core/executors.py
@@ -33,9 +33,45 @@ from pathlib import Path
 from typing import Generator, List, Optional, Sequence, Union
 
 from .exceptions import DependencyError, ExternalToolError
-from .logging import get_logger
+from .logging import get_logger, raw_sink
 
 logger = get_logger(__name__)
+
+
+def _harvest_raw_log(cmd_list: Sequence[str], cmd_str: str) -> None:
+    """Harvest an external tool's native ``.log`` into the run-scoped raw sink.
+
+    Every PLINK/PLINK2 invocation writes ``{--out}.log`` and KING writes
+    ``{--prefix}.log``. When a :class:`RunLog` is registered as the raw sink
+    (during a pipeline run), read that file and hand it to the sink so it lands
+    in the consolidated log and the per-step raw file. Best-effort: harvesting
+    must never break execution, so all failures are swallowed. A no-op when no
+    sink is registered (library/unit callers).
+    """
+    try:
+        sink = raw_sink.get()
+        if sink is None:
+            return
+
+        prefix: Optional[str] = None
+        args = list(cmd_list)
+        for flag in ("--out", "--prefix"):
+            if flag in args:
+                idx = args.index(flag)
+                if idx + 1 < len(args):
+                    prefix = args[idx + 1]
+                break
+        if prefix is None:
+            return
+
+        log_path = Path(f"{prefix}.log")
+        if not log_path.is_file():
+            return
+
+        text = log_path.read_text(errors="replace")
+        sink.append_raw(cmd_str, text)
+    except Exception:  # pragma: no cover - harvesting is strictly best-effort
+        pass
 
 # Lazy-loaded executable paths
 _plink: Optional[Path] = None
@@ -211,6 +247,10 @@ def run_command(
         stderr=result.stderr if capture_output else "",
         command=cmd_str,
     )
+
+    # Harvest the tool's native .log into the run-scoped raw sink (best-effort).
+    # Done before the failure raise so a failing step's PLINK log is captured.
+    _harvest_raw_log(cmd_list, cmd_str)
 
     if check and result.returncode != 0:
         raise ExternalToolError(

--- a/genotools/core/executors.py
+++ b/genotools/core/executors.py
@@ -44,9 +44,19 @@ def _harvest_raw_log(cmd_list: Sequence[str], cmd_str: str) -> None:
     Every PLINK/PLINK2 invocation writes ``{--out}.log`` and KING writes
     ``{--prefix}.log``. When a :class:`RunLog` is registered as the raw sink
     (during a pipeline run), read that file and hand it to the sink so it lands
-    in the consolidated log and the per-step raw file. Best-effort: harvesting
-    must never break execution, so all failures are swallowed. A no-op when no
-    sink is registered (library/unit callers).
+    in the consolidated log and the per-step raw file.
+
+    The harvested file is then **removed**, since its content now lives in both
+    of those places. Without this, every invocation that writes to a persistent
+    prefix leaves a stray ``{out}.log`` next to the real outputs (the final QC
+    step, each per-ancestry group, the ancestry preprocessing) duplicating
+    ``{out}_{step}.log`` under a confusing name. Mirrors what
+    ``GenotypeData.to_pfile`` already does for conversions, and what the legacy
+    ``concat_logs`` did for the files it consumed.
+
+    Best-effort throughout: harvesting must never break execution, so all
+    failures are swallowed. A no-op when no sink is registered (library/unit
+    callers), which also means their tool logs are left untouched.
     """
     try:
         sink = raw_sink.get()
@@ -70,6 +80,11 @@ def _harvest_raw_log(cmd_list: Sequence[str], cmd_str: str) -> None:
 
         text = log_path.read_text(errors="replace")
         sink.append_raw(cmd_str, text)
+        # Captured in the consolidated + per-step logs now; drop the stray file.
+        try:
+            log_path.unlink()
+        except OSError:
+            pass
     except Exception:  # pragma: no cover - harvesting is strictly best-effort
         pass
 

--- a/genotools/core/logging.py
+++ b/genotools/core/logging.py
@@ -24,12 +24,16 @@ import logging
 import sys
 from contextvars import ContextVar, Token
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 
 # Context variable for tracking the current QC step
 # This allows log messages to automatically include which step is running
 current_step: ContextVar[str] = ContextVar("current_step", default="")
+
+# Full detailed format used for the consolidated on-disk log.
+FILE_FORMAT = "%(asctime)s [%(levelname)s] %(step)s %(name)s: %(message)s"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 class StepContextFilter(logging.Filter):
@@ -191,3 +195,170 @@ def banner() -> str:
     ╚██████╔╝███████╗██║ ╚███║╚█████╔╝   ██║   ╚█████╔╝╚█████╔╝███████╗██████╔╝
     ╚═════╝ ╚══════╝╚═╝  ╚══╝ ╚════╝    ╚═╝    ╚════╝  ╚════╝ ╚══════╝╚═════╝
     """
+
+
+# ---------------------------------------------------------------------------
+# Consolidated run log (round 7: logging / pipeline-visibility redesign)
+# ---------------------------------------------------------------------------
+
+# A summary row: (step_label, outliers_removed, passed).
+SummaryRow = Tuple[str, int, bool]
+
+# Run-scoped raw-output sink. The executor reads this after every PLINK/KING
+# invocation and, if set, hands the harvested native .log to the RunLog. Unset
+# (None) => harvesting is a silent no-op, so library/unit callers are unaffected.
+raw_sink: ContextVar[Optional["RunLog"]] = ContextVar("raw_sink", default=None)
+
+
+class RunLog:
+    """Single writer that owns the consolidated ``{out}_all_logs.log`` file.
+
+    One object owns the file handle so structured records, section headers, and
+    buffered raw PLINK blocks land in a deterministic order. Per step the layout
+    is: a ``===== step =====`` header, the structured summary lines (written live
+    via :meth:`write_record`), then the verbatim harvested PLINK output for that
+    step (buffered via :meth:`append_raw`, flushed by :meth:`end_section`). The
+    same buffered raw is also written to a per-step ``{out}_{step}.log`` file.
+    """
+
+    def __init__(self, path: Union[str, Path]) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        # Truncate: each run starts a fresh consolidated log. The runner's
+        # re-run guard already prevents clobbering a prior run's output.
+        self._fh: Optional[object] = open(self.path, "w", encoding="utf-8")
+        self._formatter = logging.Formatter(FILE_FORMAT, datefmt=DATE_FORMAT)
+        self._raw_buffer: List[str] = []
+
+    # -- header / sections --------------------------------------------------
+
+    def write_banner(self) -> None:
+        self._write(banner() + "\n")
+
+    def begin_section(self, title: str) -> None:
+        """Open a section: flush any stray raw, write the header, reset buffer."""
+        self._raw_buffer = []
+        self._write(f"\n===== {title} =====\n")
+
+    def write_record(self, record: logging.LogRecord) -> None:
+        """Write a structured log record live (full detailed format)."""
+        if not hasattr(record, "step"):
+            record.step = ""  # type: ignore[attr-defined]
+        self._write(self._formatter.format(record) + "\n")
+
+    def append_raw(self, command: str, text: str) -> None:
+        """Buffer a harvested raw PLINK block; flushed at :meth:`end_section`."""
+        block = f"$ {command}\n{text.rstrip()}\n" if command else f"{text.rstrip()}\n"
+        self._raw_buffer.append(block)
+
+    def end_section(self, raw_log_path: Optional[Union[str, Path]] = None) -> None:
+        """Flush buffered raw into the consolidated log and per-step file."""
+        if self._raw_buffer:
+            raw = "".join(self._raw_buffer)
+            self._write(raw)
+            if raw_log_path is not None:
+                try:
+                    Path(raw_log_path).write_text(raw, encoding="utf-8")
+                except OSError:
+                    pass
+        self._raw_buffer = []
+
+    # -- summary ------------------------------------------------------------
+
+    def write_summary(self, rows: Sequence[SummaryRow]) -> None:
+        """Append the end-of-run summary table."""
+        lines = ["\n===== run summary =====\n"]
+        for label, removed, passed in rows:
+            status = "PASS" if passed else "FAIL"
+            lines.append(f"  {label:<28} {removed:>10} removed   {status}\n")
+        self._write("".join(lines))
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def _write(self, text: str) -> None:
+        if self._fh is not None:
+            self._fh.write(text)
+            self._fh.flush()
+
+    def close(self) -> None:
+        """Close the file handle. Idempotent."""
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            finally:
+                self._fh = None
+
+
+class _RunLogHandler(logging.Handler):
+    """Routes ``genotools.*`` structured records into a :class:`RunLog`."""
+
+    def __init__(self, runlog: RunLog, level: int = logging.INFO) -> None:
+        super().__init__(level)
+        self._runlog = runlog
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._runlog.write_record(record)
+        except Exception:  # pragma: no cover - never let logging crash a run
+            self.handleError(record)
+
+
+class _ConsoleFormatter(logging.Formatter):
+    """Concise, step-tagged console format: ``[step] message`` (``! `` on WARN+)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        if not hasattr(record, "step"):
+            record.step = ""  # type: ignore[attr-defined]
+        prefix = "! " if record.levelno >= logging.WARNING else ""
+        tag = f"{record.step} " if record.step else ""
+        return f"{prefix}{tag}{record.getMessage()}"
+
+
+def install_run_logging(
+    out_path: Union[str, Path],
+    level: Union[str, int] = "INFO",
+    console: bool = True,
+) -> RunLog:
+    """Configure runtime logging around a :class:`RunLog` and return it.
+
+    Builds the consolidated ``{out}_all_logs.log`` (banner written), attaches a
+    :class:`_RunLogHandler` (+ an optional concise console handler) to the
+    ``genotools`` logger, and registers the RunLog as the run-scoped raw sink so
+    the executor harvests PLINK ``.log`` output into it.
+
+    Args:
+        out_path: Output prefix; the log is ``{out_path}_all_logs.log``.
+        level: Log level for both handlers.
+        console: Whether to also emit the curated console stream.
+
+    Returns:
+        The RunLog (the caller owns its lifecycle; call ``close()`` when done).
+    """
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+
+    runlog = RunLog(f"{out_path}_all_logs.log")
+    runlog.write_banner()
+
+    logger = logging.getLogger("genotools")
+    logger.setLevel(level)
+    for handler in logger.handlers[:]:
+        handler.close()
+    logger.handlers.clear()
+
+    context_filter = StepContextFilter()
+
+    run_handler = _RunLogHandler(runlog, level)
+    run_handler.addFilter(context_filter)
+    logger.addHandler(run_handler)
+
+    if console:
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.setLevel(level)
+        console_handler.setFormatter(_ConsoleFormatter())
+        console_handler.addFilter(context_filter)
+        logger.addHandler(console_handler)
+
+    logger.propagate = False
+    raw_sink.set(runlog)
+    return runlog

--- a/genotools/core/logging.py
+++ b/genotools/core/logging.py
@@ -290,17 +290,35 @@ class RunLog:
 
 
 class _RunLogHandler(logging.Handler):
-    """Routes ``genotools.*`` structured records into a :class:`RunLog`."""
+    """Routes ``genotools.*`` structured records into a :class:`RunLog`.
+
+    Records marked ``extra={"console_only": True}`` are dropped: they are meant
+    for the terminal only, because the RunLog already renders that content in a
+    richer on-disk form (e.g. the run summary table).
+    """
 
     def __init__(self, runlog: RunLog, level: int = logging.INFO) -> None:
         super().__init__(level)
         self._runlog = runlog
 
     def emit(self, record: logging.LogRecord) -> None:
+        if getattr(record, "console_only", False):
+            return
         try:
             self._runlog.write_record(record)
         except Exception:  # pragma: no cover - never let logging crash a run
             self.handleError(record)
+
+
+class _ConsoleFilter(logging.Filter):
+    """Drops records marked ``extra={"file_only": True}`` from the console.
+
+    Used for detail that belongs in the consolidated log but would only add
+    noise to the curated terminal stream (e.g. absolute temp-dir step paths).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not getattr(record, "file_only", False)
 
 
 class _ConsoleFormatter(logging.Formatter):
@@ -326,10 +344,16 @@ def install_run_logging(
     ``genotools`` logger, and registers the RunLog as the run-scoped raw sink so
     the executor harvests PLINK ``.log`` output into it.
 
+    Two ``extra`` markers steer a record to one destination:
+    ``extra={"file_only": True}`` keeps it out of the console (verbose detail),
+    ``extra={"console_only": True}`` keeps it out of the consolidated log
+    (content the RunLog renders itself, e.g. the summary table).
+
     Args:
         out_path: Output prefix; the log is ``{out_path}_all_logs.log``.
         level: Log level for both handlers.
-        console: Whether to also emit the curated console stream.
+        console: Whether to also emit the curated console stream. ``False``
+            (``--quiet``) still writes the consolidated + per-step log files.
 
     Returns:
         The RunLog (the caller owns its lifecycle; call ``close()`` when done).
@@ -357,6 +381,7 @@ def install_run_logging(
         console_handler.setLevel(level)
         console_handler.setFormatter(_ConsoleFormatter())
         console_handler.addFilter(context_filter)
+        console_handler.addFilter(_ConsoleFilter())
         logger.addHandler(console_handler)
 
     logger.propagate = False

--- a/genotools/core/logging.py
+++ b/genotools/core/logging.py
@@ -5,10 +5,20 @@ This module provides:
 - Configurable log levels and output destinations
 - Consistent log formatting across the codebase
 
-Usage:
+There are two ways to configure the ``genotools`` logger, and they are mutually
+exclusive — both reset its handlers:
+
+1. :func:`install_run_logging` — what the **pipeline** uses. Builds a
+   :class:`RunLog` that owns the sectioned ``{out}_all_logs.log``, harvests raw
+   PLINK output into it, and adds a curated console stream. See below.
+2. :func:`setup_logging` — for **library/embedded** callers who drive the step
+   functions directly (no pipeline runner, so no RunLog). Plain handlers, one
+   flat log file, no sections and no raw harvesting.
+
+Library usage:
     from genotools.core.logging import setup_logging, get_logger, current_step
 
-    # Setup logging at application start
+    # Configure once, before calling step functions
     setup_logging(level="INFO", log_file=Path("output/genotools.log"))
 
     # Get a logger for your module
@@ -35,6 +45,15 @@ current_step: ContextVar[str] = ContextVar("current_step", default="")
 FILE_FORMAT = "%(asctime)s [%(levelname)s] %(step)s %(name)s: %(message)s"
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
+# Where to send a user for raw PLINK output when a step fails. Steps must not
+# name the tool's own {prefix}.log: those files live in the run's temp dir, and
+# the executor removes each one after harvesting it into the run log. Single
+# constant so the pointer stays accurate in one edit.
+RAW_LOG_HINT = (
+    "The full PLINK output for this step is in the consolidated run log "
+    "({out}_all_logs.log) and its per-step log ({out}_{step}.log)."
+)
+
 
 class StepContextFilter(logging.Filter):
     """Logging filter that adds the current step to log records.
@@ -50,12 +69,39 @@ class StepContextFilter(logging.Filter):
         return True
 
 
+def _reset_genotools_logger(level: Union[str, int]) -> logging.Logger:
+    """Return the ``genotools`` logger with handlers cleared and level set.
+
+    Shared by :func:`setup_logging` and :func:`install_run_logging` so the two
+    configure the logger identically: existing handlers are **closed** before
+    being dropped (repeated setup in one process — e.g. successive pipeline runs
+    — would otherwise leak file descriptors), and propagation to the root logger
+    is disabled to avoid duplicate output.
+    """
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+
+    logger = logging.getLogger("genotools")
+    logger.setLevel(level)
+    for handler in logger.handlers[:]:
+        handler.close()
+    logger.handlers.clear()
+    logger.propagate = False
+    return logger
+
+
 def setup_logging(
     level: Union[str, int] = "INFO",
     log_file: Optional[Path] = None,
     console: bool = True
 ) -> None:
-    """Configure structured logging with optional file output.
+    """Configure plain structured logging — for library/embedded callers.
+
+    Use this when driving the step functions directly (no pipeline runner). The
+    CLI pipeline instead calls :func:`install_run_logging`, which adds the
+    sectioned consolidated log, raw PLINK harvesting, and the curated console
+    format. Both reset the ``genotools`` logger's handlers, so calling this
+    during a pipeline run would detach that run's log — don't mix them.
 
     Args:
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) or int
@@ -65,28 +111,10 @@ def setup_logging(
     Example:
         setup_logging(level="DEBUG", log_file=Path("run.log"))
     """
-    # Convert string level to int if needed
-    if isinstance(level, str):
-        level = getattr(logging, level.upper(), logging.INFO)
+    logger = _reset_genotools_logger(level)
+    level = logger.level
 
-    # Get the root genotools logger
-    logger = logging.getLogger("genotools")
-    logger.setLevel(level)
-
-    # Clear any existing handlers, closing them first so repeated
-    # setup_logging() calls in one process (e.g. successive pipeline runs)
-    # don't leak file descriptors.
-    for handler in logger.handlers[:]:
-        handler.close()
-    logger.handlers.clear()
-
-    # Create formatter with step context placeholder
-    formatter = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(step)s %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S"
-    )
-
-    # Add context filter to include step in all messages
+    formatter = logging.Formatter(FILE_FORMAT, datefmt=DATE_FORMAT)
     context_filter = StepContextFilter()
 
     if console:
@@ -105,9 +133,6 @@ def setup_logging(
         file_handler.setFormatter(formatter)
         file_handler.addFilter(context_filter)
         logger.addHandler(file_handler)
-
-    # Prevent propagation to root logger to avoid duplicate messages
-    logger.propagate = False
 
 
 def get_logger(name: str) -> logging.Logger:
@@ -210,6 +235,26 @@ SummaryRow = Tuple[str, int, bool]
 raw_sink: ContextVar[Optional["RunLog"]] = ContextVar("raw_sink", default=None)
 
 
+def rotate_existing_log(path: Path, max_keep: int = 100) -> Optional[Path]:
+    """Move an existing log aside to the next free ``{path}.N``; return that name.
+
+    Returns None when there was nothing to rotate, or when rotation failed (never
+    worth breaking a run over). Used so a re-run cannot silently destroy a
+    previous run's audit trail.
+    """
+    if not path.exists():
+        return None
+    for i in range(1, max_keep + 1):
+        candidate = path.with_name(f"{path.name}.{i}")
+        if not candidate.exists():
+            try:
+                path.rename(candidate)
+            except OSError:  # pragma: no cover - best-effort
+                return None
+            return candidate
+    return None
+
+
 class RunLog:
     """Single writer that owns the consolidated ``{out}_all_logs.log`` file.
 
@@ -221,14 +266,37 @@ class RunLog:
     same buffered raw is also written to a per-step ``{out}_{step}.log`` file.
     """
 
-    def __init__(self, path: Union[str, Path]) -> None:
+    def __init__(self, path: Union[str, Path], rotate_existing: bool = True) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        # Truncate: each run starts a fresh consolidated log. The runner's
-        # re-run guard already prevents clobbering a prior run's output.
+        # Each run starts a fresh consolidated log. The runner's re-run guard
+        # normally means there is nothing here to lose -- except under
+        # --skip-fails, which bypasses that guard, so an existing log is rotated
+        # aside to {path}.N instead of being truncated. (Per-step raw files are
+        # still overwritten; their content is a subset of the rotated log.)
+        self.rotated_from: Optional[Path] = (
+            rotate_existing_log(self.path) if rotate_existing else None
+        )
         self._fh: Optional[object] = open(self.path, "w", encoding="utf-8")
         self._formatter = logging.Formatter(FILE_FORMAT, datefmt=DATE_FORMAT)
         self._raw_buffer: List[str] = []
+
+    def restore_rotated(self) -> None:
+        """Undo the constructor's rotation, if any (idempotent).
+
+        Used when a run dies in pre-flight and its fresh log is removed: the
+        prior run's log should go back to its original name rather than being
+        left orphaned under ``{path}.N``.
+        """
+        if self.rotated_from is None:
+            return
+        try:
+            if not self.path.exists() and self.rotated_from.exists():
+                self.rotated_from.rename(self.path)
+        except OSError:  # pragma: no cover - best-effort
+            pass
+        finally:
+            self.rotated_from = None
 
     # -- header / sections --------------------------------------------------
 
@@ -358,18 +426,11 @@ def install_run_logging(
     Returns:
         The RunLog (the caller owns its lifecycle; call ``close()`` when done).
     """
-    if isinstance(level, str):
-        level = getattr(logging, level.upper(), logging.INFO)
-
     runlog = RunLog(f"{out_path}_all_logs.log")
     runlog.write_banner()
 
-    logger = logging.getLogger("genotools")
-    logger.setLevel(level)
-    for handler in logger.handlers[:]:
-        handler.close()
-    logger.handlers.clear()
-
+    logger = _reset_genotools_logger(level)
+    level = logger.level
     context_filter = StepContextFilter()
 
     run_handler = _RunLogHandler(runlog, level)
@@ -384,6 +445,14 @@ def install_run_logging(
         console_handler.addFilter(_ConsoleFilter())
         logger.addHandler(console_handler)
 
-    logger.propagate = False
     raw_sink.set(runlog)
+
+    # Announce a rotation now that the handlers exist, so the notice lands in the
+    # new log and on the console rather than vanishing.
+    if runlog.rotated_from is not None:
+        logger.warning(
+            f"An existing log was found at {runlog.path.name}; "
+            f"the previous run's log is preserved as {runlog.rotated_from.name}"
+        )
+
     return runlog

--- a/genotools/core/validation.py
+++ b/genotools/core/validation.py
@@ -4,7 +4,6 @@ Ports the validation + data-breakdown behavior of legacy utils.upfront_check,
 including the data-driven step-skip decisions.
 """
 
-import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Union
@@ -12,6 +11,9 @@ from typing import Union
 import pandas as pd
 
 from .exceptions import ValidationError
+from .logging import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -21,6 +23,23 @@ class ValidationDecisions:
     skip_case_control: bool = False
     skip_het: bool = False
     disable_filter_controls: bool = False
+
+
+def guard_output_not_exists(
+    out_path: Union[str, Path], skip_fails: bool = False
+) -> None:
+    """Guard against re-running over a prior run's output.
+
+    Raises ``ValidationError`` if ``{out_path}_all_logs.log`` already exists and
+    ``skip_fails`` is False. Decoupled from ``validate_input`` so the runner can
+    call it *before* logging is set up (logging setup creates that log file).
+    """
+    if Path(f"{out_path}_all_logs.log").is_file() and not skip_fails:
+        raise ValidationError(
+            f"{out_path}_all_logs.log exists, which means the pipeline has "
+            f"previously been run on this output file! Rerun with --skip_fails "
+            f"to ignore this, or write output to a new file name."
+        )
 
 
 def validate_input(
@@ -34,22 +53,17 @@ def validate_input(
     filter_controls: bool = False,
     case_control_requested: bool = False,
 ) -> ValidationDecisions:
-    """Validate pipeline input, print a data breakdown, and derive step-skip decisions.
+    """Validate pipeline input, log a data breakdown, and derive step-skip decisions.
+
+    The re-run guard (output already exists) lives in ``guard_output_not_exists``
+    so it can run before logging is configured; this function is pure validation.
 
     Raises:
-        ValidationError: if the output log already exists (and not skip_fails),
-            or the psam is missing SEX/PHENO1.
+        ValidationError: if the psam is missing SEX/PHENO1.
         FileNotFoundError: if the input pgen is missing.
     """
     geno_path = str(geno_path)
     out_path = str(out_path)
-
-    if Path(f"{out_path}_all_logs.log").is_file() and not skip_fails:
-        raise ValidationError(
-            f"{out_path}_all_logs.log exists, which means the pipeline has "
-            f"previously been run on this output file! Rerun with --skip_fails "
-            f"to ignore this, or write output to a new file name."
-        )
 
     if not Path(f"{geno_path}.pgen").is_file():
         raise FileNotFoundError(f"{geno_path} does not exist.")
@@ -73,24 +87,24 @@ def validate_input(
     sex_counts = sam["SEX"].value_counts().to_dict()
     pheno_counts = sam["PHENO1"].value_counts().to_dict()
 
-    print("Your data has the following breakdown:")
-    print("- Genetic Sex:")
+    logger.info("Your data has the following breakdown:")
+    logger.info("- Genetic Sex:")
     for sex in sex_counts:
         if sex == 1:
-            print(f"{sex_counts[sex]} Males \n")
+            logger.info(f"  {sex_counts[sex]} Males")
         if sex == 2:
-            print(f"{sex_counts[sex]} Females \n")
+            logger.info(f"  {sex_counts[sex]} Females")
         if sex in (0, -9):
-            print(f"{sex_counts[sex]} Unknown \n")
+            logger.info(f"  {sex_counts[sex]} Unknown")
 
-    print("- Phenotypes:")
+    logger.info("- Phenotypes:")
     for pheno in pheno_counts:
         if pheno == 2:
-            print(f"{pheno_counts[pheno]} Cases \n")
+            logger.info(f"  {pheno_counts[pheno]} Cases")
         if pheno == 1:
-            print(f"{pheno_counts[pheno]} Controls \n")
+            logger.info(f"  {pheno_counts[pheno]} Controls")
         if pheno in (0, -9):
-            print(f"{pheno_counts[pheno]} Missing \n")
+            logger.info(f"  {pheno_counts[pheno]} Missing")
 
     chr_counts = var["#CHROM"].value_counts().to_dict()
 
@@ -100,35 +114,34 @@ def validate_input(
     skip_sex = False
     if sex_requested:
         if (1 not in sex_counts) and (2 not in sex_counts):
-            warnings.warn(
+            logger.warning(
                 "You tried calling sex prune but no sample sex data is available. "
-                "Skipping...", stacklevel=2)
+                "Skipping...")
             skip_sex = True
         elif ("23" not in chr_counts) and ("X" not in chr_counts):
-            warnings.warn(
+            logger.warning(
                 "You tried calling sex prune but no X chromosome data is "
-                "available. Skipping...", stacklevel=2)
+                "available. Skipping...")
             skip_sex = True
 
     disable_filter_controls = False
     if hwe_requested and filter_controls and (1 not in pheno_counts):
-        warnings.warn(
+        logger.warning(
             "You tried calling hwe prune with controls filtered but no controls "
-            "are available. Skipping...", stacklevel=2)
+            "are available. Skipping...")
         disable_filter_controls = True
 
     skip_case_control = False
     if case_control_requested and ((1 not in pheno_counts) or (2 not in pheno_counts)):
-        warnings.warn(
+        logger.warning(
             "You tried calling case-control prune but only cases or controls are "
-            "available, not both. Skipping...", stacklevel=2)
+            "available, not both. Skipping...")
         skip_case_control = True
 
     skip_het = False
     if het_requested and (var.shape[0] < 50):
-        warnings.warn(
-            "You tried calling het prune with less than 50 samples. Skipping...",
-            stacklevel=2)
+        logger.warning(
+            "You tried calling het prune with less than 50 samples. Skipping...")
         skip_het = True
 
     return ValidationDecisions(

--- a/genotools/core/validation.py
+++ b/genotools/core/validation.py
@@ -37,8 +37,10 @@ def guard_output_not_exists(
     if Path(f"{out_path}_all_logs.log").is_file() and not skip_fails:
         raise ValidationError(
             f"{out_path}_all_logs.log exists, which means the pipeline has "
-            f"previously been run on this output file! Rerun with --skip_fails "
-            f"to ignore this, or write output to a new file name."
+            f"previously been run on this output file! Rerun with --skip-fails "
+            f"to ignore this (the existing log is preserved as "
+            f"{Path(out_path).name}_all_logs.log.N), or write output to a new "
+            f"file name."
         )
 
 

--- a/genotools/gwas/pipeline.py
+++ b/genotools/gwas/pipeline.py
@@ -34,20 +34,19 @@ Usage:
     print(result.to_dict())  # Legacy format
 """
 
-import logging
 import warnings
 from pathlib import Path
 from typing import Optional
 
 from genotools.core.exceptions import GWASError, ValidationError
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.gwas.config import AssocConfig, CovariateConfig
 from genotools.gwas.results import AssocResult, PCAResult, GWASResult
 from genotools.gwas.steps.pca import run_pca
 from genotools.gwas.steps.association import run_gwas
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class AssocPipeline:

--- a/genotools/gwas/steps/association.py
+++ b/genotools/gwas/steps/association.py
@@ -29,7 +29,6 @@ Usage:
     inflation = calculate_inflation(pvalues, n_cases=500, n_controls=1000)
 """
 
-import logging
 from pathlib import Path
 from typing import Optional
 
@@ -40,11 +39,11 @@ from scipy.stats import ncx2
 from genotools.core.exceptions import GWASError, ValidationError
 from genotools.core.executors import get_plink2, run_command
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.gwas.config import GWASConfig, CovariateConfig
 from genotools.gwas.results import GWASResult, InflationMetrics
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def calculate_inflation(

--- a/genotools/gwas/steps/association.py
+++ b/genotools/gwas/steps/association.py
@@ -39,7 +39,7 @@ from scipy.stats import ncx2
 from genotools.core.exceptions import GWASError, ValidationError
 from genotools.core.executors import get_plink2, run_command
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.gwas.config import GWASConfig, CovariateConfig
 from genotools.gwas.results import GWASResult, InflationMetrics
 
@@ -295,7 +295,7 @@ def run_gwas(
                 inflation=None,
                 n_variants_tested=0,
                 success=False,
-                log=f"Check {out_path}.log for more information",
+                log=RAW_LOG_HINT,
             )
 
 

--- a/genotools/gwas/steps/pca.py
+++ b/genotools/gwas/steps/pca.py
@@ -29,18 +29,17 @@ Usage:
     pca_result = run_pca(data, config, out_path)
 """
 
-import logging
 from pathlib import Path
 from typing import Optional
 
 from genotools.core.exceptions import ValidationError
 from genotools.core.executors import get_plink2, run_command, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.gwas.config import PCAConfig, PCAPruningConfig, get_exclusion_regions
 from genotools.gwas.results import PCAResult, PruningResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _write_exclusion_file(out_path: Path, build: str) -> Path:

--- a/genotools/gwas/steps/pca.py
+++ b/genotools/gwas/steps/pca.py
@@ -35,7 +35,7 @@ from typing import Optional
 from genotools.core.exceptions import ValidationError
 from genotools.core.executors import get_plink2, run_command, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.gwas.config import PCAConfig, PCAPruningConfig, get_exclusion_regions
 from genotools.gwas.results import PCAResult, PruningResult
 
@@ -211,7 +211,7 @@ def run_pca_pruning(
                 variants_after=0,
                 exclusion_file=None,
                 success=False,
-                log=f"Check {pruned_path}.log for more information",
+                log=RAW_LOG_HINT,
             )
 
 
@@ -317,5 +317,5 @@ def run_pca(
                 n_samples=0,
                 pruning_result=pruning_result,
                 success=False,
-                log=f"Check {out_path}.log for more information",
+                log=RAW_LOG_HINT,
             )

--- a/genotools/qc/steps/callrate.py
+++ b/genotools/qc/steps/callrate.py
@@ -18,7 +18,6 @@
 Removes samples with high missing genotype rates using PLINK2 --mind.
 """
 
-import logging
 from pathlib import Path
 
 import pandas as pd
@@ -26,11 +25,11 @@ import pandas as pd
 from genotools.core.exceptions import ValidationError
 from genotools.core.executors import run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import CallrateConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_callrate(

--- a/genotools/qc/steps/case_control.py
+++ b/genotools/qc/steps/case_control.py
@@ -26,7 +26,7 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.qc.config import CaseControlConfig
 from genotools.qc.results import FilterResult
 
@@ -171,6 +171,5 @@ def filter_case_control(
                         bfile.unlink()
 
             raise QCError(
-                f"Case-control missingness test failed. "
-                f"Check {mis_tmp}.log for more information."
+                f"Case-control missingness test failed. {RAW_LOG_HINT}"
             )

--- a/genotools/qc/steps/case_control.py
+++ b/genotools/qc/steps/case_control.py
@@ -19,7 +19,6 @@ Removes variants with significantly different missing rates between
 cases and controls using PLINK 1.9 --test-missing.
 """
 
-import logging
 from pathlib import Path
 
 import pandas as pd
@@ -27,11 +26,11 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import CaseControlConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_case_control(

--- a/genotools/qc/steps/haplotype.py
+++ b/genotools/qc/steps/haplotype.py
@@ -19,7 +19,6 @@ Removes variants with non-random patterns of missing data using
 PLINK 1.9 --test-mishap.
 """
 
-import logging
 from pathlib import Path
 
 import pandas as pd
@@ -27,11 +26,11 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import HaplotypeConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_haplotype(

--- a/genotools/qc/steps/haplotype.py
+++ b/genotools/qc/steps/haplotype.py
@@ -26,7 +26,7 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.qc.config import HaplotypeConfig
 from genotools.qc.results import FilterResult
 
@@ -176,6 +176,5 @@ def filter_haplotype(
                         bfile.unlink()
 
             raise QCError(
-                f"Haplotype missingness test failed. "
-                f"Check {hap_tmp}.log for more information."
+                f"Haplotype missingness test failed. {RAW_LOG_HINT}"
             )

--- a/genotools/qc/steps/heterozygosity.py
+++ b/genotools/qc/steps/heterozygosity.py
@@ -25,7 +25,7 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.qc.config import HetConfig
 from genotools.qc.results import FilterResult
 
@@ -105,8 +105,7 @@ def filter_heterozygosity(
         prune_in_file = het_tmp.with_suffix(".prune.in")
         if not prune_in_file.exists():
             raise QCError(
-                f"LD pruning failed - {prune_in_file} not found. "
-                f"Check {het_tmp}.log for details."
+                f"LD pruning failed - {prune_in_file} not found. {RAW_LOG_HINT}"
             )
 
         run_plink2(
@@ -202,6 +201,6 @@ def filter_heterozygosity(
         else:
             raise QCError(
                 f"Heterozygosity calculation failed - {het_file} not found. "
-                f"Check {het_tmp}.log, {het_tmp2}.log, or {het_tmp3}.log for details. "
+                f"{RAW_LOG_HINT} "
                 "Note: This can happen if there's only one sample in the genotype file."
             )

--- a/genotools/qc/steps/heterozygosity.py
+++ b/genotools/qc/steps/heterozygosity.py
@@ -18,7 +18,6 @@
 Removes samples with extreme heterozygosity rates using PLINK2.
 """
 
-import logging
 from pathlib import Path
 
 import pandas as pd
@@ -26,11 +25,11 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import HetConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_heterozygosity(

--- a/genotools/qc/steps/hwe.py
+++ b/genotools/qc/steps/hwe.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.qc.config import HWEConfig
 from genotools.qc.results import FilterResult
 
@@ -145,6 +145,5 @@ def filter_hwe(
                         bfile.unlink()
 
             raise QCError(
-                f"HWE test failed. "
-                f"Check {hwe_tmp}.log or {out_path}.log for more information."
+                f"HWE test failed. {RAW_LOG_HINT}"
             )

--- a/genotools/qc/steps/hwe.py
+++ b/genotools/qc/steps/hwe.py
@@ -18,17 +18,16 @@
 Removes variants violating Hardy-Weinberg equilibrium using PLINK 1.9.
 """
 
-import logging
 from pathlib import Path
 
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import HWEConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_hwe(

--- a/genotools/qc/steps/ld_prune.py
+++ b/genotools/qc/steps/ld_prune.py
@@ -18,17 +18,16 @@
 Removes variants in high LD using PLINK2 --indep-pairwise.
 """
 
-import logging
 from pathlib import Path
 
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import LDConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def prune_ld(

--- a/genotools/qc/steps/ld_prune.py
+++ b/genotools/qc/steps/ld_prune.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.qc.config import LDConfig
 from genotools.qc.results import FilterResult
 
@@ -130,6 +130,5 @@ def prune_ld(
             )
         else:
             raise QCError(
-                f"LD pruning failed - {prune_in_file} not found. "
-                f"Check {ld_tmp}.log or {out_path}.log for more information."
+                f"LD pruning failed - {prune_in_file} not found. {RAW_LOG_HINT}"
             )

--- a/genotools/qc/steps/relatedness.py
+++ b/genotools/qc/steps/relatedness.py
@@ -18,7 +18,6 @@
 Removes related and/or duplicated samples using PLINK2 KING-based methods.
 """
 
-import logging
 import platform
 import shutil
 from pathlib import Path
@@ -29,11 +28,11 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_command, run_plink2, get_king
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import RelatedConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_relatedness(

--- a/genotools/qc/steps/sex.py
+++ b/genotools/qc/steps/sex.py
@@ -25,7 +25,7 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import get_logger, step_context
+from genotools.core.logging import RAW_LOG_HINT, get_logger, step_context
 from genotools.qc.config import SexConfig
 from genotools.qc.results import FilterResult
 
@@ -197,7 +197,4 @@ def filter_sex(
                     if bfile.exists():
                         bfile.unlink()
 
-            raise QCError(
-                f"Sex check failed. Check {sex_tmp1}.log and {sex_tmp2}.log "
-                "for more information."
-            )
+            raise QCError(f"Sex check failed. {RAW_LOG_HINT}")

--- a/genotools/qc/steps/sex.py
+++ b/genotools/qc/steps/sex.py
@@ -18,7 +18,6 @@
 Removes samples with sex discrepancies using PLINK 1.9 --check-sex.
 """
 
-import logging
 from pathlib import Path
 
 import pandas as pd
@@ -26,11 +25,11 @@ import pandas as pd
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.core.executors import run_plink, run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import SexConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_sex(

--- a/genotools/qc/steps/variant_missingness.py
+++ b/genotools/qc/steps/variant_missingness.py
@@ -18,17 +18,16 @@
 Removes variants with high missing genotype rates using PLINK2 --geno.
 """
 
-import logging
 from pathlib import Path
 
 from genotools.core.exceptions import ValidationError
 from genotools.core.executors import run_plink2
 from genotools.core.genotypes import GenotypeData
-from genotools.core.logging import step_context
+from genotools.core.logging import get_logger, step_context
 from genotools.qc.config import GenoConfig
 from genotools.qc.results import FilterResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def filter_variant_missingness(

--- a/tests/regression/test_cli_errors.py
+++ b/tests/regression/test_cli_errors.py
@@ -1,0 +1,183 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""CLI failure-boundary tests.
+
+Expected, user-actionable failures (``GenoToolsError``) must reach the terminal
+as a one-line ``ERROR: ...`` message with a non-zero exit code -- not a Python
+traceback. Unexpected exceptions are bugs and keep their traceback.
+
+Requires the synthetic test data; skips cleanly otherwise.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_cli(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "genotools", *args],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def test_rerun_guard_reports_cleanly(test_geno_path: Path, tmp_path: Path) -> None:
+    """Re-running on a used prefix: clean message, exit 1, no traceback."""
+    out = tmp_path / "guarded"
+    first = _run_cli(["--pfile", str(test_geno_path), "--out", str(out), "--callrate"])
+    assert first.returncode == 0, f"first run failed:\n{first.stderr}"
+
+    second = _run_cli(["--pfile", str(test_geno_path), "--out", str(out), "--callrate"])
+    assert second.returncode == 1, "a blocked prefix must exit non-zero"
+    assert "Traceback" not in second.stderr, (
+        f"expected a message, got a traceback:\n{second.stderr}"
+    )
+    assert "ERROR:" in second.stderr
+    assert "previously been run" in second.stderr
+    # The suggested flag must be the one the parser actually accepts: the old
+    # message said --skip_fails, which argparse rejects.
+    assert "--skip-fails" in second.stderr
+    assert "--skip_fails" not in second.stderr
+    # Short enough to actually read.
+    assert len(second.stderr.strip().splitlines()) <= 4, second.stderr
+
+
+def test_no_steps_requested_reports_cleanly(
+    test_geno_path: Path, tmp_path: Path
+) -> None:
+    """Nothing to do is a user error, not a crash."""
+    out = tmp_path / "nosteps"
+    res = _run_cli(["--pfile", str(test_geno_path), "--out", str(out)])
+
+    assert res.returncode == 1
+    assert "Traceback" not in res.stderr, res.stderr
+    assert "ERROR:" in res.stderr
+    assert "No QC steps" in res.stderr
+
+
+def test_missing_input_reports_cleanly(tmp_path: Path) -> None:
+    """A nonexistent --pfile is reported as a message, not a traceback.
+
+    Missing files are signalled codebase-wide with FileNotFoundError, so the
+    boundary handler has to cover it -- it is the most common user error.
+    """
+    res = _run_cli(
+        [
+            "--pfile", str(tmp_path / "does_not_exist"),
+            "--out", str(tmp_path / "out"),
+            "--callrate",
+        ]
+    )
+
+    assert res.returncode == 1
+    assert "Traceback" not in res.stderr, res.stderr
+    assert "ERROR:" in res.stderr
+    assert "does not exist" in res.stderr
+
+
+def test_out_of_range_argument_reports_cleanly(
+    test_geno_path: Path, tmp_path: Path
+) -> None:
+    """Config validation (ValueError) is a user error, not a crash.
+
+    The parser accepts --callrate 1.5; the range check lives in the step config.
+    """
+    res = _run_cli(
+        [
+            "--pfile", str(test_geno_path),
+            "--out", str(tmp_path / "badval"),
+            "--callrate", "1.5",
+        ]
+    )
+
+    assert res.returncode == 1
+    assert "Traceback" not in res.stderr, res.stderr
+    assert "mind must be between" in res.stderr
+
+
+def test_debug_flag_restores_the_traceback(
+    test_geno_path: Path, tmp_path: Path
+) -> None:
+    """--debug re-raises, so the traceback is always one flag away."""
+    res = _run_cli(
+        [
+            "--pfile", str(test_geno_path),
+            "--out", str(tmp_path / "badval_debug"),
+            "--callrate", "1.5",
+            "--debug",
+        ]
+    )
+
+    assert res.returncode != 0
+    assert "Traceback" in res.stderr, "--debug should surface the full traceback"
+    assert "mind must be between" in res.stderr
+
+
+def test_skip_fails_rerun_preserves_prior_log(
+    test_geno_path: Path, tmp_path: Path
+) -> None:
+    """--skip-fails bypasses the guard, so the prior log is rotated, not lost."""
+    out = tmp_path / "rerun"
+    first = _run_cli(["--pfile", str(test_geno_path), "--out", str(out), "--callrate"])
+    assert first.returncode == 0, f"first run failed:\n{first.stderr}"
+
+    original = Path(f"{out}_all_logs.log").read_text()
+    assert "===== callrate =====" in original
+
+    second = _run_cli(
+        [
+            "--pfile", str(test_geno_path),
+            "--out", str(out),
+            "--geno",
+            "--skip-fails",
+        ]
+    )
+    assert second.returncode == 0, f"re-run failed:\n{second.stderr}"
+
+    rotated = Path(f"{out}_all_logs.log.1")
+    assert rotated.exists(), "prior run's consolidated log was destroyed"
+    assert rotated.read_text() == original
+
+    # The new log is this run's, and it says where the old one went.
+    current = Path(f"{out}_all_logs.log").read_text()
+    assert "===== geno =====" in current
+    assert "rerun_all_logs.log.1" in current
+    assert "rerun_all_logs.log.1" in second.stderr, (
+        "the rotation should be announced on the console too"
+    )
+
+
+def test_no_stray_tool_log_beside_outputs(
+    test_geno_path: Path, tmp_path: Path
+) -> None:
+    """PLINK's own {out}.log is harvested and removed, not left as a duplicate."""
+    out = tmp_path / "nostray"
+    res = _run_cli(
+        ["--pfile", str(test_geno_path), "--out", str(out), "--callrate", "--geno"]
+    )
+    assert res.returncode == 0, f"Pipeline failed:\n{res.stderr}"
+
+    assert not Path(f"{out}.log").exists(), (
+        "PLINK's stray {out}.log should be harvested into the run log and removed"
+    )
+    # Its content is still on disk, under the per-step and consolidated names.
+    assert "PLINK v" in Path(f"{out}_geno.log").read_text()
+    assert "PLINK v" in Path(f"{out}_all_logs.log").read_text()

--- a/tests/regression/test_logging.py
+++ b/tests/regression/test_logging.py
@@ -13,15 +13,19 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Consolidated run-log integration tests.
+"""Consolidated + per-step run-log integration tests (round 7 redesign).
 
-core/logging.py::setup_logging() was never called at runtime, so the root
-logger's WARNING default dropped every step's logger.info/error and the
-consolidated {out}_all_logs.log came out header-only. These tests run the real
-CLI and assert the consolidated log is actually populated with structured,
-step-tagged records.
+Exercise the real CLI and assert the round-7 logging contract:
+  * ``{out}_all_logs.log`` is a per-step-sectioned consolidated log: banner,
+    ``===== step =====`` headers, structured ``[step]`` records, the verbatim
+    harvested PLINK output inlined after each step's summary, and a final run
+    summary table;
+  * per-step raw ``{out}_{step}.log`` files carry the exact PLINK output and
+    persist even without ``--full_output``;
+  * the dead ``{out}_cleaned_logs.log`` is gone;
+  * the console (stderr) shows the concise curated stream, not the raw PLINK dump.
 
-They require PLINK2 and the synthetic test data; they skip cleanly otherwise.
+Requires PLINK2 and the synthetic test data; skips cleanly otherwise.
 """
 
 import subprocess
@@ -41,10 +45,7 @@ def _run_cli(args: list[str]) -> subprocess.CompletedProcess:
     )
 
 
-def test_run_log_contains_step_markers(test_geno_path: Path, tmp_path: Path) -> None:
-    """The consolidated {out}_all_logs.log must contain the steps' structured logs."""
-    out = tmp_path / "logtest"
-
+def _run_callrate_geno(test_geno_path: Path, out: Path) -> subprocess.CompletedProcess:
     res = _run_cli(
         [
             "--pfile", str(test_geno_path),
@@ -56,24 +57,80 @@ def test_run_log_contains_step_markers(test_geno_path: Path, tmp_path: Path) -> 
     assert res.returncode == 0, (
         f"Pipeline failed.\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
     )
+    return res
+
+
+def test_consolidated_log_is_sectioned_with_raw(test_geno_path: Path, tmp_path: Path) -> None:
+    """{out}_all_logs.log: banner, per-step sections, structured lines + raw PLINK."""
+    out = tmp_path / "logtest"
+    _run_callrate_geno(test_geno_path, out)
 
     all_logs = Path(f"{out}_all_logs.log")
     assert all_logs.exists(), "consolidated {out}_all_logs.log was not created"
-
     content = all_logs.read_text()
 
-    # The banner header alone is short; a populated log is materially longer.
-    header_only_len = 400
-    assert len(content) > header_only_len, (
-        "consolidated log looks header-only (structured step logs were dropped):\n"
-        f"{content!r}"
-    )
+    # Materially longer than a bare banner.
+    assert len(content) > 400, f"consolidated log looks header-only:\n{content!r}"
 
-    # Structured step-context markers written by core.logging.step_context.
+    # Per-step section headers.
+    assert "===== callrate =====" in content, "missing callrate section header"
+    assert "===== geno =====" in content, "missing geno section header"
+
+    # Structured, step-tagged records.
     assert "[callrate_prune]" in content, "no callrate step marker in run log"
     assert "[geno_prune]" in content, "no geno step marker in run log"
+    assert "filtering complete" in content.lower(), "step completion messages missing"
 
-    # Actual step messages emitted via logger.info must be present.
-    assert "filtering complete" in content.lower(), (
-        "step completion messages missing from run log"
+    # Verbatim harvested PLINK output inlined (raw source of truth).
+    assert "PLINK v" in content, "raw PLINK output not inlined in consolidated log"
+
+    # For each step, its structured summary precedes its raw PLINK block.
+    i_marker = content.index("[callrate_prune]")
+    i_raw = content.index("PLINK v")
+    assert i_marker < i_raw, "raw PLINK block should follow the structured summary"
+
+    # End-of-run summary table.
+    assert "run summary" in content.lower(), "missing run summary block"
+    assert "PASS" in content, "summary table missing pass/fail status"
+
+
+def test_per_step_raw_logs_persist(test_geno_path: Path, tmp_path: Path) -> None:
+    """Per-step {out}_{step}.log files carry raw PLINK output and persist (no --full_output)."""
+    out = tmp_path / "logtest"
+    _run_callrate_geno(test_geno_path, out)
+
+    callrate_raw = Path(f"{out}_callrate.log")
+    geno_raw = Path(f"{out}_geno.log")
+    assert callrate_raw.exists(), "per-step {out}_callrate.log missing"
+    assert geno_raw.exists(), "per-step {out}_geno.log missing"
+
+    callrate_text = callrate_raw.read_text()
+    assert "PLINK v" in callrate_text, "per-step raw log lacks PLINK output"
+    assert "--mind" in callrate_text, "per-step raw log lacks the invoked command"
+
+    # The per-step raw file is distinct from the consolidated log.
+    assert callrate_text != Path(f"{out}_all_logs.log").read_text()
+
+
+def test_cleaned_logs_is_gone(test_geno_path: Path, tmp_path: Path) -> None:
+    """The dead 0-byte {out}_cleaned_logs.log is no longer produced."""
+    out = tmp_path / "logtest"
+    _run_callrate_geno(test_geno_path, out)
+    assert not Path(f"{out}_cleaned_logs.log").exists(), (
+        "cleaned_logs.log should be removed in the round-7 redesign"
     )
+
+
+def test_console_is_curated_not_raw(test_geno_path: Path, tmp_path: Path) -> None:
+    """The console (stderr) shows the concise step-tagged stream, not raw PLINK."""
+    out = tmp_path / "logtest"
+    res = _run_callrate_geno(test_geno_path, out)
+
+    # Curated, step-tagged progress reaches the terminal.
+    assert "[callrate_prune]" in res.stderr, "curated step line missing from console"
+    assert "Run summary" in res.stderr, "run summary missing from console"
+
+    # The verbose raw PLINK dump stays file-only.
+    assert "PLINK v" not in res.stderr, "raw PLINK output leaked to the console"
+    # No full file-format timestamps on the console (concise formatter).
+    assert "genotools.qc.steps" not in res.stderr, "console used the full file format"

--- a/tests/regression/test_logging.py
+++ b/tests/regression/test_logging.py
@@ -134,3 +134,62 @@ def test_console_is_curated_not_raw(test_geno_path: Path, tmp_path: Path) -> Non
     assert "PLINK v" not in res.stderr, "raw PLINK output leaked to the console"
     # No full file-format timestamps on the console (concise formatter).
     assert "genotools.qc.steps" not in res.stderr, "console used the full file format"
+
+    # The verbose per-step path line (absolute temp-dir paths) is file-only.
+    assert "Running: callrate" not in res.stderr, (
+        "verbose step-path line leaked to the console"
+    )
+    assert "_tmp/" not in res.stderr, "temp-dir paths leaked to the console"
+    assert "Running: callrate" in Path(f"{out}_all_logs.log").read_text(), (
+        "verbose step-path line should still be in the consolidated log"
+    )
+
+
+def test_summary_not_duplicated_in_log(test_geno_path: Path, tmp_path: Path) -> None:
+    """The consolidated log renders the summary once (aligned table only)."""
+    out = tmp_path / "logtest"
+    _run_callrate_geno(test_geno_path, out)
+
+    content = Path(f"{out}_all_logs.log").read_text()
+    assert content.count("===== run summary =====") == 1
+    # The console-side rows ("  callrate: N removed [PASS]") are console_only, so
+    # the file holds exactly one row per step -- the table's.
+    assert content.count("removed   PASS") == 2, (
+        f"expected one table row per step, got:\n{content[-800:]}"
+    )
+    assert "Run summary:" not in content, "console summary header leaked into the log"
+
+
+def test_quiet_silences_console_but_keeps_logs(
+    test_geno_path: Path, tmp_path: Path
+) -> None:
+    """--quiet drops the console stream; the log files are still complete."""
+    out = tmp_path / "quiettest"
+    res = _run_cli(
+        ["--pfile", str(test_geno_path), "--out", str(out), "--callrate", "--geno", "--quiet"]
+    )
+    assert res.returncode == 0, f"Pipeline failed.\nSTDERR:\n{res.stderr}"
+
+    assert "[callrate_prune]" not in res.stderr, "--quiet still printed step lines"
+    assert "Run summary" not in res.stderr, "--quiet still printed the summary"
+
+    content = Path(f"{out}_all_logs.log").read_text()
+    assert "===== callrate =====" in content, "--quiet lost the consolidated log"
+    assert "[callrate_prune]" in content, "--quiet lost the structured records"
+    assert "PLINK v" in content, "--quiet lost the harvested raw output"
+    assert "run summary" in content.lower(), "--quiet lost the summary table"
+    assert Path(f"{out}_callrate.log").exists(), "--quiet lost the per-step raw log"
+
+
+def test_debug_adds_detail_to_log(test_geno_path: Path, tmp_path: Path) -> None:
+    """--debug is accepted and widens the log to DEBUG level."""
+    out = tmp_path / "debugtest"
+    res = _run_cli(
+        ["--pfile", str(test_geno_path), "--out", str(out), "--callrate", "--debug"]
+    )
+    assert res.returncode == 0, f"Pipeline failed.\nSTDERR:\n{res.stderr}"
+
+    content = Path(f"{out}_all_logs.log").read_text()
+    # The curated INFO contract still holds at DEBUG level.
+    assert "===== callrate =====" in content
+    assert "[callrate_prune]" in content

--- a/tests/unit/test_cli/test_parser.py
+++ b/tests/unit/test_cli/test_parser.py
@@ -215,6 +215,21 @@ class TestOutputArgs:
         assert args.full_output is False
         assert args.skip_fails is False
         assert args.warn_only is True
+        # Verbosity: curated console on, INFO level.
+        assert args.quiet is False
+        assert args.debug is False
+
+    def test_verbosity_flags_parse(self) -> None:
+        """--quiet / --debug reach OutputArgs (defaults are off)."""
+        default = parse_args(["--pfile", "/data/test", "--out", "/output/test"])
+        assert default.output.quiet is False
+        assert default.output.debug is False
+
+        verbose = parse_args(
+            ["--pfile", "/data/test", "--out", "/output/test", "--quiet", "--debug"]
+        )
+        assert verbose.output.quiet is True
+        assert verbose.output.debug is True
 
 
 class TestPipelineArgs:

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List
 
 import pytest
 
-from genotools.core.exceptions import QCError
+from genotools.core.exceptions import QCError, ValidationError
 from genotools.cli.parser import InputArgs, OutputArgs, PipelineArgs
 from genotools.cli.runner import PipelineRunner, PipelineState
 
@@ -585,8 +585,41 @@ class TestPreflightFailureDoesNotPoisonPrefix:
         # out to isolate the "no steps" raise path.
         runner._convert_input_format = lambda: None  # type: ignore[method-assign]
 
-        with pytest.raises(ValueError, match="No QC steps"):
+        # A GenoToolsError subclass, so main() renders it as a message not a
+        # traceback (ValidationError is not a ValueError).
+        with pytest.raises(ValidationError, match="No QC steps"):
             runner.run()
 
         assert not Path(f"{out}_all_logs.log").exists()
+        assert raw_sink.get() is None
+
+    def test_preflight_failure_restores_a_rotated_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed re-run leaves the directory exactly as it found it.
+
+        With --skip-fails the guard is bypassed, so setup rotates the prior log
+        aside; if the run then dies in pre-flight, the fresh log is removed AND
+        the rotation is undone -- otherwise the prior log would be orphaned under
+        a .1 suffix.
+        """
+        from genotools.core.logging import raw_sink
+
+        geno = tmp_path / "geno"
+        out = tmp_path / "out"
+        _touch_pfiles(geno)
+        Path(f"{out}_all_logs.log").write_text("PRIOR RUN CONTENT\n")
+
+        args = PipelineArgs(
+            input=InputArgs(pfile=geno),
+            output=OutputArgs(out_path=out, full_output=True, skip_fails=True),
+        )
+        runner = PipelineRunner(args)
+        runner._convert_input_format = lambda: None  # type: ignore[method-assign]
+
+        with pytest.raises(ValidationError, match="No QC steps"):
+            runner.run()
+
+        assert Path(f"{out}_all_logs.log").read_text() == "PRIOR RUN CONTENT\n"
+        assert not Path(f"{out}_all_logs.log.1").exists()
         assert raw_sink.get() is None

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -475,6 +475,64 @@ class TestRunSummary:
         # Also surfaced as log records (→ console).
         assert any("Run summary" in r.getMessage() for r in captured)
 
+        # The summary is rendered ONCE on disk: the console rows are marked
+        # console_only so they don't duplicate the RunLog's aligned table.
+        assert content.count("7 removed") == 2, (  # one row per step, no duplicates
+            f"summary rows duplicated in the consolidated log:\n{content}"
+        )
+        assert "Run summary:" not in content, (
+            "console summary header leaked into the consolidated log"
+        )
+
+    def test_step_paths_are_logged_to_file_not_console(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The verbose "Running: <step> with input ..." line is file-only.
+
+        It carries absolute temp-dir paths that are essential when debugging but
+        pure noise on the curated console.
+        """
+        import logging as _logging
+        from genotools.core.logging import raw_sink
+
+        runner, geno, out = _make_runner(tmp_path, warn_only=False)
+        runner._setup_logging()
+
+        console_messages: List[str] = []
+
+        class _ConsoleCapture(_logging.Handler):
+            """Mimics the console handler, including its file_only filter."""
+
+            def emit(self, record):
+                if not getattr(record, "file_only", False):
+                    console_messages.append(record.getMessage())
+
+        cap = _ConsoleCapture()
+        _logging.getLogger("genotools").addHandler(cap)
+
+        def fake_single_step(step, step_input, step_output, legacy_args):
+            _touch_pfiles(Path(step_output))
+            return {"pass": True, "step": step, "metrics": {}, "output": {}}
+
+        monkeypatch.setattr(runner, "_run_single_step", fake_single_step)
+        try:
+            runner._run_qc_pipeline(
+                steps=["callrate"], geno_path=str(geno), out_path=str(out)
+            )
+        finally:
+            _logging.getLogger("genotools").removeHandler(cap)
+            if runner._runlog is not None:
+                runner._runlog.close()
+            raw_sink.set(None)
+
+        assert not any("Running: callrate" in m for m in console_messages), (
+            f"verbose step-path line leaked to the console: {console_messages}"
+        )
+        # But it is preserved in the consolidated log, with the full paths.
+        content = Path(f"{out}_all_logs.log").read_text()
+        assert "Running: callrate" in content
+        assert str(out) in content
+
 
 class TestPreflightFailureDoesNotPoisonPrefix:
     """Round 7 fix: logging is set up before validate_input so the breakdown is

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -362,3 +362,115 @@ class TestValidationDecisionsApplied:
         monkeypatch.setattr(runner, "_run_single_step", fake_single_step)
         runner._run_qc_pipeline(steps=["hwe"], geno_path=str(geno), out_path=str(out))
         assert captured["filter_controls"] is False
+
+
+class TestSetupLoggingArtifacts:
+    """Round 7: _setup_logging installs a RunLog and no longer creates the dead
+    cleaned_logs.log."""
+
+    def test_installs_runlog_and_no_cleaned_logs(self, tmp_path: Path) -> None:
+        from genotools.core.logging import raw_sink
+
+        runner, geno, out = _make_runner(tmp_path, warn_only=False)
+        try:
+            runner._setup_logging()
+            assert runner._runlog is not None
+            assert Path(f"{out}_all_logs.log").exists()
+            # The banner header is written at install time.
+            assert Path(f"{out}_all_logs.log").read_text().strip() != ""
+            # The dead 0-byte cleaned_logs.log is gone for good.
+            assert not Path(f"{out}_cleaned_logs.log").exists()
+        finally:
+            if runner._runlog is not None:
+                runner._runlog.close()
+            raw_sink.set(None)
+
+
+class TestRerunGuardRunsBeforeLogging:
+    """Round 7: the re-run guard is a standalone pre-check that runs BEFORE
+    logging setup truncates/creates the consolidated log."""
+
+    def test_run_raises_and_preserves_existing_log(self, tmp_path: Path) -> None:
+        from genotools.core.exceptions import ValidationError
+
+        geno = tmp_path / "geno"
+        out = tmp_path / "out"
+        _touch_pfiles(geno)
+        # A prior run's consolidated log exists.
+        Path(f"{out}_all_logs.log").write_text("PRIOR RUN MARKER\n")
+
+        args = PipelineArgs(
+            input=InputArgs(pfile=geno),
+            output=OutputArgs(out_path=out, warn_only=False, full_output=True),
+        )
+        # Enable a step so run() has work; the guard should fire first regardless.
+        args.sample_qc.run_callrate = True
+        runner = PipelineRunner(args)
+
+        with pytest.raises(ValidationError):
+            runner.run()
+
+        # Guard ran before install_run_logging => the existing log was NOT
+        # truncated/overwritten with a fresh banner.
+        assert "PRIOR RUN MARKER" in Path(f"{out}_all_logs.log").read_text()
+
+
+class TestNoPrintInRunnerSource:
+    """Round 7: the four runtime print() calls are migrated to logging."""
+
+    def test_no_print_calls_left(self) -> None:
+        import genotools.cli.runner as runner_mod
+
+        source = Path(runner_mod.__file__).read_text()
+        assert "print(" not in source, "runner.py must route all output through logging"
+
+
+class TestRunSummary:
+    """Round 7: end-of-run summary table reaches the console and consolidated log."""
+
+    def test_summary_written_to_log_and_records(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import logging as _logging
+        from genotools.core.logging import raw_sink
+
+        runner, geno, out = _make_runner(tmp_path, warn_only=False)
+        runner._setup_logging()
+
+        # Capture the curated console stream directly off the genotools logger
+        # (install_run_logging sets propagate=False, so caplog's root handler
+        # would miss these records).
+        captured: List[_logging.LogRecord] = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        cap = _Capture()
+        _logging.getLogger("genotools").addHandler(cap)
+
+        def fake_single_step(step, step_input, step_output, legacy_args):
+            _touch_pfiles(Path(step_output))
+            return {
+                "pass": True, "step": step,
+                "metrics": {"outlier_count": 7}, "output": {},
+            }
+
+        monkeypatch.setattr(runner, "_run_single_step", fake_single_step)
+        try:
+            runner._run_qc_pipeline(
+                steps=["callrate", "geno"], geno_path=str(geno), out_path=str(out)
+            )
+            runner._emit_run_summary()
+        finally:
+            _logging.getLogger("genotools").removeHandler(cap)
+            if runner._runlog is not None:
+                runner._runlog.close()
+            raw_sink.set(None)
+
+        content = Path(f"{out}_all_logs.log").read_text()
+        assert "run summary" in content.lower()
+        assert "callrate" in content and "geno" in content
+        assert "7 removed" in content and "PASS" in content
+        # Also surfaced as log records (→ console).
+        assert any("Run summary" in r.getMessage() for r in captured)

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -474,3 +474,61 @@ class TestRunSummary:
         assert "7 removed" in content and "PASS" in content
         # Also surfaced as log records (→ console).
         assert any("Run summary" in r.getMessage() for r in captured)
+
+
+class TestPreflightFailureDoesNotPoisonPrefix:
+    """Round 7 fix: logging is set up before validate_input so the breakdown is
+    captured, but a pre-flight failure (bad input / no steps) must remove the
+    freshly-created log so the output prefix isn't blocked on the next run."""
+
+    def test_validation_failure_removes_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from genotools.core.exceptions import ValidationError
+        from genotools.core.logging import raw_sink
+
+        geno = tmp_path / "geno"
+        out = tmp_path / "out"
+        _touch_pfiles(geno)
+        args = PipelineArgs(
+            input=InputArgs(pfile=geno),
+            output=OutputArgs(out_path=out, full_output=True),
+        )
+        args.sample_qc.run_callrate = True
+        runner = PipelineRunner(args)
+
+        def boom() -> None:
+            raise ValidationError("bad input")
+
+        monkeypatch.setattr(runner, "_convert_input_format", boom)
+
+        with pytest.raises(ValidationError):
+            runner.run()
+
+        # The consolidated log created just before validation must be cleaned up,
+        # so a corrected re-run over the same --out is not blocked by the guard.
+        assert not Path(f"{out}_all_logs.log").exists()
+        assert runner._runlog is None
+        assert raw_sink.get() is None
+
+    def test_no_steps_failure_removes_log(self, tmp_path: Path) -> None:
+        from genotools.core.logging import raw_sink
+
+        geno = tmp_path / "geno"
+        out = tmp_path / "out"
+        _touch_pfiles(geno)
+        args = PipelineArgs(
+            input=InputArgs(pfile=geno),
+            output=OutputArgs(out_path=out, full_output=True),
+        )
+        runner = PipelineRunner(args)
+        # No QC steps and no ancestry requested; _convert_input_format is a no-op
+        # for already-pfile input with a touched (empty) psam/pvar, so patch it
+        # out to isolate the "no steps" raise path.
+        runner._convert_input_format = lambda: None  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match="No QC steps"):
+            runner.run()
+
+        assert not Path(f"{out}_all_logs.log").exists()
+        assert raw_sink.get() is None

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,5 +1,6 @@
 """Unit tests for genotools.core module."""
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from genotools.core import (
     BaseConfig,
     ThresholdConfig,
 )
+from genotools.core.logging import RunLog, install_run_logging, raw_sink
 
 
 class TestExceptions:
@@ -95,6 +97,106 @@ class TestLogging:
         logger = get_logger(__name__)
         assert logger is not None
         assert "genotools" in logger.name
+
+
+def _info_record(msg: str, step: str = "") -> logging.LogRecord:
+    """Build an INFO LogRecord with an optional bracketed step tag."""
+    rec = logging.LogRecord(
+        name="genotools.test", level=logging.INFO, pathname=__file__,
+        lineno=1, msg=msg, args=(), exc_info=None,
+    )
+    rec.step = f"[{step}]" if step else ""
+    return rec
+
+
+class TestRunLog:
+    """Tests for the consolidated-log RunLog writer (round 7)."""
+
+    def test_banner_header_structured_then_raw_order(self, tmp_path: Path):
+        """Within a section: header, then structured lines, then buffered raw."""
+        log_path = tmp_path / "out_all_logs.log"
+        rl = RunLog(log_path)
+        rl.write_banner()
+        rl.begin_section("callrate_prune")
+        rl.write_record(_info_record("Filtering samples (mind=0.02)", "callrate_prune"))
+        rl.write_record(_info_record("filtering complete: 5 removed", "callrate_prune"))
+        rl.append_raw("plink2 --geno --out x", "PLINK log line: 5 samples removed.")
+        rl.end_section(None)
+        rl.close()
+
+        content = log_path.read_text()
+        # Banner present.
+        assert "GENOTOOLS" in content or "██" in content
+        # Section header present.
+        i_header = content.index("===== callrate_prune =====")
+        # Structured lines present and after header.
+        i_struct = content.index("filtering complete: 5 removed")
+        # Raw present and AFTER the structured summary.
+        i_raw = content.index("PLINK log line: 5 samples removed.")
+        assert i_header < i_struct < i_raw
+        # Structured line carries the step tag.
+        assert "[callrate_prune]" in content
+
+    def test_end_section_writes_per_step_raw_file(self, tmp_path: Path):
+        """end_section(raw_path) writes the buffered raw to a per-step file too."""
+        log_path = tmp_path / "out_all_logs.log"
+        raw_path = tmp_path / "out_callrate.log"
+        rl = RunLog(log_path)
+        rl.begin_section("callrate_prune")
+        rl.append_raw("plink2 --out x", "raw plink content here")
+        rl.end_section(raw_path)
+        rl.close()
+
+        assert raw_path.exists()
+        assert "raw plink content here" in raw_path.read_text()
+        # Consolidated also contains it.
+        assert "raw plink content here" in log_path.read_text()
+
+    def test_append_raw_buffers_until_end_section(self, tmp_path: Path):
+        """append_raw does not hit disk until end_section flushes it."""
+        log_path = tmp_path / "out_all_logs.log"
+        rl = RunLog(log_path)
+        rl.begin_section("geno_prune")
+        rl.append_raw("plink2 --out x", "DEFERRED_RAW_MARKER")
+        # Not flushed yet.
+        assert "DEFERRED_RAW_MARKER" not in log_path.read_text()
+        rl.end_section(None)
+        assert "DEFERRED_RAW_MARKER" in log_path.read_text()
+        rl.close()
+
+    def test_write_summary_appends_block(self, tmp_path: Path):
+        """write_summary appends a recognizable summary block at the tail."""
+        log_path = tmp_path / "out_all_logs.log"
+        rl = RunLog(log_path)
+        rl.write_banner()
+        rl.write_summary([("callrate_prune", 5, True), ("geno_prune", 112, True)])
+        rl.close()
+        content = log_path.read_text()
+        assert "summary" in content.lower()
+        assert "callrate_prune" in content
+        assert "112" in content
+
+    def test_close_is_idempotent(self, tmp_path: Path):
+        """Double close does not raise."""
+        rl = RunLog(tmp_path / "out_all_logs.log")
+        rl.close()
+        rl.close()
+
+    def test_install_run_logging_sets_sink_and_banner(self, tmp_path: Path):
+        """install_run_logging writes the banner and registers the raw sink."""
+        out = tmp_path / "out"
+        rl = install_run_logging(str(out), console=False)
+        try:
+            assert raw_sink.get() is rl
+            assert Path(f"{out}_all_logs.log").exists()
+            # A genotools logger record now flows into the consolidated log.
+            get_logger("genotools.test").info("hello from a step")
+            for h in logging.getLogger("genotools").handlers:
+                h.flush()
+            assert "hello from a step" in Path(f"{out}_all_logs.log").read_text()
+        finally:
+            rl.close()
+            raw_sink.set(None)
 
 
 class TestGenotypeData:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -199,6 +199,150 @@ class TestRunLog:
             raw_sink.set(None)
 
 
+class TestRunLogRotation:
+    """A re-run must never silently destroy the previous run's log.
+
+    The re-run guard normally blocks a second run on the same prefix, but
+    ``--skip-fails`` bypasses it -- so RunLog rotates an existing log aside
+    instead of truncating it.
+    """
+
+    def test_existing_log_is_rotated_not_truncated(self, tmp_path: Path):
+        log_path = tmp_path / "out_all_logs.log"
+        log_path.write_text("PRIOR RUN CONTENT\n")
+
+        rl = RunLog(log_path)
+        try:
+            assert rl.rotated_from == tmp_path / "out_all_logs.log.1"
+            assert rl.rotated_from.read_text() == "PRIOR RUN CONTENT\n"
+            # The new log starts clean.
+            rl.write_banner()
+            assert "PRIOR RUN CONTENT" not in log_path.read_text()
+        finally:
+            rl.close()
+
+    def test_rotation_picks_next_free_index(self, tmp_path: Path):
+        log_path = tmp_path / "out_all_logs.log"
+        log_path.write_text("run 2\n")
+        (tmp_path / "out_all_logs.log.1").write_text("run 1\n")
+
+        rl = RunLog(log_path)
+        try:
+            assert rl.rotated_from == tmp_path / "out_all_logs.log.2"
+            # The older rotation is untouched.
+            assert (tmp_path / "out_all_logs.log.1").read_text() == "run 1\n"
+            assert (tmp_path / "out_all_logs.log.2").read_text() == "run 2\n"
+        finally:
+            rl.close()
+
+    def test_no_rotation_when_no_existing_log(self, tmp_path: Path):
+        rl = RunLog(tmp_path / "out_all_logs.log")
+        try:
+            assert rl.rotated_from is None
+            assert not (tmp_path / "out_all_logs.log.1").exists()
+        finally:
+            rl.close()
+
+    def test_rotate_existing_false_truncates(self, tmp_path: Path):
+        """Opt-out for callers that explicitly want a clobber."""
+        log_path = tmp_path / "out_all_logs.log"
+        log_path.write_text("PRIOR\n")
+        rl = RunLog(log_path, rotate_existing=False)
+        try:
+            assert rl.rotated_from is None
+            assert not (tmp_path / "out_all_logs.log.1").exists()
+            assert log_path.read_text() == ""
+        finally:
+            rl.close()
+
+    def test_restore_rotated_puts_the_log_back(self, tmp_path: Path):
+        """Pre-flight failure: the fresh log is removed, the prior one restored."""
+        log_path = tmp_path / "out_all_logs.log"
+        log_path.write_text("PRIOR RUN CONTENT\n")
+
+        rl = RunLog(log_path)
+        rl.write_banner()
+        rl.close()
+        log_path.unlink()  # what _teardown_logging(remove_logs=True) does
+        rl.restore_rotated()
+
+        assert log_path.read_text() == "PRIOR RUN CONTENT\n"
+        assert not (tmp_path / "out_all_logs.log.1").exists()
+        # Idempotent.
+        rl.restore_rotated()
+
+    def test_install_run_logging_announces_rotation(self, tmp_path: Path):
+        out = tmp_path / "out"
+        Path(f"{out}_all_logs.log").write_text("PRIOR\n")
+
+        rl = install_run_logging(str(out), console=False)
+        try:
+            assert rl.rotated_from is not None
+            # The notice reaches the new log (handlers are installed first).
+            content = Path(f"{out}_all_logs.log").read_text()
+            assert "out_all_logs.log.1" in content
+            assert "WARNING" in content
+        finally:
+            rl.close()
+            raw_sink.set(None)
+
+
+class TestSetupLoggingLibraryPath:
+    """``setup_logging`` is the library/embedded entry point (no RunLog).
+
+    It shares :func:`_reset_genotools_logger` with ``install_run_logging``, so
+    both configure the ``genotools`` logger identically; it deliberately does
+    *not* register a raw sink or write sections.
+    """
+
+    def test_writes_step_tagged_records_to_file(self, tmp_path: Path):
+        from genotools.core.logging import setup_logging
+
+        log_file = tmp_path / "library.log"
+        setup_logging(level="INFO", log_file=log_file, console=False)
+        try:
+            with step_context("callrate_prune"):
+                get_logger("genotools.test").info("library-mode message")
+            for h in logging.getLogger("genotools").handlers:
+                h.flush()
+
+            content = log_file.read_text()
+            assert "library-mode message" in content
+            assert "[callrate_prune]" in content, "step context not applied"
+            assert "[INFO]" in content
+        finally:
+            logging.getLogger("genotools").handlers.clear()
+
+    def test_does_not_register_raw_sink(self, tmp_path: Path):
+        """No RunLog => the executor's harvest stays a no-op for library callers."""
+        from genotools.core.logging import setup_logging
+
+        setup_logging(level="INFO", log_file=tmp_path / "library.log", console=False)
+        try:
+            assert raw_sink.get() is None
+        finally:
+            logging.getLogger("genotools").handlers.clear()
+
+    def test_shares_logger_reset_with_install_run_logging(self, tmp_path: Path):
+        """Either entry point replaces the other's handlers, and kills propagation."""
+        from genotools.core.logging import _RunLogHandler, setup_logging
+
+        logger = logging.getLogger("genotools")
+
+        rl = install_run_logging(str(tmp_path / "out"), console=False)
+        try:
+            assert [type(h) for h in logger.handlers] == [_RunLogHandler]
+
+            setup_logging(log_file=tmp_path / "library.log", console=False)
+            # The RunLog handler is gone, replaced by the plain file handler.
+            assert [type(h) for h in logger.handlers] == [logging.FileHandler]
+            assert logger.propagate is False
+        finally:
+            logger.handlers.clear()
+            rl.close()
+            raw_sink.set(None)
+
+
 class TestLogRoutingMarkers:
     """``extra`` markers that send a record to one destination only.
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -486,29 +486,39 @@ class TestValidation:
     def geno(self) -> Path:
         return Path("tests/data/synthetic/genotools_test")
 
-    def test_passes_on_valid_input(self, geno: Path, tmp_path: Path, capsys):
+    def test_passes_on_valid_input(self, geno: Path, tmp_path: Path, caplog):
         from genotools.core.validation import validate_input
-        validate_input(geno, tmp_path / "out", skip_fails=False)  # no raise
-        out = capsys.readouterr().out
-        assert "breakdown" in out.lower()
+        with caplog.at_level(logging.INFO, logger="genotools"):
+            validate_input(geno, tmp_path / "out", skip_fails=False)  # no raise
+        # Breakdown is logged (not printed) now.
+        assert any("breakdown" in r.message.lower() for r in caplog.records)
 
     def test_raises_on_missing_pgen(self, tmp_path: Path):
         from genotools.core.validation import validate_input
         with pytest.raises(FileNotFoundError):
             validate_input(tmp_path / "nope", tmp_path / "out", skip_fails=False)
 
-    def test_raises_when_log_exists(self, geno: Path, tmp_path: Path):
+    def test_validate_input_does_not_guard_existing_log(self, geno: Path, tmp_path: Path):
+        """The re-run guard moved out of validate_input; it no longer raises here."""
         from genotools.core.validation import validate_input
-        from genotools.core.exceptions import ValidationError
-        log = tmp_path / "out_all_logs.log"
-        log.write_text("prior run\n")
-        with pytest.raises(ValidationError):
-            validate_input(geno, tmp_path / "out", skip_fails=False)
+        (tmp_path / "out_all_logs.log").write_text("prior run\n")
+        validate_input(geno, tmp_path / "out", skip_fails=False)  # no raise
 
-    def test_skip_fails_ignores_existing_log(self, geno: Path, tmp_path: Path):
-        from genotools.core.validation import validate_input
+    def test_guard_raises_when_log_exists(self, geno: Path, tmp_path: Path):
+        from genotools.core.validation import guard_output_not_exists
+        from genotools.core.exceptions import ValidationError
+        (tmp_path / "out_all_logs.log").write_text("prior run\n")
+        with pytest.raises(ValidationError):
+            guard_output_not_exists(tmp_path / "out", skip_fails=False)
+
+    def test_guard_skip_fails_ignores_existing_log(self, tmp_path: Path):
+        from genotools.core.validation import guard_output_not_exists
         (tmp_path / "out_all_logs.log").write_text("prior\n")
-        validate_input(geno, tmp_path / "out", skip_fails=True)  # no raise
+        guard_output_not_exists(tmp_path / "out", skip_fails=True)  # no raise
+
+    def test_guard_passes_when_no_log(self, tmp_path: Path):
+        from genotools.core.validation import guard_output_not_exists
+        guard_output_not_exists(tmp_path / "fresh", skip_fails=False)  # no raise
 
     def test_raises_on_missing_sex_column(self, geno: Path, tmp_path: Path):
         from genotools.core.validation import validate_input
@@ -591,12 +601,19 @@ class TestValidation:
         d = validate_input(bad, tmp_path / "o4", case_control_requested=True)
         assert d.skip_case_control is True
 
-    def test_skip_het_when_few_variants(self, geno: Path, tmp_path: Path):
+    def test_skip_het_when_few_variants(self, geno: Path, tmp_path: Path, recwarn, caplog):
         from genotools.core.validation import validate_input
         bad = tmp_path / "fewvar"
         self._pfile_with(geno, bad, pvar_rows=40)  # < 50 variants
-        d = validate_input(bad, tmp_path / "o5", het_requested=True)
+        with caplog.at_level(logging.WARNING, logger="genotools"):
+            d = validate_input(bad, tmp_path / "o5", het_requested=True)
         assert d.skip_het is True
+        # Skip decisions are logged as warnings now, not emitted via warnings.warn.
+        assert any(
+            r.levelno == logging.WARNING and "het prune" in r.message.lower()
+            for r in caplog.records
+        )
+        assert not any("het prune" in str(w.message).lower() for w in recwarn.list)
 
     def test_no_decisions_when_skip_fails(self, geno: Path, tmp_path: Path):
         import pandas as pd

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -199,6 +199,91 @@ class TestRunLog:
             raw_sink.set(None)
 
 
+class TestLogRoutingMarkers:
+    """``extra`` markers that send a record to one destination only.
+
+    ``file_only`` keeps verbose detail (absolute temp paths) off the console;
+    ``console_only`` keeps content the RunLog renders itself (the summary table)
+    from being duplicated into the consolidated log.
+    """
+
+    def test_file_only_record_skips_console(self, tmp_path: Path, capsys):
+        out = tmp_path / "out"
+        rl = install_run_logging(str(out), console=True)
+        try:
+            logger = get_logger("genotools.test")
+            logger.info("VERBOSE_PATH_DETAIL", extra={"file_only": True})
+            logger.info("CURATED_LINE")
+            for h in logging.getLogger("genotools").handlers:
+                h.flush()
+
+            console = capsys.readouterr().err
+            log_text = Path(f"{out}_all_logs.log").read_text()
+
+            assert "VERBOSE_PATH_DETAIL" not in console
+            assert "VERBOSE_PATH_DETAIL" in log_text
+            # A normal record still reaches both.
+            assert "CURATED_LINE" in console and "CURATED_LINE" in log_text
+        finally:
+            rl.close()
+            raw_sink.set(None)
+
+    def test_console_only_record_skips_consolidated_log(self, tmp_path: Path, capsys):
+        out = tmp_path / "out"
+        rl = install_run_logging(str(out), console=True)
+        try:
+            get_logger("genotools.test").info(
+                "SUMMARY_ROW", extra={"console_only": True}
+            )
+            for h in logging.getLogger("genotools").handlers:
+                h.flush()
+
+            assert "SUMMARY_ROW" in capsys.readouterr().err
+            assert "SUMMARY_ROW" not in Path(f"{out}_all_logs.log").read_text()
+        finally:
+            rl.close()
+            raw_sink.set(None)
+
+    def test_console_false_still_writes_log_file(self, tmp_path: Path, capsys):
+        """``--quiet`` (console=False) keeps the on-disk log complete."""
+        out = tmp_path / "out"
+        rl = install_run_logging(str(out), console=False)
+        try:
+            get_logger("genotools.test").info("QUIET_MODE_RECORD")
+            for h in logging.getLogger("genotools").handlers:
+                h.flush()
+
+            assert "QUIET_MODE_RECORD" not in capsys.readouterr().err
+            assert "QUIET_MODE_RECORD" in Path(f"{out}_all_logs.log").read_text()
+        finally:
+            rl.close()
+            raw_sink.set(None)
+
+    def test_debug_level_captures_debug_records(self, tmp_path: Path):
+        """``--debug`` (level=DEBUG) lets DEBUG records through; INFO does not."""
+        out_debug = tmp_path / "dbg"
+        rl = install_run_logging(str(out_debug), level="DEBUG", console=False)
+        try:
+            get_logger("genotools.test").debug("DEBUG_DETAIL")
+            for h in logging.getLogger("genotools").handlers:
+                h.flush()
+            assert "DEBUG_DETAIL" in Path(f"{out_debug}_all_logs.log").read_text()
+        finally:
+            rl.close()
+            raw_sink.set(None)
+
+        out_info = tmp_path / "inf"
+        rl = install_run_logging(str(out_info), level="INFO", console=False)
+        try:
+            get_logger("genotools.test").debug("DEBUG_DETAIL")
+            for h in logging.getLogger("genotools").handlers:
+                h.flush()
+            assert "DEBUG_DETAIL" not in Path(f"{out_info}_all_logs.log").read_text()
+        finally:
+            rl.close()
+            raw_sink.set(None)
+
+
 class TestGenotypeData:
     """Tests for GenotypeData class."""
 

--- a/tests/unit/test_executors.py
+++ b/tests/unit/test_executors.py
@@ -1,0 +1,83 @@
+"""Unit tests for the executor raw-log harvest (round 7)."""
+
+from pathlib import Path
+
+import pytest
+
+from genotools.core.executors import _harvest_raw_log
+from genotools.core.logging import raw_sink
+
+
+class _FakeSink:
+    """Captures append_raw calls in place of a RunLog."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def append_raw(self, command: str, text: str) -> None:
+        self.calls.append((command, text))
+
+
+@pytest.fixture
+def sink():
+    s = _FakeSink()
+    token = raw_sink.set(s)  # type: ignore[arg-type]
+    try:
+        yield s
+    finally:
+        raw_sink.reset(token)
+
+
+def test_harvest_reads_out_log(tmp_path: Path, sink: _FakeSink):
+    """--out <prefix> => reads <prefix>.log and hands text to the sink."""
+    prefix = tmp_path / "step_output"
+    Path(f"{prefix}.log").write_text("PLINK2 v2.0\n112 variants removed.\n")
+
+    cmd = ["plink2", "--pfile", "in", "--geno", "0.02", "--out", str(prefix)]
+    _harvest_raw_log(cmd, " ".join(cmd))
+
+    assert len(sink.calls) == 1
+    command, text = sink.calls[0]
+    assert "112 variants removed." in text
+    assert "--out" in command
+
+
+def test_harvest_reads_prefix_log_for_king(tmp_path: Path, sink: _FakeSink):
+    """KING uses --prefix; harvest reads <prefix>.log too."""
+    prefix = tmp_path / "king_out"
+    Path(f"{prefix}.log").write_text("KING relatedness output\n")
+
+    cmd = ["king", "-b", "x.bed", "--prefix", str(prefix)]
+    _harvest_raw_log(cmd, " ".join(cmd))
+
+    assert len(sink.calls) == 1
+    assert "KING relatedness output" in sink.calls[0][1]
+
+
+def test_harvest_noop_when_no_log_file(tmp_path: Path, sink: _FakeSink):
+    """No .log on disk => nothing handed to the sink, no error."""
+    cmd = ["plink2", "--out", str(tmp_path / "missing")]
+    _harvest_raw_log(cmd, " ".join(cmd))
+    assert sink.calls == []
+
+
+def test_harvest_noop_when_no_out_flag(tmp_path: Path, sink: _FakeSink):
+    """No --out/--prefix (e.g. --version) => no-op."""
+    _harvest_raw_log(["plink2", "--version"], "plink2 --version")
+    assert sink.calls == []
+
+
+def test_harvest_noop_without_sink(tmp_path: Path):
+    """Unset sink => harvesting is a silent no-op (no raise)."""
+    prefix = tmp_path / "s"
+    Path(f"{prefix}.log").write_text("some log")
+    # raw_sink defaults to None here (no fixture).
+    _harvest_raw_log(["plink2", "--out", str(prefix)], "cmd")  # must not raise
+
+
+def test_harvest_never_raises_on_bad_read(tmp_path: Path, sink: _FakeSink):
+    """A directory at the .log path (unreadable) must not propagate."""
+    prefix = tmp_path / "d"
+    Path(f"{prefix}.log").mkdir()  # reading this as a file fails
+    _harvest_raw_log(["plink2", "--out", str(prefix)], "cmd")  # must not raise
+    assert sink.calls == []

--- a/tests/unit/test_executors.py
+++ b/tests/unit/test_executors.py
@@ -42,6 +42,36 @@ def test_harvest_reads_out_log(tmp_path: Path, sink: _FakeSink):
     assert "--out" in command
 
 
+def test_harvest_removes_the_file_it_consumed(tmp_path: Path, sink: _FakeSink):
+    """Harvested content lives in the run log, so the stray {prefix}.log goes.
+
+    Otherwise every invocation writing to a persistent prefix (the final QC step,
+    each per-ancestry group) leaves a {out}.log beside the real outputs that
+    duplicates {out}_{step}.log under a confusing name.
+    """
+    prefix = tmp_path / "step_output"
+    log_path = Path(f"{prefix}.log")
+    log_path.write_text("PLINK2 v2.0\n112 variants removed.\n")
+
+    _harvest_raw_log(["plink2", "--out", str(prefix)], "cmd")
+
+    assert len(sink.calls) == 1, "content must be captured before removal"
+    assert "112 variants removed." in sink.calls[0][1]
+    assert not log_path.exists(), "harvested log should not be left behind"
+
+
+def test_harvest_keeps_log_when_no_sink(tmp_path: Path):
+    """Library/unit callers have no sink, so their tool logs must be untouched."""
+    prefix = tmp_path / "library_run"
+    log_path = Path(f"{prefix}.log")
+    log_path.write_text("some log")
+
+    _harvest_raw_log(["plink2", "--out", str(prefix)], "cmd")
+
+    assert log_path.exists(), "harvest must not delete logs it did not consume"
+    assert log_path.read_text() == "some log"
+
+
 def test_harvest_reads_prefix_log_for_king(tmp_path: Path, sink: _FakeSink):
     """KING uses --prefix; harvest reads <prefix>.log too."""
     prefix = tmp_path / "king_out"

--- a/tests/unit/test_logging_hygiene.py
+++ b/tests/unit/test_logging_hygiene.py
@@ -1,0 +1,57 @@
+"""Static hygiene checks for the round-7 logging redesign.
+
+Locks two invariants across the pipeline-path modules:
+  * they bind the shared ``get_logger`` (not the bare ``logging.getLogger``), so
+    every record lands under the ``genotools`` namespace and reaches the RunLog;
+  * they route user-facing output through logging, not ``print()``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import genotools
+
+GENOTOOLS_DIR = Path(genotools.__file__).resolve().parent
+
+# Modules on the pipeline path that were standardized in round 7.
+PIPELINE_MODULES = [
+    "cli/runner.py",
+    "core/validation.py",
+    "core/executors.py",
+    "ancestry/model.py",
+    "ancestry/preprocessing.py",
+    "gwas/steps/association.py",
+    "gwas/steps/pca.py",
+    "gwas/pipeline.py",
+    "qc/steps/heterozygosity.py",
+    "qc/steps/case_control.py",
+    "qc/steps/sex.py",
+    "qc/steps/ld_prune.py",
+    "qc/steps/hwe.py",
+    "qc/steps/relatedness.py",
+    "qc/steps/haplotype.py",
+    "qc/steps/variant_missingness.py",
+    "qc/steps/callrate.py",
+]
+
+
+@pytest.mark.parametrize("rel", PIPELINE_MODULES)
+def test_no_bare_getlogger(rel: str) -> None:
+    src = (GENOTOOLS_DIR / rel).read_text()
+    assert "logging.getLogger(" not in src, (
+        f"{rel} should bind get_logger(__name__), not logging.getLogger"
+    )
+
+
+@pytest.mark.parametrize("rel", ["cli/runner.py", "core/validation.py"])
+def test_no_print_calls(rel: str) -> None:
+    """The runner and validation route everything through logging now."""
+    src = (GENOTOOLS_DIR / rel).read_text()
+    assert "print(" not in src, f"{rel} must not use print()"
+
+
+def test_preprocessing_binds_get_logger() -> None:
+    src = (GENOTOOLS_DIR / "ancestry/preprocessing.py").read_text()
+    assert "from genotools.core.logging import get_logger" in src
+    assert "logger = get_logger(__name__)" in src


### PR DESCRIPTION
## Summary

Round 7 of the refactor: make each pipeline step's behavior clearly visible, on the terminal during a run and on disk afterwards. Resolves tracker item #0 (the 6.5/10 logging audit: raw PLINK output dropped from disk, a dead 0-byte `cleaned_logs.log`, and three uncoordinated `print`/`logging`/`warnings.warn` channels).

**Consolidated run log.** A single `RunLog` owns `{out}_all_logs.log` and writes it in a fixed order: banner → one `===== step =====` section per step (structured `[step]` summary lines live, then that step's verbatim PLINK output) → an end-of-run summary table.

**Raw output is captured again.** `run_command` harvests each PLINK/KING native `.log` via a run-scoped `raw_sink` ContextVar, so compound steps (PCA/GWAS, ancestry preprocessing — dozens of invocations) are fully captured rather than just their last call. Each step's raw output is also written to `{out}_{step}.log` (`{out}_{label}_{step}.log` under `--ancestry`), harvested out of the temp dir before cleanup so logs persist without `--full_output` — which now governs only intermediate pfiles. `cleaned_logs.log` is deleted; its `process_log` blacklist mangled PLINK prose (it dropped any line containing `(see`, orphaning the text that followed).

**One output channel.** `print`/`warnings.warn` on the pipeline path are routed through `logging`: a curated console (`[step] message`, `!` on WARN+) and the file-only raw stream. Two `extra` markers route a record to one destination — `file_only` (verbose temp paths) and `console_only` (content the RunLog renders itself). The re-run guard moved out of `validate_input` into `guard_output_not_exists` so it runs before logging setup and `validate_input` can log its data breakdown into the fresh log.

**Failure boundary.** `main()` reports expected failures (`GenoToolsError`, `FileNotFoundError`, config `ValueError`/`TypeError`) as a one-line `ERROR:` message with exit 1 instead of a traceback; `--debug` re-raises. New `--quiet` (drop the console; log files still written) and `--debug` (DEBUG level + tracebacks).

### Bugs found along the way

- The re-run guard told users to `Rerun with --skip_fails` — a spelling argparse **rejects** (it is `--skip-fails`). The only advice that error gave was unusable.
- A re-run under `--skip_fails` silently **truncated** the prior consolidated log. It is now rotated to `{out}_all_logs.log.N`, and a pre-flight failure restores the rotation so a failed re-run leaves the directory as it found it.
- `--callrate 1.5` and a missing `--pfile` both crashed with a traceback; range checks live in the step config, not the parser.
- 8 step error messages pointed at `.log` files that no longer exist (several were already wrong before this branch, naming temp files the cleanup had deleted). They now share a `RAW_LOG_HINT` constant pointing at the logs that do exist.
- PLINK's stray `{out}.log` sat beside the real outputs duplicating `{out}_{step}.log`; it is now removed after harvest (following `GenotypeData.to_pfile`'s existing precedent).

### Docs

`docs/cli_args.md` rewritten against `genotools/cli/parser.py` — it still described the legacy flag surface (underscore spellings argparse rejects, a `--cloud_model` that does not exist, `--full_output` documented as defaulting to True). All 42 flags are documented and parse-checked.

## Test plan

- [x] Full suite: **437 → 475 passed** (+38 over the branch point; `tests/regression/test_logging.py` rewritten for the new contract, new `tests/regression/test_cli_errors.py` for the failure boundary)
- [x] Old-vs-new parity **8/8** (`tests/regression/test_parity.py` against `.venv-stable`) — logging changes don't touch genotype output
- [x] Static gates: no `cleaned_logs`, no `warnings.warn`, no pipeline-path `print(` in new code
- [x] Real cohort (3661 samples × 1.95M variants): `--callrate --het --geno` and a re-run under `--skip-fails` — sectioned log, per-step raw files, summary table, rotation notice, no stray `{out}.log`
- [x] `--ancestry` end-to-end on synthetic data: per-group sections and per-group log files
- [ ] CI green on this PR (unit+regression and parity jobs)

## Notes for review

- The per-ancestry consolidated log is single-file/sectioned; tracker item #9 (parallelize ancestry groups) will need per-group log files.
- Follow-up left open: step configs are built inside the step loop, so an out-of-range value fails *after* logging is installed, leaving a log that blocks the prefix on the corrected re-run. Pre-flight config validation is its own change.
- `REFACTOR.md` records the full round-7 write-up, including both review passes and the remaining follow-ups.
