### PR TITLE
Feat/het ancestry grammar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,634 +1,184 @@
-# GenoTools AI Development Guide
+# GenoTools — AI Development Guide
 
-**AI-Assisted Development Guide for GenoTools**
+Conventions for AI assistants working on this codebase. This file is loaded
+every session, so it holds only what changes what you do. Everything else is a
+pointer:
 
-This guide provides patterns, conventions, and requirements for AI coding assistants working on the GenoTools codebase.
-
----
-
-## Quick Reference
-
-### Before You Start
-1. Read this entire document
-2. Understand the pipeline architecture (CLI → QC classes → PLINK execution)
-3. Know the standard return dictionary format
-4. Verify external tool availability (PLINK, PLINK2, KING)
-
-### Critical Rules
-- **Always validate inputs** at the start of every method
-- **Always return the standard output dictionary** format
-- **Never break the pipeline chain** - methods must produce valid PLINK2 pfiles
-- **Log everything** via `concat_logs()`
-- **Test with real PLINK files** - the pipeline depends on external executables
-
----
-
-## Project Overview
-
-GenoTools is a command-line tool for genotype quality control (QC) and ancestry prediction in genetic studies. It wraps PLINK/PLINK2 commands in a Python pipeline with ML-based ancestry inference.
-
-### Key Components
-
-| Component | Purpose |
-|-----------|---------|
-| `genotools/pipeline.py` | CLI argument parsing, pipeline orchestration |
-| `genotools/qc.py` | `SampleQC` and `VariantQC` classes |
-| `genotools/ancestry.py` | `Ancestry` class for ML predictions |
-| `genotools/gwas.py` | `Assoc` class for GWAS/PCA |
-| `genotools/utils.py` | Shell execution, file conversion helpers |
-| `genotools/dependencies.py` | External tool management |
-
-### Entry Points
-```python
-# Main CLI
-genotools → genotools.__main__:handle_main
-
-# Reference download
-genotools-download → genotools.download_refs:handle_download
-```
+| Need | Read |
+|---|---|
+| CLI flags and their semantics | `docs/cli_args.md` |
+| Test suite, parity harness, real-cohort runs | `TESTING.md` |
+| What changed in 2.0 and why | `MIGRATION_2.0.md` |
+| Refactor history, tracked remaining work | `REFACTOR.md` |
+| JSON report shape | `docs/json_output_overview.md` |
 
 ---
 
 ## Architecture
 
-### Pipeline Flow
+2.0 replaced the `SampleQC`/`VariantQC`/`Ancestry` classes with pure functions
+over frozen config dataclasses. Guidance anywhere referring to
+`genotools/qc.py`, `pipeline.py`, `run_het_prune()`, `shell_do()` or
+`concat_logs()` predates 2.0 and is wrong.
+
 ```
-Input (bfile/pfile/vcf)
-    ↓
-Format Conversion → PLINK2 pfiles
-    ↓
-Ancestry Prediction (optional)
-    ↓
-Split by Ancestry
-    ↓
-┌─────────────────────────────────────┐
-│ QC Pipeline (per ancestry group)    │
-│   callrate → sex → het → related →  │
-│   case_control → haplotype → hwe →  │
-│   geno → ld → assoc                 │
-└─────────────────────────────────────┘
-    ↓
-JSON Output + Cleaned Files
+argv → parse_args() → PipelineArgs → PipelineRunner.run()
+  → validate_input() → ValidationDecisions (steps the data rules out)
+  → convert to pfiles → ancestry prediction (optional)
+  → _run_with_ancestry (per label)  |  _run_qc_only (flat)
+      → _run_qc_pipeline → _run_single_step → filter_<step>(data, config, out)
+         callrate → sex → het → related → kinship_check →
+         geno → case_control → haplotype → hwe → ld → assoc
+  → JSON report + pfiles + {out}_all_logs.log
 ```
 
-### Class Responsibilities
+- `cli/` — `parser.py` typed args + validation, `runner.py` orchestration and
+  step dispatch, `output.py` JSON report
+- `qc/` — `steps/*.py` one function per step, `config.py` frozen configs,
+  `results.py` `FilterResult` / `STEP_REPORT`
+- `core/` — `executors.py` (`run_plink2`, `run_plink`, `run_king`,
+  `run_command`), `genotypes.py` (`GenotypeData`), `logging.py` (`RunLog`,
+  `step_context`), `validation.py`, `exceptions.py`
+- `ancestry/` — `AncestryModel`, preprocessing, reducers, cohort split
+- `gwas/` — PCA and association
 
-**SampleQC** - Sample-level quality control
-- `run_callrate_prune()` - Remove samples with low call rates
-- `run_sex_prune()` - Remove samples with sex discrepancies
-- `run_het_prune()` - Remove samples with extreme heterozygosity
-- `run_related_prune()` - Handle related/duplicate samples
-- `run_confirming_kinship()` - Verify family relationships
-
-**VariantQC** - Variant-level quality control
-- `run_geno_prune()` - Remove variants with high missingness
-- `run_case_control_prune()` - Remove variants with case/control differences
-- `run_haplotype_prune()` - Remove haplotype-inconsistent variants
-- `run_hwe_prune()` - Remove Hardy-Weinberg violating variants
-- `run_ld_prune()` - Prune variants in linkage disequilibrium
-
-**Ancestry** - Ancestry prediction
-- PCA calculation and projection
-- UMAP + XGBoost classification
-- Container/cloud inference support
-- Admixture handling
-
-**Assoc** - Association analysis
-- PCA preparation and execution
-- GWAS execution
-- Lambda/inflation calculation
+**Off the 2.0 path:** `utils.py`, `imputation.py`, `container/`, `prototype/`.
+Never import them from `cli`/`core`/`qc`/`gwas`/`ancestry`; that decoupling is
+tested.
 
 ---
 
-## Code Conventions
+## Contracts
 
-### Standard Return Dictionary
-
-**Every QC method must return this structure:**
+**Every QC step is a module-level function**, no classes or shared state:
 
 ```python
-{
-    'pass': bool,           # True if step completed successfully
-    'step': str,            # Step identifier (e.g., 'callrate_prune')
-    'metrics': {
-        'outlier_count': int,  # Number of samples/variants pruned
-        # ... other step-specific metrics
-    },
-    'output': {
-        'pruned_samples': str,  # Path to pruned sample IDs (or None)
-        'plink_out': str,       # Path to output pfiles (without extension)
-        # ... other output files
-    }
-}
+def filter_<step>(data: GenotypeData, config: <Step>Config, out_path: Path) -> FilterResult:
 ```
 
-**Example:**
-```python
-out_dict = {
-    'pass': process_complete,
-    'step': step,
-    'metrics': metrics_dict,
-    'output': outfiles_dict
-}
-return out_dict
-```
+Copy the nearest existing step rather than a template in this file — they are
+all the same shape, and real code can't drift out of date.
 
-### Input Validation Pattern
+**Return a `FilterResult`** (`qc/results.py`); never hand-build its `to_dict()`
+output. Its `metrics` holds **counts only** — `cli/output.py` renders each
+metric as a row in a long `(step, metric, pruned_count)` table, so a mode name
+or a derived bound would land under a column meaning "how many were pruned."
+Descriptive context goes to the log. Register report metric names in
+`STEP_REPORT` so skipped and failed steps emit matching zero rows.
 
-**Every method must validate inputs before processing:**
+**Validate thresholds in the config, not the step.** Frozen dataclasses
+validating in `__post_init__` via `ThresholdConfig._validate_*`
+(`core/config.py`) fail before PLINK runs, and `parse_args` surfaces it as a
+clean `ERROR:` line.
 
-```python
-def run_some_prune(self, threshold=0.05):
-    geno_path = self.geno_path
-    out_path = self.out_path
+**Raise, don't return, on failure** — a `GenoToolsError` subclass
+(`ValidationError`, `QCError`, `ExternalToolError`, …). `_run_qc_pipeline`
+decides what happens: warn-and-continue by default, fail-fast under
+`--no-warn`. `main()` renders those plus `FileNotFoundError` / `ValueError` /
+`TypeError` as a one-line `ERROR:` with exit 1. Anything else is a bug and
+keeps its traceback.
 
-    # 1. Check paths are set
-    if geno_path is None or out_path is None:
-        raise ValueError("Both geno_path and out_path must be set before calling this method.")
+**Log via `get_logger(__name__)` inside `with step_context(step_name):`.**
+Never `print()` or `warnings.warn()`. The executors harvest PLINK's own `.log`
+themselves — there is no `concat_logs()` call to make.
 
-    # 2. Check input files exist
-    if not os.path.exists(f'{geno_path}.pgen'):
-        raise FileNotFoundError(f"{geno_path} does not exist.")
+**Keep the pfile chain intact.** Each step reads `{geno}.pgen/.pvar/.psam` and
+writes `{out}.pgen/.pvar/.psam`, or the next step has nothing to read.
+`run_plink2` adds `--make-pgen psam-cols=fid,parents,sex,pheno1,phenos` by
+default; pass `make_pgen=False` for report-only commands (`--het`,
+`--indep-pairwise`). Outlier files are tab-separated with a `#FID` header.
 
-    # 3. Check parameter types
-    if not isinstance(threshold, (int, float)):
-        raise TypeError("threshold should be of type int or float.")
+GenoTools is **synchronous**. Do not introduce async.
 
-    # 4. Check parameter bounds
-    if threshold < 0 or threshold > 1:
-        raise ValueError("threshold should be between 0 and 1.")
+---
 
-    # ... proceed with implementation
-```
+## Traps
 
-### Shell Command Execution
+These caused real bugs. They are why this file exists.
 
-**Use `shell_do()` for all external commands:**
+**Two run shapes.** `_run_with_ancestry` and `_run_qc_only` are separate paths,
+and anything per-step must be reachable from both. Production runs ancestry
+once, then QCs each group as a separate *flat* job — so a flag read only in the
+ancestry branch silently does nothing exactly where it matters (`--amr-het`,
+round 11). When a setting can vary per dataset, resolve it in one shared place
+(`SampleQCArgs.het_config_for()`), not at each call site.
 
-```python
-from genotools.utils import shell_do, concat_logs
+**Never hardcode an ancestry label.** The vocabulary is user-supplied — from
+the `--ref-labels` TSV via an unconstrained `LabelEncoder`, or a pickled
+model's encoder. Admixture detection also invents `CAH`, which appears in no
+panel. `label == "AMR"` was the second defect behind `--amr-het`.
 
-# Execute PLINK command
-plink_cmd = f"{plink2_exec} --pfile {geno_path} --mind {mind} --make-pgen psam-cols=fid,parents,sex,pheno1,phenos --out {out_path}"
-shell_do(plink_cmd)
+**`str(None)` is `"None"`,** which reaches PLINK as a filename and produces
+`Failed to open None.bed`. Validate optional paths up front — this is live in
+inference mode (`REFACTOR.md` item 23).
 
-# Always log after execution
-listOfFiles = [f'{out_path}.log']
-concat_logs(step, out_path, listOfFiles)
-```
+**Data preconditions are skips, not crashes.** A step the data rules out gets a
+`<step>_skip_reason()` in `core/validation.py`, wired into `_skip_reasons()`,
+so the report distinguishes "not requested" from "requested but impossible".
 
-### File Path Conventions
+**KING is Linux-only.** Check `platform.system()` and warn.
 
-```python
-# Input/output paths never include extensions
-geno_path = '/path/to/data'      # Files: data.pgen, data.pvar, data.psam
-out_path = '/path/to/output'     # Will create: output.pgen, output.pvar, output.psam
+**`python -m genotools` puts the cwd first on `sys.path`** — from the repo root
+it imports the working tree whatever virtualenv you use. Matters when comparing
+against `.venv-stable`.
 
-# Intermediate files use step suffix
-step_output = f'{out_path}_{step}'  # e.g., output_callrate_prune
+**Flag policy.** Hyphenated spellings only for anything added in 2.0+.
+Underscore spellings are deprecated 1.x aliases in `_DEPRECATED_SPELLINGS`; a
+*removed* flag goes in `_REMOVED_FLAGS`, which gives a targeted error naming
+the replacement instead of argparse's bare "unrecognized arguments".
+`--container` / `--singularity` / `--cloud` follow the same pattern.
 
-# Outlier files
-outliers_out = f'{out_path}.outliers'
-```
+---
 
-### PLINK2 psam Column Standard
+## Adding a QC step
 
-**Always preserve sample metadata columns:**
+Seven touch points. Miss one and the step silently never runs.
 
-```python
-# Use this flag for all --make-pgen commands
---make-pgen psam-cols=fid,parents,sex,pheno1,phenos
-```
+1. **Config** — frozen dataclass in `qc/config.py`, validating in `__post_init__`
+2. **Function** — `qc/steps/<name>.py`, shape above
+3. **Exports** — `qc/steps/__init__.py` and `qc/__init__.py` (imports + `__all__`)
+4. **Report** — entry in `STEP_REPORT` (`qc/results.py`)
+5. **CLI** — flag in `create_parser()`, field on `SampleQCArgs`/`VariantQCArgs`,
+   `to_<step>_config()`, wiring in `parse_args()`, entry in
+   `get_enabled_*_steps()`
+6. **Dispatch** — register in `_initialize_modules()`, branch in
+   `_run_single_step()`
+7. **Tests, and `docs/cli_args.md`**
 
 ---
 
 ## Testing
 
-### Current State
-GenoTools does not have a formal test suite. Test data exists in `/data/` but no pytest infrastructure.
-
-### When Adding Tests
-
-**Recommended structure:**
-```
-tests/
-├── conftest.py           # Fixtures for test data paths
-├── test_sample_qc.py     # SampleQC method tests
-├── test_variant_qc.py    # VariantQC method tests
-├── test_ancestry.py      # Ancestry prediction tests
-├── test_pipeline.py      # Integration tests
-└── test_utils.py         # Utility function tests
-```
-
-**Test pattern:**
-```python
-import pytest
-from genotools.qc import SampleQC
-
-class TestSampleQC:
-    """Tests for SampleQC class."""
-
-    def test_callrate_prune_valid_input(self, sample_pfiles):
-        """Test callrate pruning with valid input."""
-        # Arrange
-        qc = SampleQC(geno_path=sample_pfiles, out_path='/tmp/test_out')
-
-        # Act
-        result = qc.run_callrate_prune(mind=0.02)
-
-        # Assert
-        assert result['pass'] is True
-        assert result['step'] == 'callrate_prune'
-        assert 'outlier_count' in result['metrics']
-
-    def test_callrate_prune_invalid_mind(self, sample_pfiles):
-        """Test that invalid mind value raises ValueError."""
-        qc = SampleQC(geno_path=sample_pfiles, out_path='/tmp/test_out')
-
-        with pytest.raises(ValueError, match="mind should be between 0 and 1"):
-            qc.run_callrate_prune(mind=1.5)
-```
-
----
-
-## Common Pitfalls
-
-### 1. Missing await/async
-GenoTools is **synchronous**. Do not add async/await unless refactoring the entire pipeline.
-
-### 2. Breaking the pfile chain
-Every QC step must:
-- Read from `{geno_path}.pgen/.pvar/.psam`
-- Write to `{out_path}.pgen/.pvar/.psam`
-
-```python
-# ❌ BAD - Breaks the chain
-result = run_analysis(geno_path)
-return result  # No pfiles created
-
-# ✅ GOOD - Maintains the chain
-plink_cmd = f"{plink2_exec} --pfile {geno_path} ... --make-pgen ... --out {out_path}"
-shell_do(plink_cmd)
-# Now out_path.pgen exists for next step
-```
-
-### 3. Forgetting to log
-```python
-# ❌ BAD - No logging
-shell_do(plink_cmd)
-return out_dict
-
-# ✅ GOOD - Always log
-shell_do(plink_cmd)
-listOfFiles = [f'{out_path}.log']
-concat_logs(step, out_path, listOfFiles)
-return out_dict
-```
-
-### 4. Incorrect outlier file format
-```python
-# Outlier files must be tab-separated with #FID header
-# ❌ BAD
-df.to_csv(outliers_out, sep=',')
-
-# ✅ GOOD
-df = df.rename({'FID': '#FID'}, axis=1)
-df.to_csv(outliers_out, sep='\t', header=True, index=False)
-```
-
-### 5. Platform-specific code without checks
-```python
-# ❌ BAD - KING only works on Linux
-result = run_king_analysis()
-
-# ✅ GOOD - Check platform first
-import platform
-if platform.system() != 'Linux':
-    print('This analysis can only run on Linux!')
-    return None
-result = run_king_analysis()
-```
-
----
-
-## Adding New QC Steps
-
-### Template for Sample-Level QC
-
-```python
-def run_new_sample_prune(self, param1=default1, param2=default2):
-    """
-    Execute new sample pruning on genotype data.
-
-    Parameters:
-    - param1 (type): Description. Default is default1.
-    - param2 (type): Description. Default is default2.
-
-    Returns:
-    - dict: Standard output dictionary with 'pass', 'step', 'metrics', 'output'.
-    """
-    geno_path = self.geno_path
-    out_path = self.out_path
-
-    # Input validation
-    if geno_path is None or out_path is None:
-        raise ValueError("Both geno_path and out_path must be set.")
-    if not os.path.exists(f'{geno_path}.pgen'):
-        raise FileNotFoundError(f"{geno_path} does not exist.")
-    # ... validate param1, param2
-
-    step = "new_sample_prune"
-    outliers_out = f'{out_path}.outliers'
-
-    # Execute PLINK commands
-    plink_cmd = f"{plink2_exec} --pfile {geno_path} ... --make-pgen psam-cols=fid,parents,sex,pheno1,phenos --out {out_path}"
-    shell_do(plink_cmd)
-
-    # Log
-    listOfFiles = [f'{out_path}.log']
-    concat_logs(step, out_path, listOfFiles)
-
-    # Process results and count outliers
-    if os.path.isfile(f'{out_path}.some_output'):
-        outliers = pd.read_csv(f'{out_path}.some_output', sep='\s+')
-        outliers = outliers.rename({'FID': '#FID'}, axis=1)
-        outliers.to_csv(outliers_out, sep='\t', header=True, index=False)
-        outlier_count = outliers.shape[0]
-    else:
-        outlier_count = 0
-
-    process_complete = True
-
-    # Build return dictionary
-    outfiles_dict = {
-        'pruned_samples': outliers_out,
-        'plink_out': out_path,
-    }
-    metrics_dict = {
-        'outlier_count': outlier_count
-    }
-    out_dict = {
-        'pass': process_complete,
-        'step': step,
-        'metrics': metrics_dict,
-        'output': outfiles_dict
-    }
-
-    return out_dict
-```
-
-### Registering New Steps in Pipeline
-
-After adding a new method, update `pipeline.py`:
-
-```python
-# In handle_main() or execute_pipeline()
-
-# 1. Add to appropriate step list
-samp_steps = ['callrate', 'sex', 'het', 'related', 'kinship_check', 'new_step']
-
-# 2. Add to steps_dict mapping
-steps_dict = {
-    # ... existing steps
-    'new_step': samp_qc.run_new_sample_prune,
-}
-
-# 3. Add argument in gt_argparse()
-parser.add_argument('--new_step', type=float, nargs='?', default=None, const=0.05,
-                    help='Description of new step')
-```
-
----
-
-## External Dependencies
-
-### Required Executables
-- **PLINK 1.9** - Legacy format support, sex checks
-- **PLINK2** - Primary tool for QC operations
-- **KING** - Relatedness analysis (Linux only)
-
-### Checking Dependencies
-```python
-from genotools.dependencies import check_plink, check_plink2, check_king
-
-plink_exec = check_plink()    # Returns path or downloads
-plink2_exec = check_plink2()  # Returns path or downloads
-king_exec = check_king()      # Returns path (Linux) or None
-```
-
-### Python Dependencies
-```
-pandas, numpy              # Data manipulation
-scikit-learn, xgboost     # ML models
-umap-learn==0.5.3         # Dimensionality reduction (pinned version)
-scipy, statsmodels        # Statistics
-matplotlib, seaborn       # Visualization
-```
-
----
-
-## File Formats
-
-### Input Formats
-- **bfile**: PLINK 1.9 (`.bed`, `.bim`, `.fam`)
-- **pfile**: PLINK 2 (`.pgen`, `.pvar`, `.psam`)
-- **VCF**: Variant Call Format (`.vcf`)
-
-### Internal Format
-All processing uses PLINK2 pfiles. Conversion happens automatically at pipeline start.
-
-### Required psam Columns
-```
-#FID    IID    SEX    PHENO1    [additional columns]
-```
-- `SEX`: 0=unknown, 1=male, 2=female
-- `PHENO1`: -9=missing, 1=control, 2=case
-
-### Output JSON Structure
-```json
-{
-    "ancestry_counts": {"EUR": 100, "AFR": 50, ...},
-    "ancestry_labels": [{"#FID": "...", "IID": "...", "label": "EUR"}, ...],
-    "QC": [
-        {"step": "callrate_prune", "pruned_count": 5, "metric": "outlier_count", ...}
-    ],
-    "GWAS": [
-        {"value": 1.02, "metric": "lambda", "ancestry": "EUR"}
-    ],
-    "pruned_samples": [...],
-    "related_samples": [...]
-}
-```
-
----
-
-## Ancestry Prediction
-
-### Model Architecture
-- **Step 1**: PCA on merged reference + input samples
-- **Step 2**: UMAP transformation
-- **Step 3**: XGBoost classification
-- **Supported labels**: AFR, SAS, EAS, EUR, AMR, AJ, CAS, MDE, FIN, AAC
-
-### Remote execution: not supported in 2.0
-
-`--container`, `--singularity` and `--cloud` are **rejected with an error**.
-Ancestry prediction always runs locally, in process.
-
-`--container`/`--singularity` worked in 1.x but are tied to a Docker image whose
-`run.py` unpickles a 1.x `umap_linearsvc` model that 2.0 cannot load; restoring
-them requires republishing that image with a 2.0-format model. `--cloud` was
-never implemented in any version. See `MIGRATION_2.0.md` and REFACTOR.md
-round 10.
-
----
-
-## Development Workflow
-
-### Virtual Environment Setup
-
-Use separate virtual environments to keep stable and development versions isolated:
-
-| Environment | Install Command | Purpose |
-|-------------|-----------------|---------|
-| `.venv` | `pip install -e .` | Active development, code changes reflected immediately |
-| `.venv-stable` | `pip install .` | Frozen baseline snapshot for regression comparison |
-
 ```bash
-# Development environment (editable - use this for active work)
-python -m venv .venv
-source .venv/bin/activate
-pip install -e .
-
-# Stable baseline (frozen snapshot - use for comparison)
-python -m venv .venv-stable
-source .venv-stable/bin/activate
-pip install .
+.venv/bin/python -m pytest tests/unit -q        # ~25s, 616 tests
+.venv/bin/python -m pytest tests/regression -q  # ~7min, needs PLINK
 ```
 
-**Note:** Both are installed from the local repo, not PyPI, since PyPI may be outdated.
+- **Revert-check any test claiming to gate a fix.** Break the production call
+  site and confirm the test fails. `REFACTOR.md` item 17 records round-7 tests
+  that passed against the broken code because they drove a helper rather than
+  the path the bug lived in.
+- **Test through the layer that owns the behaviour.** The parser has three
+  worth covering — dataclass, `_parse_*` helper, end-to-end `parse_args` — and
+  bugs hide in the gaps.
+- **Runner regressions** go in `tests/unit/test_cli/test_runner_regression.py`.
+- **Split pure logic out of PLINK-driven steps** so it can be tested against a
+  hand-built frame. `select_het_outliers` is the pattern.
+- **Changing the JSON report shape** means regenerating
+  `tests/regression/golden/` via `tests/scripts/generate_golden.py` — a
+  contract change, not a chore.
 
-### 1. Making Changes
-```bash
-# Install in development mode
-pip install -e .
-
-# Run linting (recommended)
-flake8 genotools/
-black genotools/
-
-# Test manually
-genotools --pfile test_data --out test_output --callrate
-```
-
-### 2. Testing Changes
-```bash
-# Basic pipeline test
-genotools --pfile data/test --out output/test --all_sample --all_variant
-
-# With ancestry
-genotools --pfile data/test --out output/test --ancestry --ref_panel /path/to/ref --ref_labels /path/to/labels
-```
-
-### 3. Committing
-```bash
-# Version bump in setup.py if needed
-# Update CITATION.cff if adding authors
-git add .
-git commit -m "Description of changes"
-```
+`.venv` is `pip install -e .`; `.venv-stable` is the frozen parity baseline
+(currently 1.3.6). See `TESTING.md`.
 
 ---
 
-## Error Handling Checklist
+## Writing it up
 
-When AI generates code, verify:
-
-- [ ] All inputs validated at method start
-- [ ] FileNotFoundError raised for missing files
-- [ ] ValueError raised for invalid parameters
-- [ ] TypeError raised for wrong parameter types
-- [ ] Platform checks for OS-specific features
-- [ ] Proper error messages guide users to logs
-- [ ] `--warn` flag behavior respected (continue on failure)
-
----
-
-## Quick Debugging
-
-### Check PLINK availability
-```python
-from genotools.dependencies import check_plink, check_plink2
-print(check_plink())   # Should print path
-print(check_plink2())  # Should print path
-```
-
-### Inspect pipeline state
-```python
-# After pipeline runs, check pass_fail dict
-for step, status in out_dict['pass_fail'].items():
-    print(f"{step}: {'PASS' if status['status'] else 'FAIL'}")
-```
-
-### Read logs
-```bash
-cat output_all_logs.log      # Full PLINK output
-cat output_cleaned_logs.log  # Formatted summary
-```
-
----
-
-## AI Communication Guidelines
-
-### Commit Messages
-
-When reaching a good checkpoint, provide a commit message following these rules:
-
-1. **Never include** `Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>` or any co-author attribution
-2. Use conventional commit format when appropriate (feat:, fix:, refactor:, docs:, test:)
-3. First line should be concise (50 chars or less if possible)
-4. Include a blank line then detailed bullet points for complex changes
-
-**Example:**
-```
-refactor: migrate QC module to pure function architecture
-
-- Add typed config dataclasses (CallrateConfig, SexConfig, etc.)
-- Create pure functions for each QC step
-- Implement SampleQC and VariantQC wrapper classes
-- Add comprehensive unit tests (84 tests)
-- Maintain backward compatibility with legacy interface
-```
-
-### Pull Request Descriptions
-
-When asked for PR descriptions:
-
-1. **Always return in markdown format** so it can be copied directly to GitHub web interface
-2. **Never include** "Generated with Claude Code" or similar attribution text
-3. Use this structure:
-
-```markdown
-## Summary
-- Bullet point 1
-- Bullet point 2
-- Bullet point 3
-
-## Test plan
-- [ ] Test item 1
-- [ ] Test item 2
-- [ ] Integration testing notes
-```
-
----
-
-## Summary
-
-| Rule | Reason |
-|------|--------|
-| Validate all inputs | Catch errors early with clear messages |
-| Use standard return dict | Pipeline depends on consistent structure |
-| Always log with concat_logs() | Debugging and audit trail |
-| Maintain pfile chain | Each step feeds the next |
-| Check platform for KING | Only works on Linux |
-| Pin umap-learn==0.5.3 | Model compatibility |
+- **Commit messages:** conventional prefix (`feat:`, `fix:`, `refactor:`,
+  `docs:`, `test:`), concise first line, bullets for anything non-trivial.
+  **Never** add `Co-Authored-By:` or any attribution trailer.
+- **PR descriptions:** markdown, `## Summary` + `## Test plan`, ready to paste
+  into GitHub. **Never** include "Generated with Claude Code" or similar.
+- **`REFACTOR.md`:** append a *new* round entry; never edit historical ones.
+  Deferred work goes in "Remaining work" with a number.

--- a/MIGRATION_2.0.md
+++ b/MIGRATION_2.0.md
@@ -26,7 +26,6 @@ so existing scripts keep running. They will be removed in a future release.
 |---|---|
 | `--all_sample` | `--all-sample` |
 | `--all_variant` | `--all-variant` |
-| `--amr_het` | `--amr-het` |
 | `--case_control` | `--case-control` |
 | `--covar_names` | `--covar-names` |
 | `--duplicated_cutoff` | `--duplicated-cutoff` |
@@ -45,7 +44,7 @@ so existing scripts keep running. They will be removed in a future release.
 To find them in your own scripts:
 
 ```bash
-grep -rnE '\-\-(all|amr|case|covar|duplicated|filter|full|kinship|maf|min|prune|ref|related|skip|subset)_' .
+grep -rnE '\-\-(all|case|covar|duplicated|filter|full|kinship|maf|min|prune|ref|related|skip|subset)_' .
 ```
 
 ### Boolean flags no longer accept a value
@@ -64,7 +63,7 @@ enable it, or omit it to disable it.
 ```
 
 To migrate: **pass the flag alone to enable, omit it to disable.** Affects
-`--all_sample`, `--all_variant`, `--amr_het`, `--ancestry`,
+`--all_sample`, `--all_variant`, `--ancestry`,
 `--filter_controls`, `--full_output`, `--gwas`, `--kinship_check`,
 `--maf_lambdas`, `--prune_related`, `--related`, `--skip_fails`, `--warn`,
 `--prune_duplicated`. (`--container` and `--singularity` are also presence-only
@@ -81,9 +80,60 @@ rather than omission:
 `--warn` and `--prune_duplicated` are still accepted on their own as no-ops,
 since what they requested is now the default.
 
+### `--amr-het` was removed, replaced by `--het-ancestry`
+
+Not a rename — a different flag with different reach. Both spellings
+(`--amr-het`, `--amr_het`) are rejected with a message naming the replacement:
+
+```
+$ genotools ... --all-sample --amr-het
+ERROR: --amr-het was removed in GenoTools 2.0.1. Use '--het-ancestry AMR sd'
+instead, which also works in a flat run (--amr-het silently did nothing
+without --ancestry). See MIGRATION_2.0.md.
+```
+
+| 1.x / 2.0.0 | 2.0.1 |
+|---|---|
+| `--ancestry --all-sample --amr_het` | `--ancestry --all-sample --het-ancestry AMR sd` |
+
+Three reasons it changed rather than being carried forward:
+
+- **It was silently inert outside `--ancestry`.** The flag was read in exactly
+  one place, inside the ancestry branch; a flat run never consulted it. The
+  per-ancestry production workflow runs ancestry once and then QCs each group
+  as a separate flat job — precisely the path where it did nothing, with no
+  warning and a normal-looking JSON. `--het-ancestry` works in both run shapes,
+  and errors rather than being ignored when it cannot apply.
+- **It hardcoded one reference panel's label.** `label == "AMR"` was the only
+  user-facing feature in the codebase that assumed a particular panel's naming.
+  The label vocabulary is user-supplied — from `--ref-labels`, or from a
+  pickled model's encoder — so the flag was unusable on any panel spelling the
+  group differently, and could never reach `CAH`, the synthetic admixed label
+  that admixture detection invents.
+- **The multiplier was invisible.** `--amr-het` was described as "auto-detect",
+  but only the location and scale were derived from the data; the `3` was
+  hardcoded. `sd [N]` makes it a knob.
+
+**The replacement is not bit-for-bit identical in principle, though it was in
+practice here.** `--amr-het` thresholded the derived heterozygosity *rate*;
+`sd` thresholds `F`, so that both spellings of `--het` bound the same
+statistic. The two are near-perfectly anti-correlated within a group, so the
+`mean ± 3σ` rule picks the same samples either way: measured on the GP2 r12 10k
+subset (9,771 samples post-callrate) the two rules select **identical** sets —
+99 samples each, zero disagreements cohort-wide and zero within AMR's 340 —
+despite bounds on quite different scales (`F: [-0.081, 0.160]` against
+`rate: [0.258, 0.332]`). Nothing guarantees that on other data, so treat a
+borderline sample moving as possible rather than expected.
+
+`--het` itself gained the same spec grammar (`--het sd [N]` alongside
+`LOWER UPPER`), and the 1.x `--het -1 -1` sentinel still works while warning
+that `--het sd` is the spelling now. See
+[docs/cli_args.md](docs/cli_args.md) for the full grammar.
+
 ### New flags
 
-`--quiet`, `--debug`, `--no-warn`, `--no-prune-duplicated`.
+`--het-ancestry`, `--quiet`, `--debug`, `--no-warn`, `--no-prune-duplicated`.
+`--het` accepts a new `sd [N]` form.
 
 ---
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -696,6 +696,164 @@ assertion.
 
 ---
 
+### Round 11 (per-ancestry heterozygosity bounds, 2.0.1)
+
+Generalizes `--amr-het` into a per-ancestry heterozygosity grammar, and fixes
+the bug that made it silently inert in the run shape production actually uses.
+
+**The bug.** `runner.py:496` — `if self.args.sample_qc.amr_het and label ==
+"AMR"` — was the *only* place the flag was read, and it lived inside
+`_run_with_ancestry`. `_run_qc_only` never passed het values at all, so
+`legacy_args["het"]` kept the base bounds. The per-ancestry production workflow
+runs ancestry once and then QCs each group as a separate **flat** job, which is
+exactly the path where the flag did nothing: no warning, no error, and a JSON
+that looks like a normal het run. The same structure exists on 1.x
+(`__main__.py:177`), so this is longstanding rather than a 2.0 regression.
+A second, narrower inert case: `--amr-het` did not enable the het step, so
+`--ancestry --amr-het` with no `--het`/`--all-sample` was also a no-op.
+
+**The second defect: one panel's label, hardcoded.** `label == "AMR"` was the
+only user-facing feature in the codebase assuming a particular reference
+panel's naming. The label vocabulary is entirely user-supplied — from the
+`--ref-labels` TSV via an unconstrained `LabelEncoder`, or from a pickled
+model's encoder in inference mode — so the flag was unusable on any panel not
+spelling the group "AMR", and could never reach `CAH`, the synthetic admixed
+label that admixture detection *invents* (`ancestry/model.py:411-414`) and the
+group most likely to want adaptive bounds.
+
+**The grammar.** Two flags sharing one spec resolver:
+
+```
+--het [LOWER UPPER | sd [N]]                  # base: applies to every group
+--het-ancestry LABEL [LOWER UPPER | sd [N]]   # repeatable; overrides one group
+```
+
+Override beats base — a precedence that needs no invented rule, which is why
+this shape beat independent flags. `sd` is a keyword, so the forms never
+collide: a two-token spec is fixed bounds when it starts with a number and a
+multiplier when it starts with `sd`. `_parse_het_spec` is the single resolver
+both flags call, so they cannot drift into different rules or error wording.
+
+**Named `sd`, not `auto`.** The existing mode was called "auto-detect", but only
+its *location and scale* were data-derived — the `3` at `heterozygosity.py:142`
+was hardcoded. Once the multiplier is user-visible, `auto 3` reads as
+"automatic… three?". `--het sd 2` says exactly what it does.
+
+**`sd` thresholds F, not the het rate — decided on data.** Both spellings of
+`--het` then bound the same statistic, which is the whole reason the single
+grammar is legible. The design estimated the cost at 18 of 9,759 samples
+(0.18%); measured after implementing, on a real `.het` table from the GP2 r12
+10k subset (9,771 post-callrate), it is **zero** — the two rules select
+identical 99-sample sets cohort-wide and identical sets within AMR's 340,
+despite bounds on different scales (`F: [-0.081, 0.160]` against
+`rate: [0.258, 0.332]`). F and rate are anti-correlated at r ≈ −0.99 within a
+group, so the ±3σ cut lands on the same samples. The `[-1, -1]` sentinel keeps
+the legacy rate-based path for Python-API callers; only the CLI moved, and
+`--het -1 -1` on the command line now resolves to the F rule.
+
+**`--amr-het` removed, not aliased.** Kept in a `_REMOVED_FLAGS` map purely so
+a 1.x command line gets a targeted error naming `--het-ancestry AMR sd`, the
+round-10 treatment of `--container`. It left `_DEPRECATED_SPELLINGS`, which
+models spelling renames only. The replacement is **not bit-for-bit identical**
+(F vs rate), which `MIGRATION_2.0.md` says plainly.
+
+**The linchpin.** `SampleQCArgs.het_config_for(label)` resolves base + override
+in one place, and both runner paths call it — the flat run with `None`, the
+ancestry loop with each label. The original bug existed precisely because two
+paths decided het config independently and only one knew about `amr_het`; this
+makes that class of divergence unrepresentable. `_run_qc_pipeline`'s
+`het_values: Optional[List[float]]` parameter, which existed solely to carry
+the `[-1,-1]` sentinel, is now a resolved `HetConfig`.
+
+**Resolved semantics.**
+
+| Case | Behavior |
+|---|---|
+| `--het-ancestry` without `--ancestry` | error — no labels exist to match |
+| `--het-ancestry` with no `--het`/`--all-sample` | implies the het step runs |
+| `--het-ancestry LABEL` where LABEL was not predicted | warn once, naming the predicted groups |
+| duplicate label across repeats | error at parse time |
+| `N <= 0` | error at parse time |
+| bare `--het-ancestry LABEL` (no spec) | error — a silent fixed-defaults no-op is the thing being removed |
+| `--het -1 -1` | still means `sd 3`, now with a deprecation warning |
+
+Erroring rather than warning on the first row is deliberate and differs from
+round 10's treatment of `--container`: those flags *could not* work; this one
+can, and being ignored was the defect.
+
+**Why the default multiplier stays 3.** Measured on GP2 r12 (10k subset),
+samples pruned on F:
+
+| group | n | sd 2 | sd 3 | fixed ±0.15 |
+|---|---|---|---|---|
+| **AMR** | 340 | 21 | **0** | **31** |
+| EUR | 6802 | 141 | 85 | 2 |
+| **all 10 groups** | 9759 | 287 | **137** | **35** |
+
+Two things follow. `sd` and fixed are **not** interchangeable defaults — a
+global `sd 3` prunes 137 where fixed prunes 35, and EUR alone goes 2 → 85; that
+is why the per-group override is required rather than a nicety, and it rules
+out retiring `--amr-het` by making `sd` the global default. And `3` is correct
+for AMR: at `sd 3` AMR prunes zero, which is the intended outcome, not
+under-pruning. The 31 samples fixed bounds catch sit at only ~2.5σ of AMR's own
+spread and are a structured subgroup (28 of 30 from one contributing cohort),
+not bad data. `sd 2` would prune 21 of them — discarding the very samples the
+feature exists to keep.
+
+**The documented rationale was wrong.** The feature was justified as
+"heterozygosity is higher in admixed populations." On this data AMR has the
+*lowest* mean het rate and the *highest* mean F of all ten groups, and **30 of
+the 31** samples fixed bounds prune are on the heterozygote-*deficit* side
+(`F >= +0.15`), 28 from a single contributing cohort. AMR is a pooled label
+spanning heterogeneous admixture proportions; pooling those allele frequencies
+produces an apparent heterozygote deficit (Wahlund), pushing a structured
+subgroup past the fixed **upper** bound. The feature is right; the explanation
+was not, and `docs/cli_args.md` now carries the corrected one.
+
+**Deliberately not fixed: `sd` is not robust.** Mean and σ are computed over
+every sample, outliers included, so a real subpopulation inflates σ and widens
+the bounds, sparing itself — which is the desired behavior here. A median/MAD
+sibling was considered and **rejected on data**: `MAD 3` on AMR gives bounds
+`-0.113 .. +0.102` and prunes **63**, clipping the structured subgroup twice as
+hard as the fixed bounds it replaces. MAD assumes a clean core plus sparse
+outliers; AMR is a clean core plus a real subpopulation. The cost is documented
+rather than papered over: at `sd 3` AMR's bounds exceed the observed range on
+both sides, so het pruning is effectively a no-op for that group and is not a
+contamination screen for it.
+
+**Gating.** 45 new tests across four layers: the spec grammar and its error
+cases (`_parse_het_spec`, `_parse_het_args`, `_parse_het_ancestry_args`),
+`het_config_for` resolution on the dataclass, every row of the semantics table
+end-to-end through `parse_args`, runner-level per-group resolution across an
+ancestry loop, and step-level bound arithmetic against a frame with a known
+mean and σ (`select_het_outliers` is split out of `filter_heterozygosity` so
+this needs no PLINK). **Revert-checked**, per item 17: dropping `het_config=`
+from `_run_qc_only`'s call fails 3 of the 4 `TestHetConfigReachesEveryRunShape`
+tests. The first draft of the headline test passed under that revert because it
+handed `_run_qc_pipeline` a config itself; it was rewritten to drive
+`_run_qc_only` — the entry point the bug lived in — before it gated anything.
+
+**Deviation from the plan: the mode is logged, not put in `metrics`.** The plan
+called for recording the mode and multiplier in the step's `metrics` dict, so
+that a per-group mix does not leave incomparable `outlier_count` values in one
+JSON. Implementing it revealed why that home is wrong: `output.py:335` renders
+every metric as a row in a long `(step, metric, pruned_count)` table, so
+`het_mode="sd"` landed under a column meaning "how many were pruned", and the
+numeric descriptors were no better. `metrics` stays counts-only; the mode,
+statistic, multiplier and derived bounds go to the run log, which names them on
+every het run. Recording them in the JSON properly needs a new section rather
+than an overloaded column — tracked as item 22.
+
+**Also folded in.** `docs/cli_args.md:103` said the het step is skipped when the
+input has fewer than 50 *variants*; it is samples (`MIN_HET_SAMPLES`).
+`TestParseHetArgs` was missing the wrong-arity test that `TestParseSexArgs` and
+`TestParseLdArgs` both have. `docs/genotools_function_guide.md` carried a 1.x
+`run_het_prune(het_filter=[-0.25,0.25])` signature with a default the shipped
+pipeline never used. `HetConfig.auto_detect` — written but never reachable from
+the CLI — is now live.
+
+---
+
 ## Remaining work (tracked, not yet done)
 
 Priority order for making the refactor mergeable to `main`:
@@ -791,4 +949,39 @@ Priority order for making the refactor mergeable to `main`:
     highest-risk behaviors, not an exhaustive sweep of every round-7 test.
 18. ✅ **`--container`, `--singularity` and `--cloud` were silently inert** —
     RESOLVED in **round 10**: they now fail loudly. See round 10 above.
+19. ✅ **`--amr-het` was silently inert without `--ancestry`, and hardcoded one
+    panel's label** — RESOLVED in **round 11**: replaced by the
+    `--het` / `--het-ancestry` spec grammar, which works in both run shapes and
+    on any label. See round 11 above.
+20. **`--het-ancestry` labels are not validated until the ancestry loop runs.**
+    An unmatched label warns rather than erroring, because the predicted label
+    set is not known until after prediction — by which point the run has done
+    its most expensive work. `--subset-ancestry` (`ancestry/cohort.py:26`) has
+    the same shape with no validation at all. Both could be checked eagerly
+    against `--ref-labels`, or against a loaded model's encoder classes under
+    `--model`, before prediction starts.
+21. **No separate sample floor for `sd` mode.** `MIN_HET_SAMPLES` (50) is
+    PLINK's LD floor, not a floor for estimating a dispersion. σ estimated near
+    50 samples makes the derived boundary itself wobble in a way a fixed bound
+    does not. Documented in `docs/cli_args.md`, not gated. A higher floor for
+    `sd` specifically is a possible follow-up.
+22. **The het mode is not in the JSON report.** `sd` and fixed bounds threshold
+    different cuts, so with a per-group mix the `outlier_count` values in one
+    report are not comparable without knowing which rule produced each. The
+    mode, statistic, multiplier and derived bounds are logged but not
+    serialized, because the QC report is a long `(step, metric, pruned_count)`
+    table with no room for a descriptive value (see round 11). Needs a
+    dedicated JSON section, which changes the report contract and the goldens.
+23. **`--model` without `--ref-panel`/`--ref-labels` fails inside PLINK.**
+    Inference mode still needs the reference panel — `get_raw_files(train=False)`
+    subsets it to the model's common SNPs and reads its `.raw`
+    (`ancestry/preprocessing.py:110`) — but nothing checks for it, so
+    `runner.py:893`'s `str(self.args.ancestry.ref_panel)` stringifies `None`
+    and PLINK is handed `--bfile None`, reporting
+    `Failed to open None.bed`. Reproduced on `afad04c` with the het work
+    absent, so it predates round 11; 1.3.6 caught the same mistake with
+    "Please make sure geno_path, ref_panel, ref_labels, and out_path are all
+    set", so this is a 2.0 regression in *diagnosis*, not in capability. Wants
+    the same up-front rejection round 10 gave `--container`: validate in
+    `AncestryArgs.__post_init__` that `--model` is accompanied by both.
 

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -100,7 +100,7 @@ A requested step is **skipped automatically** when the input can't support it.
 | Step | Skipped when |
 |------|--------------|
 | `--sex` | No sample sex data (no males and no females recorded), or no X chromosome in the input |
-| `--het` | The input has fewer than 50 variants |
+| `--het` | The input has fewer than 50 samples (PLINK's LD floor) |
 | `--case-control` | Cases or controls are missing (both are required) |
 | `--filter-controls` | No controls present — the HWE filter runs on everyone instead |
 
@@ -124,18 +124,89 @@ consolidated run log.
     discordant with the recorded sex are pruned. Requires 0 or exactly 2 values.
     Subject to auto-skip (see above).
 
-- **`--het [LOWER UPPER]`**
-  - *Type*: `float` (zero or two values)
+- **`--het [LOWER UPPER | sd [N]]`**
+  - *Type*: `str` (see the spec grammar below)
   - *Default*: `-0.15 0.15` when the flag is passed bare; step skipped if omitted
-  - *Description*: Heterozygosity rate (F coefficient) bounds. Samples outside
-    the range are pruned. Requires 0 or exactly 2 values. Subject to auto-skip
+  - *Description*: Heterozygosity bounds on PLINK's F coefficient, applied to
+    every dataset. Samples outside the bounds are pruned. Subject to auto-skip
     (see above).
 
-- **`--amr-het`**
-  - *Type*: `flag`
-  - *Default*: `False`
-  - *Description*: Use auto-detected heterozygosity bounds for the AMR ancestry
-    group instead of the fixed `--het` values. Only meaningful with `--ancestry`.
+- **`--het-ancestry LABEL [LOWER UPPER | sd [N]]`**
+  - *Type*: `str`, repeatable (one ancestry group per use)
+  - *Default*: none; `--het`'s value applies to every group
+  - *Description*: Override `--het` for one ancestry group. Requires
+    `--ancestry` — a run without ancestry prediction has no labels to match, so
+    passing it in a flat run is an error. Using it implies the het step runs,
+    even without `--het` or `--all-sample`. A label that no group in the run
+    carries produces a warning naming the groups that were predicted.
+
+#### The heterozygosity spec grammar
+
+Both flags take the same four-row spec, so they cannot mean different things:
+
+| Tokens | Meaning |
+|---|---|
+| *(none)* | fixed `-0.15 0.15` (the defaults) |
+| `LOWER UPPER` | fixed bounds on PLINK's `F` |
+| `sd` | bounds at `mean ± 3σ` of this dataset's `F` |
+| `sd N` | bounds at `mean ± N·σ` |
+
+`sd` bounds `F`, the same statistic the fixed bounds do — only the location and
+scale come from the data. A per-group override always beats the base `--het`.
+
+| Command | Effect |
+|---|---|
+| `--het` | every group: fixed `-0.15 0.15` |
+| `--het -0.2 0.2` | every group: fixed `-0.2 0.2` |
+| `--het sd` | every group / the whole input: `mean ± 3σ` |
+| `--het sd 2.5` | every group: `mean ± 2.5σ` |
+| `--het -0.2 0.2 --het-ancestry AMR sd` | AMR adaptive, everything else `-0.2 0.2` |
+| `--het sd 2 --het-ancestry AMR sd 1.5` | 2σ everywhere, AMR tightened to 1.5σ |
+| `--het-ancestry AMR sd --het-ancestry CAH -0.3 0.3` | adaptive and custom ranges, mixed per group |
+
+#### When to reach for `sd`
+
+Fixed bounds are one absolute cut applied to groups whose dispersion differs by
+an order of magnitude. Measured on GP2 r12 (10k subset, 9,759 samples across 10
+groups), `sd(F)` is 0.0669 for AMR against 0.0088 for EUR, so `±0.15` is a 2.24σ
+cut for AMR and a 17σ cut for EUR. In practice `--het -0.15 0.15` is an AMR-only
+filter: 31 of the 35 samples it prunes cohort-wide are AMR.
+
+`sd` expresses the cut in multiples of a group's own spread instead. Three
+things follow that are worth knowing before using it:
+
+- **`sd` and fixed are not interchangeable defaults.** On the same data a global
+  `sd 3` prunes 137 samples where fixed prunes 35, and EUR alone goes from 2 to
+  85. That is why the per-group override exists — `sd` is not the global default.
+- **`sd N` is a dispersion multiplier, not an expected-flag-rate dial.** The
+  "3σ ≈ 0.3%" intuition assumes normality; heterozygosity within an admixed
+  group is often skewed and multimodal by admixture proportion, which is the
+  premise of the feature.
+- **`sd` is not robust, deliberately.** Mean and σ are computed over every
+  sample, outliers included, so a real subpopulation inflates σ, widens the
+  bounds and spares itself. For AMR at `sd 3` the bounds work out to
+  `-0.177 .. +0.225` — wider than the observed range on both sides, so het
+  pruning is effectively a no-op for that group. That is the intended outcome
+  (see below), but it means het pruning is **not** a contamination screen for a
+  widely-dispersed group. On small groups, σ estimated near the 50-sample floor
+  makes the boundary itself wobble in a way a fixed bound does not.
+
+#### Why AMR, and why `sd 3` prunes nothing there
+
+The long-standing rationale for special-casing AMR was that "heterozygosity is
+higher in admixed populations." On GP2 r12 that is not what the data shows: AMR
+has the *lowest* mean het rate and the *highest* mean F of all ten groups, and
+30 of the 31 samples fixed bounds prune are on the heterozygote-*deficit* side
+(`F >= +0.15`), 28 of them from a single contributing cohort.
+
+AMR is a pooled label spanning heterogeneous admixture proportions; pooling
+those allele frequencies produces an apparent heterozygote deficit (Wahlund),
+pushing a structured subgroup past the fixed **upper** bound. Those samples sit
+at only ~2.5σ of AMR's own spread. So `sd 3` pruning zero AMR samples is the
+correct outcome rather than under-pruning — `sd 2` would prune 21 of them, which
+is to say it would discard the very samples the feature exists to keep. The
+per-group multiplier exists so base and group *can* disagree, not because AMR
+should be tightened.
 
 - **`--related`**
   - *Type*: `flag`
@@ -176,6 +247,9 @@ consolidated run log.
   - *Description*: Run callrate, sex, het, and related with default thresholds.
     Note that the callrate threshold under this flag is **0.05**, not the 0.02
     used by a bare `--callrate`. Does not include `--kinship-check`.
+    Passing `--het` alongside it still applies — `--all-sample` turns the step
+    on, `--het` supplies the bounds — so `--all-sample --het sd` runs the full
+    sample battery with derived heterozygosity bounds.
 
 ---
 

--- a/docs/default_pipeline_overview.md
+++ b/docs/default_pipeline_overview.md
@@ -7,16 +7,20 @@ GenoTools' default pipeline commences with ancestry prediction, followed by a se
 
 ### Ancestry Prediction Pipeline
 
-The `Ancestry` class in GenoTools provides a comprehensive pipeline for ancestry predictions in genetic data. Key features include:
+The `AncestryModel` class (`genotools/ancestry/model.py`) provides a comprehensive pipeline for ancestry predictions in genetic data. Key features include:
 
 - **Data Preparation**: Processes and prunes genotype data, aligns it with reference panels, and prepares labeled datasets for analysis.
 - **Principal Component Analysis**: Performs PCA to transform the genetic data for downstream analysis, crucial for capturing genetic variance.
 - **Machine Learning Pipeline**: Utilizes a combination of UMAP and XGBoost for sophisticated ancestry prediction, including training, parameter tuning, and evaluation.
-- **Flexible Prediction Environment**: Supports predictions both in local, containerized, and cloud environments, catering to diverse computational needs.
+- **Local Prediction**: Prediction runs locally, in process. `--container`,
+  `--singularity` and `--cloud` were removed in 2.0 and are rejected with an
+  error — the container images were built around a 1.x model format that 2.0
+  cannot load, and cloud prediction was never implemented in any version. See
+  [MIGRATION_2.0.md](../MIGRATION_2.0.md).
 - **Admixture Analysis**: Adjusts labels for samples with complex genetic backgrounds using clustering techniques.
 - **Cohort Splitting**: Efficiently splits data based on predicted ancestries, facilitating focused analysis on specific genetic groups.
 
-Designed for robustness and versatility, the `Ancestry` class is a key component of GenoTools, streamlining complex tasks in ancestry estimation and genetic data analysis.
+Designed for robustness and versatility, `AncestryModel` is a key component of GenoTools, streamlining complex tasks in ancestry estimation and genetic data analysis.
 
 
 ### QC Steps
@@ -26,7 +30,15 @@ Following ancestry analysis, the pipeline undergoes these sample-level and varia
 - **Callrate**: Default threshold: 0.05
 - **Sex Check**: Default cutoffs: [0.25, 0.75]
 - **Relatedness Check**: Enabled by default
-- **Heterozygosity Rate (Het)**: Default range: [-0.15, 0.15]
+- **Heterozygosity (Het)**: Default range: `[-0.15, 0.15]` on PLINK's F
+  coefficient. Bounds can instead be derived from each dataset's own spread
+  with `--het sd [N]` (`mean ± N·σ` of F, N defaults to 3), and overridden for
+  a single ancestry group with `--het-ancestry LABEL ...`. Under `--ancestry`
+  the base applies to every group unless a group has an override. Fixed bounds
+  cut groups of very different dispersion at very different strictness, which
+  is what the `sd` form exists to address — see
+  [cli_args.md](cli_args.md#the-heterozygosity-spec-grammar) for the grammar
+  and for when to prefer each.
 
 ### Variant-Level QC Steps
 - **Case-Control Check**: Default threshold: 1e-4

--- a/docs/genotools_function_guide.md
+++ b/docs/genotools_function_guide.md
@@ -111,7 +111,7 @@ Executes sex-based pruning on genotype data using PLINK.
 ## run_het_prune
 
 ```python
-run_het_prune(self, het_filter=[-0.25,0.25])
+filter_heterozygosity(data, config: HetConfig, out_path)
 ```
 
 ### Description
@@ -120,7 +120,15 @@ Executes heterozygosity-based pruning on genotype data using PLINK.
 
 ### Parameters
 
-- **het_filter**: Threshold for acceptable heterozygosity rate. Defaults to [-0.25,0.25].
+- **config**: A `HetConfig`. `f_lower`/`f_upper` are fixed bounds on PLINK's F
+  coefficient, defaulting to `-0.15`/`0.15`. Setting `auto_detect=True` derives
+  the bounds from the data instead, at `mean ± auto_sd · σ` of F (`auto_sd`
+  defaults to `3.0`); `f_lower`/`f_upper` are then unused. The legacy
+  `f_lower=f_upper=-1.0` sentinel also derives bounds, but from the
+  heterozygosity *rate* at 3σ — retained for existing callers.
+
+The 1.x `SampleQC.run_het_prune(het_filter=[-0.25, 0.25])` signature is gone,
+and its default was never `[-0.25, 0.25]` in the shipped pipeline.
 
 ### Returns
 

--- a/genotools/cli/parser.py
+++ b/genotools/cli/parser.py
@@ -81,6 +81,46 @@ class InputArgs:
         raise ValueError("No input file specified")
 
 
+@dataclass(frozen=True)
+class HetSpec:
+    """One resolved heterozygosity specification.
+
+    Both ``--het`` and ``--het-ancestry LABEL`` accept the same four-row
+    grammar, so both resolve to one of these:
+
+    ==================  ====================================================
+    Tokens              Meaning
+    ==================  ====================================================
+    *(none)*            fixed ``-0.15 0.15`` (the defaults)
+    ``LOWER UPPER``     fixed bounds on PLINK's F
+    ``sd``              ``mean +/- 3 * sd`` of this dataset's F
+    ``sd N``            ``mean +/- N * sd``
+    ==================  ====================================================
+
+    Sharing one spec type is what keeps the two flags from drifting into
+    different rules: :func:`_parse_het_spec` is the only thing that builds one.
+    """
+
+    auto: bool = False
+    sd: float = 3.0
+    lower: float = -0.15
+    upper: float = 0.15
+
+    def to_het_config(self) -> HetConfig:
+        """Convert to the step-level HetConfig.
+
+        ``lower``/``upper`` ride along unused when ``auto`` is set. They are
+        deliberately *not* forced to the legacy ``[-1, -1]`` sentinel, which
+        would select HetConfig's rate-based path instead of the F-based one.
+        """
+        return HetConfig(
+            f_lower=self.lower,
+            f_upper=self.upper,
+            auto_detect=self.auto,
+            auto_sd=self.sd,
+        )
+
+
 @dataclass
 class SampleQCArgs:
     """Sample-level QC arguments."""
@@ -94,11 +134,16 @@ class SampleQCArgs:
     female_max_f: float = 0.25
     male_min_f: float = 0.75
 
-    # Heterozygosity
+    # Heterozygosity. het_lower/het_upper (or het_auto/het_auto_sd) are the
+    # base, applying to every dataset; het_by_ancestry overrides it for named
+    # ancestry groups. Resolve the pair through het_config_for -- never read
+    # them apart, or the two runner paths can disagree again.
     run_het: bool = False
     het_lower: float = -0.15
     het_upper: float = 0.15
-    amr_het: bool = False
+    het_auto: bool = False
+    het_auto_sd: float = 3.0
+    het_by_ancestry: Dict[str, HetSpec] = field(default_factory=dict)
 
     # Relatedness
     run_related: bool = False
@@ -121,12 +166,41 @@ class SampleQCArgs:
             male_min_f=self.male_min_f,
         )
 
-    def to_het_config(self) -> HetConfig:
-        """Convert to HetConfig."""
-        return HetConfig(
-            f_lower=self.het_lower,
-            f_upper=self.het_upper,
+    def het_base_spec(self) -> HetSpec:
+        """The base spec, applying wherever no per-ancestry override does."""
+        return HetSpec(
+            auto=self.het_auto,
+            sd=self.het_auto_sd,
+            lower=self.het_lower,
+            upper=self.het_upper,
         )
+
+    def het_config_for(self, label: Optional[str] = None) -> HetConfig:
+        """Resolve the heterozygosity config for one dataset.
+
+        The single point where base and per-ancestry override are combined.
+        Both runner paths call it -- the flat run with ``label=None``, the
+        ancestry loop with each group's label -- so neither can decide het
+        config on its own. ``--amr-het`` was silently inert outside
+        ``--ancestry`` precisely because the two paths *did* decide separately
+        and only one of them knew about the flag.
+
+        Args:
+            label: Ancestry group being configured, or None for a flat run
+                (which has no labels, so only the base can apply).
+
+        Returns:
+            HetConfig for this dataset: the override for ``label`` if one was
+            given, otherwise the base.
+        """
+        spec = self.het_by_ancestry.get(label) if label is not None else None
+        if spec is None:
+            spec = self.het_base_spec()
+        return spec.to_het_config()
+
+    def to_het_config(self) -> HetConfig:
+        """Convert to HetConfig (the base, with no ancestry override)."""
+        return self.het_config_for(None)
 
     def to_related_config(self) -> RelatedConfig:
         """Convert to RelatedConfig."""
@@ -288,6 +362,19 @@ class PipelineArgs:
     ancestry: AncestryArgs = field(default_factory=AncestryArgs)
     gwas: GWASArgs = field(default_factory=GWASArgs)
 
+    def __post_init__(self) -> None:
+        """Validate arguments that span more than one group."""
+        # A flat run has no ancestry labels, so a per-label override cannot be
+        # honoured. Erroring is the point of this feature: --amr-het's defining
+        # bug was accepting exactly this and quietly doing nothing.
+        if self.sample_qc.het_by_ancestry and not self.ancestry.run_ancestry:
+            labels = ", ".join(sorted(self.sample_qc.het_by_ancestry))
+            raise ValueError(
+                f"--het-ancestry ({labels}) requires --ancestry: a run without "
+                f"ancestry prediction has no ancestry labels to match. To set "
+                f"bounds for the whole input, use --het instead."
+            )
+
     @property
     def geno_path(self) -> Path:
         """Get the input genotype path."""
@@ -377,7 +464,9 @@ class PipelineArgs:
             "het": [self.sample_qc.het_lower, self.sample_qc.het_upper]
             if self.sample_qc.run_het
             else None,
-            "amr_het": self.sample_qc.amr_het,
+            "het_auto": self.sample_qc.het_auto,
+            "het_auto_sd": self.sample_qc.het_auto_sd,
+            "het_by_ancestry": dict(self.sample_qc.het_by_ancestry),
             "related": self.sample_qc.run_related,
             "related_cutoff": self.sample_qc.related_cutoff,
             "duplicated_cutoff": self.sample_qc.duplicated_cutoff,
@@ -539,19 +628,37 @@ Examples:
         metavar="VALUE",
         help="Sex check thresholds [female_max_f male_min_f] (default: 0.25 0.75)",
     )
+    # type=str, not float: the spec grammar mixes numbers with the "sd"
+    # keyword, so coercion moves into _parse_het_spec. argparse still parses
+    # leading negatives here -- its negative-number heuristic keys off whether
+    # the parser has number-like option strings, not off the argument type,
+    # and GenoTools has none (nor any positionals for greedy nargs to eat).
     sample_group.add_argument(
         "--het",
-        type=float,
+        type=str,
         nargs="*",
         default=None,
-        metavar="VALUE",
-        help="Heterozygosity thresholds [lower upper] (default: -0.15 0.15)",
+        metavar="SPEC",
+        help=(
+            "Heterozygosity bounds for every dataset: [LOWER UPPER] fixed "
+            "bounds on F, or 'sd [N]' for bounds at N standard deviations of "
+            "this dataset's own F (default: -0.15 0.15, or 3 sd for bare 'sd')"
+        ),
     )
     sample_group.add_argument(
-        "--amr-het",
-        "--amr_het",  # deprecated underscore spelling
-        action="store_true",
-        help="Use auto-detect heterozygosity for AMR samples",
+        # No underscore alias: underscores exist only as deprecated 1.x
+        # spellings, and this flag is new. Same as every other 2.0 addition.
+        "--het-ancestry",
+        type=str,
+        nargs="+",
+        action="append",
+        default=None,
+        metavar="SPEC",
+        help=(
+            "Override --het for one ancestry group: LABEL followed by the "
+            "same spec ('sd [N]' or LOWER UPPER). Repeatable, one group per "
+            "use. Requires --ancestry"
+        ),
     )
     sample_group.add_argument(
         "--related",
@@ -802,29 +909,162 @@ def _parse_sex_args(
         )
 
 
-def _parse_het_args(
-    het_values: Optional[List[float]],
-) -> Tuple[bool, float, float]:
-    """Parse heterozygosity arguments.
+#: Spelling of the data-derived mode on the command line. The config layer
+#: calls it ``auto_detect``, which predates the multiplier being user-visible;
+#: "auto 3" would read as "automatic... three?". Only the location and scale
+#: are derived from the data - the multiplier is a human choice - so the CLI
+#: says ``sd``, and ``--het sd 2`` says exactly what it does.
+_HET_SD_TOKEN = "sd"
+
+
+def _het_float(token: str, flag: str) -> float:
+    """Coerce one spec token to a float with an actionable error.
+
+    ``--het`` is ``type=str`` so the grammar can carry the ``sd`` keyword,
+    which means argparse no longer supplies the type error. This does.
+    """
+    try:
+        return float(token)
+    except ValueError:
+        raise ValueError(
+            f"{flag} expects numbers or '{_HET_SD_TOKEN}', got {token!r}"
+        ) from None
+
+
+def _parse_het_spec(tokens: Sequence[str], flag: str) -> HetSpec:
+    """Resolve one heterozygosity spec - the single grammar for both flags.
+
+    ``--het`` and ``--het-ancestry LABEL`` share this so they cannot drift into
+    different rules or different error wording. The forms never collide:
+    ``sd`` is a keyword, so a two-token spec is fixed bounds when it starts
+    with a number and a multiplier when it starts with ``sd``.
 
     Args:
-        het_values: List of threshold values or None.
+        tokens: Spec tokens, with any ancestry label already stripped.
+        flag: Flag name, for error messages.
 
     Returns:
-        Tuple of (run_het, het_lower, het_upper).
+        The resolved HetSpec.
+
+    Raises:
+        ValueError: On unparseable tokens, a bad arity, a non-positive
+            multiplier, or bounds that are not ordered.
+    """
+    if len(tokens) == 0:
+        return HetSpec()
+
+    if tokens[0].lower() == _HET_SD_TOKEN:
+        if len(tokens) == 1:
+            return HetSpec(auto=True)
+        if len(tokens) == 2:
+            sd = _het_float(tokens[1], flag)
+            if sd <= 0:
+                raise ValueError(
+                    f"{flag} '{_HET_SD_TOKEN}' multiplier must be greater "
+                    f"than 0, got {sd}"
+                )
+            return HetSpec(auto=True, sd=sd)
+        raise ValueError(
+            f"{flag} '{_HET_SD_TOKEN}' takes at most one multiplier, got "
+            f"{len(tokens) - 1}: {list(tokens[1:])}"
+        )
+
+    if len(tokens) == 2:
+        lower = _het_float(tokens[0], flag)
+        upper = _het_float(tokens[1], flag)
+        # The 1.x sentinel for "derive the bounds", still reachable on old
+        # command lines. It has a real keyword now, so accept but redirect:
+        # a silent second spelling is worse than a deprecation.
+        if lower == -1.0 and upper == -1.0:
+            from ..core.logging import get_logger
+
+            get_logger(__name__).warning(
+                f"{flag} -1 -1 is deprecated; use "
+                f"'{flag} {_HET_SD_TOKEN}' instead."
+            )
+            return HetSpec(auto=True)
+        if lower >= upper:
+            raise ValueError(
+                f"{flag} lower bound ({lower}) must be less than the upper "
+                f"bound ({upper})"
+            )
+        return HetSpec(lower=lower, upper=upper)
+
+    # Report an unparseable token as a type error before falling back to the
+    # arity message: "--het abc" wanted 'abc' explained, not counted.
+    for token in tokens:
+        _het_float(token, flag)
+    raise ValueError(
+        f"{flag} requires 0 or 2 values, or '{_HET_SD_TOKEN}' [N], got "
+        f"{len(tokens)}: {list(tokens)}"
+    )
+
+
+def _parse_het_args(
+    het_values: Optional[List[str]],
+) -> Tuple[bool, HetSpec]:
+    """Parse the base --het argument.
+
+    Args:
+        het_values: Raw spec tokens, or None when the flag was not passed.
+
+    Returns:
+        Tuple of (run_het, spec).
     """
     if het_values is None:
-        return False, -0.15, 0.15
+        return False, HetSpec()
+    return True, _parse_het_spec(het_values, "--het")
 
-    if len(het_values) == 0:
-        # Flag used without values - use defaults
-        return True, -0.15, 0.15
-    elif len(het_values) == 2:
-        return True, het_values[0], het_values[1]
-    else:
-        raise ValueError(
-            f"--het requires 0 or 2 values, got {len(het_values)}: {het_values}"
-        )
+
+def _parse_het_ancestry_args(
+    occurrences: Optional[List[List[str]]],
+) -> Dict[str, HetSpec]:
+    """Parse repeated --het-ancestry occurrences into per-label specs.
+
+    Args:
+        occurrences: One token list per use of the flag, each beginning with
+            an ancestry label, or None when the flag was not passed.
+
+    Returns:
+        Mapping of ancestry label to its spec. Empty when the flag is unused.
+
+    Raises:
+        ValueError: On a missing spec, a label that looks like a spec token,
+            or the same label overridden twice.
+    """
+    specs: Dict[str, HetSpec] = {}
+    for tokens in occurrences or []:
+        label, rest = tokens[0], tokens[1:]
+        # Guard the easy transposition: --het-ancestry sd 2 names no group.
+        if label.lower() == _HET_SD_TOKEN or _is_number(label):
+            raise ValueError(
+                f"--het-ancestry expects an ancestry label first, got "
+                f"{label!r}. Usage: --het-ancestry LABEL "
+                f"['{_HET_SD_TOKEN}' [N] | LOWER UPPER]"
+            )
+        # A bare label would silently mean "fixed defaults for this group",
+        # which is the class of quiet no-op this flag exists to remove.
+        if not rest:
+            raise ValueError(
+                f"--het-ancestry {label} needs a spec: "
+                f"'{_HET_SD_TOKEN}' [N], or LOWER UPPER"
+            )
+        if label in specs:
+            raise ValueError(
+                f"--het-ancestry {label} given more than once; pass one "
+                f"spec per ancestry group"
+            )
+        specs[label] = _parse_het_spec(rest, f"--het-ancestry {label}")
+    return specs
+
+
+def _is_number(token: str) -> bool:
+    """Whether a token parses as a float."""
+    try:
+        float(token)
+    except ValueError:
+        return False
+    return True
 
 
 def _parse_ld_args(
@@ -857,7 +1097,6 @@ def _parse_ld_args(
 _DEPRECATED_SPELLINGS = {
     "--all_sample": "--all-sample",
     "--all_variant": "--all-variant",
-    "--amr_het": "--amr-het",
     "--case_control": "--case-control",
     "--covar_names": "--covar-names",
     "--duplicated_cutoff": "--duplicated-cutoff",
@@ -873,6 +1112,46 @@ _DEPRECATED_SPELLINGS = {
     "--skip_fails": "--skip-fails",
     "--subset_ancestry": "--subset-ancestry",
 }
+
+#: Flags removed outright, mapped to what to use instead. Declared here rather
+#: than in the parser so a 1.x command line gets a targeted error naming the
+#: replacement instead of argparse's bare "unrecognized arguments".
+#:
+#: ``--amr-het`` switched the het step to data-derived bounds for one
+#: hardcoded label. It was read in exactly one place, inside the --ancestry
+#: branch, so it did nothing at all in a flat run - which is how the
+#: per-ancestry production workflow runs QC. ``--het-ancestry AMR sd`` is the
+#: same rule, on any label, in either run shape.
+_REMOVED_FLAGS: Dict[str, str] = {
+    "--amr-het": (
+        "Use '--het-ancestry AMR sd' instead, which also works in a flat run "
+        "(--amr-het silently did nothing without --ancestry). See "
+        "MIGRATION_2.0.md."
+    ),
+    "--amr_het": (
+        "Use '--het-ancestry AMR sd' instead, which also works in a flat run "
+        "(--amr_het silently did nothing without --ancestry). See "
+        "MIGRATION_2.0.md."
+    ),
+}
+
+
+def _reject_removed_flags(args: Optional[Sequence[str]] = None) -> None:
+    """Give an actionable error for a flag that 2.1 removed.
+
+    Runs before argparse so the message survives - and before
+    ``_reject_boolean_values``, so ``--amr-het False`` reports the removal
+    rather than the (now irrelevant) presence-flag rule.
+    """
+    import sys
+
+    argv = list(args) if args is not None else sys.argv[1:]
+    used = {tok.split("=", 1)[0] for tok in argv if tok.startswith("--")}
+    for flag in sorted(used & set(_REMOVED_FLAGS)):
+        raise ValueError(
+            f"{flag} was removed in GenoTools 2.0.1. {_REMOVED_FLAGS[flag]}"
+        )
+
 
 # Flags replaced by a --no- inverse. 1.x defaulted both to on, which is now the
 # default, so passing them changes nothing.
@@ -972,6 +1251,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> PipelineArgs:
         ValueError: If argument validation fails.
     """
     parser = create_parser()
+    _reject_removed_flags(args)
     _reject_boolean_values(parser, args)
     ns = parser.parse_args(args)
     _warn_deprecated_flags(args)
@@ -982,8 +1262,15 @@ def parse_args(args: Optional[Sequence[str]] = None) -> PipelineArgs:
 
     # Parse complex arguments
     run_sex, female_max_f, male_min_f = _parse_sex_args(ns.sex)
-    run_het, het_lower, het_upper = _parse_het_args(ns.het)
+    run_het, het_spec = _parse_het_args(ns.het)
+    het_by_ancestry = _parse_het_ancestry_args(ns.het_ancestry)
     run_ld, ld_window, ld_step, ld_r2 = _parse_ld_args(ns.ld)
+
+    # An override implies the system it overrides is on. (Unlike the round-10
+    # treatment of --container, which fails loudly: those flags could not work,
+    # this one can.)
+    if het_by_ancestry:
+        run_het = True
 
     # Handle --all-sample
     run_callrate = ns.callrate is not None
@@ -1041,9 +1328,11 @@ def parse_args(args: Optional[Sequence[str]] = None) -> PipelineArgs:
         female_max_f=female_max_f,
         male_min_f=male_min_f,
         run_het=run_het,
-        het_lower=het_lower,
-        het_upper=het_upper,
-        amr_het=ns.amr_het,
+        het_lower=het_spec.lower,
+        het_upper=het_spec.upper,
+        het_auto=het_spec.auto,
+        het_auto_sd=het_spec.sd,
+        het_by_ancestry=het_by_ancestry,
         run_related=run_related,
         related_cutoff=ns.related_cutoff,
         duplicated_cutoff=ns.duplicated_cutoff,

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -28,7 +28,7 @@ import shutil
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pandas as pd
 
@@ -51,6 +51,9 @@ from ..core.validation import (
     sex_skip_reason,
 )
 from ..qc.results import unrun_result
+
+if TYPE_CHECKING:  # QC config is imported lazily in _initialize_modules
+    from ..qc.config import HetConfig
 
 logger = get_logger(__name__)
 
@@ -483,18 +486,15 @@ class PipelineRunner:
         if not steps:
             return self._build_output()
 
-        # Run QC for each ancestry group
-        het_value = [self.args.sample_qc.het_lower, self.args.sample_qc.het_upper]
+        # An override naming a group that was never predicted would otherwise
+        # do nothing at all, silently - --amr-het's failure mode on any panel
+        # that does not spell the group "AMR".
+        self._warn_unmatched_het_labels()
 
         for label in self.state.labels_list:
             # Set up paths for this ancestry
             geno_path = f"{self.args.out_path}_ancestry_{label}"
             out_path = f"{self.args.out_path}_{label}"
-
-            # Handle AMR heterozygosity
-            current_het = het_value
-            if self.args.sample_qc.amr_het and label == "AMR":
-                current_het = [-1.0, -1.0]
 
             # Decided per group: an ancestry group's sample count can differ
             # sharply from the cohort validate_input saw. Counting samples reads
@@ -514,12 +514,34 @@ class PipelineRunner:
                 steps=steps,
                 geno_path=geno_path,
                 out_path=out_path,
-                het_values=current_het,
+                het_config=self.args.sample_qc.het_config_for(label),
                 ancestry_label=label,
                 skip_reasons=group_skips,
             )
 
         return self._build_output()
+
+    def _warn_unmatched_het_labels(self) -> None:
+        """Warn once for each --het-ancestry label that was never predicted.
+
+        The label vocabulary is entirely user-supplied - from the --ref-labels
+        TSV, or from a pickled model's encoder - so a typo, or a panel that
+        spells the group differently, produces an override that matches
+        nothing. Naming the predicted labels turns that into a fixable
+        message rather than a silently ignored flag.
+        """
+        assert self.state is not None
+        predicted = set(self.state.labels_list or [])
+        unmatched = sorted(
+            set(self.args.sample_qc.het_by_ancestry) - predicted
+        )
+        if not unmatched:
+            return
+        logger.warning(
+            f"--het-ancestry {', '.join(unmatched)}: no such ancestry group in "
+            f"this run, so the override does nothing. Predicted groups: "
+            f"{', '.join(sorted(predicted))}."
+        )
 
     def _resolve_existing_geno(self, geno_path: str) -> str:
         """Resolve the prefix whose pfiles are actually on disk.
@@ -602,10 +624,14 @@ class PipelineRunner:
         """
         assert self.state is not None
 
+        # A flat run has no labels, so only the base spec can apply - but it
+        # must still be *passed*. Omitting it here is what made --amr-het inert
+        # in exactly the run shape the per-ancestry production workflow uses.
         self._run_qc_pipeline(
             steps=steps,
             geno_path=str(self.state.geno_path),
             out_path=str(self.state.out_path),
+            het_config=self.args.sample_qc.het_config_for(None),
             skip_reasons=self._skip_reasons(steps, str(self.state.geno_path)),
         )
 
@@ -909,7 +935,7 @@ class PipelineRunner:
         steps: List[str],
         geno_path: str,
         out_path: str,
-        het_values: Optional[List[float]] = None,
+        het_config: Optional["HetConfig"] = None,
         ancestry_label: str = "all",
         skip_reasons: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
@@ -919,7 +945,10 @@ class PipelineRunner:
             steps: List of QC steps to run.
             geno_path: Input genotype path.
             out_path: Output path.
-            het_values: Optional heterozygosity thresholds.
+            het_config: Resolved HetConfig for this dataset. Callers resolve it
+                through ``SampleQCArgs.het_config_for`` rather than passing raw
+                thresholds, so the base/override precedence is decided in one
+                place for every run shape.
             ancestry_label: Ancestry label for this run.
             skip_reasons: Steps the input data rules out, mapped to why. They
                 stay in ``steps`` and are reported as skipped rather than
@@ -948,8 +977,8 @@ class PipelineRunner:
 
         # Get legacy args for parameter passing
         legacy_args = self.args.to_legacy_dict()
-        if het_values is not None:
-            legacy_args["het"] = het_values
+        if het_config is None:
+            het_config = self.args.sample_qc.het_config_for(None)
         if self._validation_decisions.disable_filter_controls:
             legacy_args["filter_controls"] = False
 
@@ -1058,6 +1087,7 @@ class PipelineRunner:
                         step_input=step_input,
                         step_output=step_output,
                         legacy_args=legacy_args,
+                        het_config=het_config,
                     )
                 except GenoToolsError as e:
                     logger.error(f"Step {step} failed: {e}")
@@ -1219,6 +1249,7 @@ class PipelineRunner:
         step_input: str,
         step_output: str,
         legacy_args: Dict[str, Any],
+        het_config: Optional["HetConfig"] = None,
     ) -> Optional[Dict[str, Any]]:
         """Run a single QC step using pure function modules.
 
@@ -1227,6 +1258,9 @@ class PipelineRunner:
             step_input: Input path.
             step_output: Output path.
             legacy_args: Legacy argument dictionary.
+            het_config: Resolved HetConfig for the het step. Passed in already
+                resolved rather than rebuilt from legacy_args, which cannot
+                express the derived-bounds mode.
 
         Returns:
             Step result dictionary in legacy format, or None if step skipped.
@@ -1249,9 +1283,14 @@ class PipelineRunner:
             return result.to_dict()
 
         elif step == "het":
-            het_vals = legacy_args["het"]
-            config = self._config_classes["HetConfig"](f_lower=het_vals[0], f_upper=het_vals[1])
-            result = self._new_modules["filter_heterozygosity"](data, config, Path(step_output))
+            if het_config is None:
+                het_vals = legacy_args["het"]
+                het_config = self._config_classes["HetConfig"](
+                    f_lower=het_vals[0], f_upper=het_vals[1]
+                )
+            result = self._new_modules["filter_heterozygosity"](
+                data, het_config, Path(step_output)
+            )
             return result.to_dict()
 
         elif step == "related":

--- a/genotools/qc/config.py
+++ b/genotools/qc/config.py
@@ -76,28 +76,48 @@ class SexConfig(ThresholdConfig):
 class HetConfig(ThresholdConfig):
     """Configuration for heterozygosity filtering.
 
-    Removes samples with extreme heterozygosity rates, either using
-    fixed F-statistic bounds or automatic detection based on standard
-    deviations from the mean.
+    Removes samples with extreme heterozygosity, either using fixed
+    F-statistic bounds or bounds derived from the group's own dispersion.
+
+    The CLI spells the derived mode ``sd`` (``--het sd [N]``); the config
+    fields keep the ``auto_*`` prefix that predates it. ``--het sd N`` maps to
+    ``auto_detect=True, auto_sd=N``.
+
+    Two statistics are in play, for back-compatibility reasons:
+
+    - ``auto_detect=True`` thresholds **F** at ``mean +/- auto_sd * sd``, so
+      both modes bound the same statistic the fixed bounds do. This is what
+      the CLI's ``sd`` mode uses.
+    - The legacy ``f_lower == f_upper == -1.0`` sentinel thresholds the derived
+      **heterozygosity rate** instead, at 3 standard deviations. Retained
+      unchanged for Python-API callers that already pass it; the CLI no longer
+      produces it.
 
     Attributes:
-        f_lower: Lower F-statistic bound. Samples with F < this are removed.
-            Set to -1.0 along with f_upper to enable auto_detect mode.
+        f_lower: Lower F-statistic bound. Samples with F <= this are removed.
+            Set to -1.0 along with f_upper for the legacy rate-based mode.
             Default is -0.15.
-        f_upper: Upper F-statistic bound. Samples with F > this are removed.
-            Set to -1.0 along with f_lower to enable auto_detect mode.
+        f_upper: Upper F-statistic bound. Samples with F >= this are removed.
+            Set to -1.0 along with f_lower for the legacy rate-based mode.
             Default is 0.15.
-        auto_detect: If True (or if both f_lower and f_upper are -1.0),
-            use 3 standard deviations from the mean heterozygosity rate
-            to determine outliers. Default is False.
+        auto_detect: If True, derive bounds from the data rather than using
+            f_lower/f_upper. Default is False.
+        auto_sd: Multiplier on the standard deviation when auto_detect is True.
+            Must be > 0. Default is 3.0. Ignored when auto_detect is False.
+            This is a dispersion multiplier, not an expected-flag-rate dial:
+            heterozygosity within an admixed group is often skewed or
+            multimodal, so the 3-sigma-is-0.3% intuition does not transfer.
     """
 
     f_lower: float = -0.15
     f_upper: float = 0.15
     auto_detect: bool = False
+    auto_sd: float = 3.0
 
     def __post_init__(self) -> None:
-        # Special case: [-1, -1] means auto-detect mode
+        if self.auto_sd <= 0:
+            raise ValueError(f"auto_sd ({self.auto_sd}) must be greater than 0")
+        # Special case: [-1, -1] means legacy rate-based auto-detect mode
         if self.f_lower == -1.0 and self.f_upper == -1.0:
             return
         if not self.auto_detect:

--- a/genotools/qc/steps/heterozygosity.py
+++ b/genotools/qc/steps/heterozygosity.py
@@ -19,6 +19,7 @@ Removes samples with extreme heterozygosity rates using PLINK2.
 """
 
 from pathlib import Path
+from typing import Any, Dict, Tuple
 
 import pandas as pd
 
@@ -32,6 +33,79 @@ from genotools.qc.results import FilterResult
 logger = get_logger(__name__)
 
 
+def select_het_outliers(
+    het: pd.DataFrame, config: HetConfig
+) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    """Pick the outlier rows from a PLINK ``--het`` table.
+
+    Split out from :func:`filter_heterozygosity` so the bound arithmetic can be
+    tested against a frame with known mean and sigma, without PLINK in the loop.
+
+    Three modes, in precedence order:
+
+    1. ``config.auto_detect`` - bounds at ``mean +/- auto_sd * sd`` of **F**.
+       This is the CLI's ``--het sd [N]`` mode. Thresholding F (rather than the
+       derived rate) means both CLI spellings of ``--het`` bound the same
+       statistic.
+    2. The legacy ``f_lower == f_upper == -1.0`` sentinel - bounds at 3 standard
+       deviations of the derived **heterozygosity rate**. Preserved verbatim,
+       including the ``HET`` column it adds to the output, for Python-API
+       callers that already pass it. The CLI no longer produces this form.
+    3. Otherwise - fixed bounds on F.
+
+    Note that mean and sd are computed over every sample, outliers included, so
+    a genuinely dispersed group widens its own bounds. That is deliberate: a
+    real admixed subpopulation should not be clipped as contamination. The cost
+    is that ``sd`` mode is a weak contamination screen for wide groups.
+
+    Args:
+        het: Parsed ``.het`` table, with F, OBS_CT and O(HOM) columns.
+        config: Heterozygosity filtering configuration.
+
+    Returns:
+        Tuple of (outlier rows, metrics describing the mode and bounds).
+    """
+    if config.auto_detect:
+        mean = het["F"].mean()
+        std = het["F"].std()
+        low = mean - (config.auto_sd * std)
+        high = mean + (config.auto_sd * std)
+        outliers = het[(het["F"] < low) | (het["F"] > high)]
+        metrics = {
+            "het_mode": "sd",
+            "het_statistic": "F",
+            "het_sd": config.auto_sd,
+            "het_lower": low,
+            "het_upper": high,
+        }
+    elif config.f_lower == -1.0 and config.f_upper == -1.0:
+        het = het.assign(HET=(het["OBS_CT"] - het["O(HOM)"]) / het["OBS_CT"])
+        mean = het["HET"].mean()
+        std = het["HET"].std()
+        low = mean - (3 * std)
+        high = mean + (3 * std)
+        outliers = het[(het["HET"] < low) | (het["HET"] > high)]
+        metrics = {
+            "het_mode": "sd",
+            "het_statistic": "rate",
+            "het_sd": 3.0,
+            "het_lower": low,
+            "het_upper": high,
+        }
+    else:
+        outliers = het[
+            (het["F"] <= config.f_lower) | (het["F"] >= config.f_upper)
+        ]
+        metrics = {
+            "het_mode": "fixed",
+            "het_statistic": "F",
+            "het_sd": None,
+            "het_lower": config.f_lower,
+            "het_upper": config.f_upper,
+        }
+    return outliers, metrics
+
+
 def filter_heterozygosity(
     data: GenotypeData,
     config: HetConfig,
@@ -43,7 +117,8 @@ def filter_heterozygosity(
     sample contamination or inbreeding. The filtering process:
     1. LD-prune variants (geno=0.01, maf=0.05, indep-pairwise 50 5 0.5)
     2. Calculate per-sample heterozygosity on pruned set
-    3. Filter samples outside F-statistic bounds or 3 std devs from mean
+    3. Filter samples outside fixed F bounds, or outside bounds derived
+       from the data - see :func:`select_het_outliers`
 
     Args:
         data: Input genotype data.
@@ -63,11 +138,16 @@ def filter_heterozygosity(
     step_name = "het_prune"
 
     with step_context(step_name):
-        logger.info(
-            f"Filtering samples by heterozygosity "
-            f"(f_lower={config.f_lower}, f_upper={config.f_upper}, "
-            f"auto_detect={config.auto_detect})"
-        )
+        if config.auto_detect:
+            logger.info(
+                f"Filtering samples by heterozygosity "
+                f"(bounds derived per dataset at {config.auto_sd} sd of F)"
+            )
+        else:
+            logger.info(
+                f"Filtering samples by heterozygosity "
+                f"(f_lower={config.f_lower}, f_upper={config.f_upper})"
+            )
 
         # Validate input exists
         input_file = data.path.with_suffix(".pgen" if data.format == "pfile" else ".bed")
@@ -129,28 +209,15 @@ def filter_heterozygosity(
         if het_file.exists():
             het = pd.read_csv(het_file, sep=r"\s+")
 
-            # Determine if using auto-detect mode
-            use_auto = config.auto_detect or (
-                config.f_lower == -1.0 and config.f_upper == -1.0
-            )
+            het_outliers, het_metrics = select_het_outliers(het, config)
 
-            if use_auto:
-                # Calculate heterozygosity rate and use 3 std devs
-                het["HET"] = (het["OBS_CT"] - het["O(HOM)"]) / het["OBS_CT"]
-                het_mean = het["HET"].mean()
-                het_std = het["HET"].std()
-                het_low = het_mean - (3 * het_std)
-                het_high = het_mean + (3 * het_std)
-                het_outliers = het[(het["HET"] < het_low) | (het["HET"] > het_high)]
+            if het_metrics["het_mode"] == "sd":
                 logger.info(
-                    f"Auto-detect mode: mean={het_mean:.4f}, std={het_std:.4f}, "
-                    f"bounds=[{het_low:.4f}, {het_high:.4f}]"
+                    f"Derived bounds from the data: "
+                    f"sd={het_metrics['het_sd']} on {het_metrics['het_statistic']}, "
+                    f"bounds=[{het_metrics['het_lower']:.4f}, "
+                    f"{het_metrics['het_upper']:.4f}]"
                 )
-            else:
-                # Use fixed F-statistic bounds
-                het_outliers = het[
-                    (het["F"] <= config.f_lower) | (het["F"] >= config.f_upper)
-                ]
 
             outlier_count = het_outliers.shape[0]
             het_outliers.to_csv(outliers_out, sep="\t", header=True, index=False)
@@ -191,6 +258,12 @@ def filter_heterozygosity(
                 output=output,
                 samples_removed=samples_removed,
                 variants_removed=0,
+                # Counts only. The JSON report renders every metric as a row
+                # in a long (step, metric, pruned_count) table, so a
+                # descriptive value like het_mode="sd" would land under a
+                # column meaning "how many were pruned". The mode, statistic,
+                # multiplier and derived bounds go to the log instead - see
+                # the "Derived bounds from the data" line above.
                 metrics={
                     "outlier_count": outlier_count,
                 },

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='the_real_genotools', 
-    version='2.0.0', 
+    version='2.0.1', 
     packages=find_packages(exclude=["tests", "tests.*"]),
     author='Dan Vitale',
     author_email='d.vitale199@gmail.com',

--- a/tests/unit/test_cli/test_parser.py
+++ b/tests/unit/test_cli/test_parser.py
@@ -15,12 +15,14 @@
 
 """Tests for CLI argument parsing."""
 
+import logging
 from pathlib import Path
 from typing import List
 
 import pytest
 
 from genotools.cli.parser import (
+    HetSpec,
     InputArgs,
     SampleQCArgs,
     VariantQCArgs,
@@ -32,6 +34,8 @@ from genotools.cli.parser import (
     parse_args,
     _parse_sex_args,
     _parse_het_args,
+    _parse_het_ancestry_args,
+    _parse_het_spec,
     _parse_ld_args,
 )
 
@@ -88,6 +92,9 @@ class TestSampleQCArgs:
         assert args.run_het is False
         assert args.het_lower == -0.15
         assert args.het_upper == 0.15
+        assert args.het_auto is False
+        assert args.het_auto_sd == 3.0
+        assert args.het_by_ancestry == {}
         assert args.run_related is False
         assert args.related_cutoff == 0.0884
         assert args.duplicated_cutoff == 0.354
@@ -111,6 +118,78 @@ class TestSampleQCArgs:
         config = args.to_het_config()
         assert config.f_lower == -0.2
         assert config.f_upper == 0.2
+
+    def test_het_config_for_no_label_uses_base(self) -> None:
+        """A flat run has no label, so only the base can apply."""
+        args = SampleQCArgs(het_lower=-0.2, het_upper=0.2)
+        config = args.het_config_for(None)
+        assert config.auto_detect is False
+        assert (config.f_lower, config.f_upper) == (-0.2, 0.2)
+
+    def test_het_config_for_adaptive_base(self) -> None:
+        args = SampleQCArgs(het_auto=True, het_auto_sd=2.0)
+        config = args.het_config_for(None)
+        assert config.auto_detect is True
+        assert config.auto_sd == 2.0
+
+    def test_adaptive_base_avoids_the_legacy_sentinel(self) -> None:
+        """auto_detect must not arrive as [-1, -1].
+
+        HetConfig reads that sentinel as the legacy *rate*-based mode; the CLI's
+        sd mode thresholds F. If the spec ever forced the sentinel the two would
+        silently swap statistics.
+        """
+        config = SampleQCArgs(het_auto=True).het_config_for(None)
+        assert (config.f_lower, config.f_upper) != (-1.0, -1.0)
+
+    def test_het_config_for_unknown_label_falls_back_to_base(self) -> None:
+        args = SampleQCArgs(
+            het_lower=-0.2,
+            het_upper=0.2,
+            het_by_ancestry={"AMR": HetSpec(auto=True)},
+        )
+        config = args.het_config_for("EUR")
+        assert config.auto_detect is False
+        assert (config.f_lower, config.f_upper) == (-0.2, 0.2)
+
+    def test_override_beats_fixed_base(self) -> None:
+        args = SampleQCArgs(
+            het_lower=-0.2,
+            het_upper=0.2,
+            het_by_ancestry={"AMR": HetSpec(auto=True, sd=3.0)},
+        )
+        assert args.het_config_for("AMR").auto_detect is True
+        assert args.het_config_for("EUR").auto_detect is False
+
+    def test_fixed_override_beats_adaptive_base(self) -> None:
+        """The reverse direction: an adaptive base pinned back for one group."""
+        args = SampleQCArgs(
+            het_auto=True,
+            het_auto_sd=2.0,
+            het_by_ancestry={"CAH": HetSpec(lower=-0.3, upper=0.3)},
+        )
+        cah = args.het_config_for("CAH")
+        assert cah.auto_detect is False
+        assert (cah.f_lower, cah.f_upper) == (-0.3, 0.3)
+        assert args.het_config_for("EUR").auto_detect is True
+
+    def test_per_group_multiplier_differs_from_base(self) -> None:
+        args = SampleQCArgs(
+            het_auto=True,
+            het_auto_sd=2.0,
+            het_by_ancestry={"AMR": HetSpec(auto=True, sd=1.5)},
+        )
+        assert args.het_config_for("AMR").auto_sd == 1.5
+        assert args.het_config_for("EUR").auto_sd == 2.0
+
+    def test_to_het_config_matches_the_base(self) -> None:
+        """to_het_config is het_config_for(None); they cannot drift."""
+        args = SampleQCArgs(
+            het_auto=True,
+            het_auto_sd=2.5,
+            het_by_ancestry={"AMR": HetSpec(auto=True, sd=1.0)},
+        )
+        assert args.to_het_config() == args.het_config_for(None)
 
     def test_to_related_config(self) -> None:
         """to_related_config creates correct config."""
@@ -331,29 +410,173 @@ class TestParseSexArgs:
             _parse_sex_args([0.2])
 
 
+class TestParseHetSpec:
+    """Tests for _parse_het_spec, the shared grammar for both het flags.
+
+    One resolver backs --het and --het-ancestry, so these rows are the whole
+    grammar surface for both.
+    """
+
+    def test_no_tokens_is_fixed_defaults(self) -> None:
+        spec = _parse_het_spec([], "--het")
+        assert spec == HetSpec(auto=False, lower=-0.15, upper=0.15)
+
+    def test_two_numbers_are_fixed_bounds(self) -> None:
+        spec = _parse_het_spec(["-0.2", "0.2"], "--het")
+        assert spec.auto is False
+        assert (spec.lower, spec.upper) == (-0.2, 0.2)
+
+    def test_bare_sd_uses_default_multiplier(self) -> None:
+        spec = _parse_het_spec(["sd"], "--het")
+        assert spec.auto is True
+        assert spec.sd == 3.0
+
+    def test_sd_with_multiplier(self) -> None:
+        spec = _parse_het_spec(["sd", "2.5"], "--het")
+        assert spec.auto is True
+        assert spec.sd == 2.5
+
+    def test_sd_is_case_insensitive(self) -> None:
+        assert _parse_het_spec(["SD"], "--het").auto is True
+
+    def test_legacy_sentinel_maps_to_sd(self, caplog) -> None:
+        """--het -1 -1 was the 1.x way to ask for derived bounds.
+
+        Still accepted, since old command lines carry it, but redirected to the
+        keyword: a silent second spelling would be worse than a deprecation.
+        """
+        with caplog.at_level(logging.WARNING, logger="genotools"):
+            spec = _parse_het_spec(["-1", "-1"], "--het")
+        assert spec == HetSpec(auto=True, sd=3.0)
+        assert "deprecated" in caplog.text
+        assert "sd" in caplog.text
+
+    def test_sd_rejects_two_multipliers(self) -> None:
+        with pytest.raises(ValueError, match="at most one multiplier"):
+            _parse_het_spec(["sd", "2", "3"], "--het")
+
+    def test_sd_rejects_non_positive_multiplier(self) -> None:
+        with pytest.raises(ValueError, match="greater than 0"):
+            _parse_het_spec(["sd", "0"], "--het")
+
+    def test_sd_rejects_negative_multiplier(self) -> None:
+        with pytest.raises(ValueError, match="greater than 0"):
+            _parse_het_spec(["sd", "-2"], "--het")
+
+    def test_sd_rejects_unparseable_multiplier(self) -> None:
+        with pytest.raises(ValueError, match="expects numbers or 'sd'"):
+            _parse_het_spec(["sd", "abc"], "--het")
+
+    def test_lone_number_is_an_arity_error(self) -> None:
+        with pytest.raises(ValueError, match="requires 0 or 2 values"):
+            _parse_het_spec(["0.1"], "--het")
+
+    def test_three_numbers_is_an_arity_error(self) -> None:
+        with pytest.raises(ValueError, match="requires 0 or 2 values"):
+            _parse_het_spec(["0.1", "0.2", "0.3"], "--het")
+
+    def test_unparseable_token_reports_type_not_arity(self) -> None:
+        """--het abc lost argparse's type check when it became type=str.
+
+        The helper has to supply it, and the type error has to win over the
+        arity one: 'abc' wants explaining, not counting.
+        """
+        with pytest.raises(ValueError, match="expects numbers or 'sd'"):
+            _parse_het_spec(["abc"], "--het")
+
+    def test_unordered_bounds_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be less than"):
+            _parse_het_spec(["0.3", "0.1"], "--het")
+
+    def test_error_names_the_calling_flag(self) -> None:
+        """Both flags share the resolver, so errors must name the right one."""
+        with pytest.raises(ValueError, match="--het-ancestry AMR"):
+            _parse_het_spec(["0.1"], "--het-ancestry AMR")
+
+
 class TestParseHetArgs:
     """Tests for _parse_het_args helper."""
 
     def test_none_input(self) -> None:
         """None input returns disabled state."""
-        run, lower, upper = _parse_het_args(None)
+        run, spec = _parse_het_args(None)
         assert run is False
-        assert lower == -0.15
-        assert upper == 0.15
+        assert spec == HetSpec()
 
     def test_empty_list(self) -> None:
         """Empty list enables with defaults."""
-        run, lower, upper = _parse_het_args([])
+        run, spec = _parse_het_args([])
         assert run is True
-        assert lower == -0.15
-        assert upper == 0.15
+        assert (spec.auto, spec.lower, spec.upper) == (False, -0.15, 0.15)
 
     def test_two_values(self) -> None:
         """Two values are parsed correctly."""
-        run, lower, upper = _parse_het_args([-0.2, 0.2])
+        run, spec = _parse_het_args(["-0.2", "0.2"])
         assert run is True
-        assert lower == -0.2
-        assert upper == 0.2
+        assert (spec.lower, spec.upper) == (-0.2, 0.2)
+
+    def test_sd(self) -> None:
+        run, spec = _parse_het_args(["sd"])
+        assert run is True
+        assert (spec.auto, spec.sd) == (True, 3.0)
+
+    def test_sd_with_multiplier(self) -> None:
+        run, spec = _parse_het_args(["sd", "2"])
+        assert run is True
+        assert (spec.auto, spec.sd) == (True, 2.0)
+
+    def test_wrong_count_raises(self) -> None:
+        """Wrong value count raises error.
+
+        TestParseSexArgs and TestParseLdArgs both have this; --het's was
+        missing.
+        """
+        with pytest.raises(ValueError, match="requires 0 or 2 values"):
+            _parse_het_args(["0.2"])
+
+
+class TestParseHetAncestryArgs:
+    """Tests for _parse_het_ancestry_args helper."""
+
+    def test_none_is_empty(self) -> None:
+        assert _parse_het_ancestry_args(None) == {}
+
+    def test_single_sd_override(self) -> None:
+        specs = _parse_het_ancestry_args([["AMR", "sd"]])
+        assert specs == {"AMR": HetSpec(auto=True, sd=3.0)}
+
+    def test_sd_with_multiplier(self) -> None:
+        specs = _parse_het_ancestry_args([["AMR", "sd", "1.5"]])
+        assert specs["AMR"].sd == 1.5
+
+    def test_fixed_range_override(self) -> None:
+        specs = _parse_het_ancestry_args([["CAH", "-0.3", "0.3"]])
+        assert specs["CAH"] == HetSpec(auto=False, lower=-0.3, upper=0.3)
+
+    def test_repeats_accumulate(self) -> None:
+        specs = _parse_het_ancestry_args([["AMR", "sd"], ["CAH", "-0.3", "0.3"]])
+        assert set(specs) == {"AMR", "CAH"}
+        assert specs["AMR"].auto is True
+        assert specs["CAH"].auto is False
+
+    def test_duplicate_label_rejected(self) -> None:
+        with pytest.raises(ValueError, match="given more than once"):
+            _parse_het_ancestry_args([["AMR", "sd"], ["AMR", "-0.3", "0.3"]])
+
+    def test_label_without_spec_rejected(self) -> None:
+        """A bare label would silently mean "fixed defaults for this group" -
+        the class of quiet no-op this flag exists to remove."""
+        with pytest.raises(ValueError, match="needs a spec"):
+            _parse_het_ancestry_args([["AMR"]])
+
+    def test_missing_label_rejected(self) -> None:
+        """--het-ancestry sd 2 names no group; catch the transposition."""
+        with pytest.raises(ValueError, match="expects an ancestry label first"):
+            _parse_het_ancestry_args([["sd", "2"]])
+
+    def test_numeric_label_rejected(self) -> None:
+        with pytest.raises(ValueError, match="expects an ancestry label first"):
+            _parse_het_ancestry_args([["-0.3", "0.3"]])
 
 
 class TestParseLdArgs:
@@ -549,6 +772,161 @@ class TestParseArgs:
         ])
         assert args.gwas.run_pca is True
         assert args.gwas.n_pcs == 20
+
+
+class TestHetGrammarEndToEnd:
+    """Every row of the --het / --het-ancestry semantics table, through
+    parse_args - the layer users actually reach."""
+
+    BASE = ["--pfile", "/data/test", "--out", "/tmp/out"]
+
+    def _sample_qc(self, extra: List[str]):
+        return parse_args(self.BASE + extra).sample_qc
+
+    def test_bare_het_is_unchanged(self) -> None:
+        sq = self._sample_qc(["--het"])
+        assert sq.run_het is True
+        assert (sq.het_lower, sq.het_upper) == (-0.15, 0.15)
+        assert sq.het_auto is False
+
+    def test_fixed_bounds(self) -> None:
+        sq = self._sample_qc(["--het", "-0.2", "0.2"])
+        assert (sq.het_lower, sq.het_upper) == (-0.2, 0.2)
+
+    def test_negative_bounds_survive_type_str(self) -> None:
+        """--het is type=str now; argparse's negative-number heuristic keys off
+        the parser's option strings, not the argument type, so a leading
+        negative must still parse rather than read as a flag."""
+        sq = self._sample_qc(["--het", "-0.5", "-0.1"])
+        assert (sq.het_lower, sq.het_upper) == (-0.5, -0.1)
+
+    def test_sd_base(self) -> None:
+        sq = self._sample_qc(["--het", "sd"])
+        assert sq.het_auto is True
+        assert sq.het_auto_sd == 3.0
+
+    def test_sd_base_with_multiplier(self) -> None:
+        sq = self._sample_qc(["--het", "sd", "2.5"])
+        assert (sq.het_auto, sq.het_auto_sd) == (True, 2.5)
+
+    def test_amr_override_on_fixed_base(self) -> None:
+        """Today's --amr-het, generalized."""
+        sq = self._sample_qc(
+            ["--ancestry", "--het", "-0.2", "0.2", "--het-ancestry", "AMR", "sd"]
+        )
+        assert sq.het_config_for("AMR").auto_detect is True
+        assert sq.het_config_for("EUR").f_lower == -0.2
+
+    def test_per_group_multiplier(self) -> None:
+        sq = self._sample_qc(
+            ["--ancestry", "--het", "sd", "2", "--het-ancestry", "AMR", "sd", "1.5"]
+        )
+        assert sq.het_config_for("AMR").auto_sd == 1.5
+        assert sq.het_config_for("EUR").auto_sd == 2.0
+
+    def test_mixed_adaptive_and_fixed_overrides(self) -> None:
+        sq = self._sample_qc([
+            "--ancestry",
+            "--het-ancestry", "AMR", "sd",
+            "--het-ancestry", "CAH", "-0.3", "0.3",
+        ])
+        assert sq.het_config_for("AMR").auto_detect is True
+        cah = sq.het_config_for("CAH")
+        assert (cah.f_lower, cah.f_upper) == (-0.3, 0.3)
+
+    def test_override_implies_the_step_runs(self) -> None:
+        """No --het, no --all-sample: the override still turns het on.
+
+        An override implies the system it overrides is on. --amr-het did not do
+        this, so --ancestry --amr-het alone was a second silent no-op.
+        """
+        sq = self._sample_qc(["--ancestry", "--het-ancestry", "AMR", "sd"])
+        assert sq.run_het is True
+        assert "het" in parse_args(
+            self.BASE + ["--ancestry", "--het-ancestry", "AMR", "sd"]
+        ).get_enabled_sample_steps()
+
+    def test_all_sample_with_sd_base(self) -> None:
+        """The production per-ancestry job."""
+        sq = self._sample_qc(["--all-sample", "--all-variant", "--het", "sd"])
+        assert sq.run_het is True
+        assert sq.het_auto is True
+
+    def test_het_ancestry_without_ancestry_errors(self) -> None:
+        """The whole point of the change: a per-label override in a run with no
+        labels is impossible to honour, so it must not be accepted silently."""
+        with pytest.raises(ValueError, match="requires --ancestry"):
+            parse_args(self.BASE + ["--het-ancestry", "AMR", "sd"])
+
+    def test_het_ancestry_error_names_the_label_and_the_fix(self) -> None:
+        with pytest.raises(ValueError, match="AMR") as excinfo:
+            parse_args(self.BASE + ["--het-ancestry", "AMR", "sd"])
+        assert "--het" in str(excinfo.value)
+
+    def test_no_underscore_alias(self) -> None:
+        """Underscore spellings are deprecated 1.x aliases only; a flag added
+        in 2.0.1 gets just the hyphen form, like every other 2.0 addition."""
+        with pytest.raises(SystemExit):
+            parse_args(self.BASE + ["--ancestry", "--het_ancestry", "AMR", "sd"])
+
+    def test_legacy_sentinel_still_parses_and_warns(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="genotools"):
+            sq = self._sample_qc(["--het", "-1", "-1"])
+        assert sq.het_auto is True
+        assert "deprecated" in caplog.text
+
+    def test_legacy_dict_carries_the_new_keys(self) -> None:
+        legacy = parse_args(
+            self.BASE + ["--ancestry", "--het", "sd", "2", "--het-ancestry", "AMR", "sd"]
+        ).to_legacy_dict()
+        assert legacy["het_auto"] is True
+        assert legacy["het_auto_sd"] == 2.0
+        assert set(legacy["het_by_ancestry"]) == {"AMR"}
+        assert "amr_het" not in legacy
+
+
+class TestAmrHetRemoved:
+    """--amr-het was removed, not aliased.
+
+    It was read in exactly one place, inside the --ancestry branch, so it did
+    nothing in a flat run - which is how the per-ancestry production workflow
+    runs QC. A command line still carrying it gets a targeted error naming the
+    replacement, rather than argparse's bare "unrecognized arguments".
+    """
+
+    BASE = ["--pfile", "/data/test", "--out", "/tmp/out"]
+
+    @pytest.mark.parametrize("flag", ["--amr-het", "--amr_het"])
+    def test_rejected_with_a_pointer_to_the_replacement(self, flag: str) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            parse_args(self.BASE + ["--all-sample", flag])
+        message = str(excinfo.value)
+        assert "removed" in message
+        assert "--het-ancestry AMR sd" in message
+
+    def test_rejected_even_with_a_trailing_value(self) -> None:
+        """--amr-het False must report the removal, not the presence-flag rule.
+
+        The removal check runs before _reject_boolean_values for this reason.
+        """
+        with pytest.raises(ValueError, match="removed"):
+            parse_args(self.BASE + ["--amr-het", "False"])
+
+    def test_not_in_the_spelling_rename_table(self) -> None:
+        """_DEPRECATED_SPELLINGS models renames only - a removed flag there
+        would claim the underscore form still works."""
+        from genotools.cli.parser import _DEPRECATED_SPELLINGS
+
+        assert "--amr_het" not in _DEPRECATED_SPELLINGS
+
+    def test_parser_does_not_define_it(self) -> None:
+        from genotools.cli.parser import create_parser
+
+        options = {
+            opt for action in create_parser()._actions for opt in action.option_strings
+        }
+        assert "--amr-het" not in options
+        assert "--amr_het" not in options
 
 
 class TestDeprecatedFlagSpellings:

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -15,6 +15,7 @@
 
 """Regression tests for CLI runner bugs found in the refactor hardening audit."""
 
+import logging
 import shutil
 from pathlib import Path
 from typing import Any, Dict, List
@@ -24,9 +25,11 @@ import pytest
 from genotools.core.exceptions import QCError, ValidationError
 from genotools.cli.parser import (
     AncestryArgs,
+    HetSpec,
     InputArgs,
     OutputArgs,
     PipelineArgs,
+    SampleQCArgs,
 )
 from genotools.cli.runner import PipelineRunner, PipelineState
 
@@ -69,7 +72,11 @@ def _fake_step_factory(failing_step: str):
     check succeeds; the failing step raises QCError like a real failed step.
     """
     def fake_single_step(
-        step: str, step_input: str, step_output: str, legacy_args: Dict[str, Any]
+        step: str,
+        step_input: str,
+        step_output: str,
+        legacy_args: Dict[str, Any],
+        **_: Any,
     ) -> Dict[str, Any]:
         if step == failing_step:
             raise QCError(f"{step} failed")
@@ -92,7 +99,11 @@ def _write_traceable_pfiles(prefix: Path) -> None:
 def _traceable_step_factory(failing_step: str):
     """Like _fake_step_factory but passing steps write traceable pfiles."""
     def fake_single_step(
-        step: str, step_input: str, step_output: str, legacy_args: Dict[str, Any]
+        step: str,
+        step_input: str,
+        step_output: str,
+        legacy_args: Dict[str, Any],
+        **_: Any,
     ) -> Dict[str, Any]:
         if step == failing_step:
             raise QCError(f"{step} failed")
@@ -371,7 +382,7 @@ class TestValidationDecisionsApplied:
         runner._validation_decisions = ValidationDecisions(disable_filter_controls=True)
         captured: Dict[str, Any] = {}
 
-        def fake_single_step(step, step_input, step_output, legacy_args):
+        def fake_single_step(step, step_input, step_output, legacy_args, **_):
             captured["filter_controls"] = legacy_args["filter_controls"]
             _touch_pfiles(Path(step_output))
             return {"pass": True, "step": step, "metrics": {}, "output": {}}
@@ -466,7 +477,7 @@ class TestRunSummary:
         cap = _Capture()
         _logging.getLogger("genotools").addHandler(cap)
 
-        def fake_single_step(step, step_input, step_output, legacy_args):
+        def fake_single_step(step, step_input, step_output, legacy_args, **_):
             _touch_pfiles(Path(step_output))
             return {
                 "pass": True, "step": step,
@@ -527,7 +538,7 @@ class TestRunSummary:
         cap = _ConsoleCapture()
         _logging.getLogger("genotools").addHandler(cap)
 
-        def fake_single_step(step, step_input, step_output, legacy_args):
+        def fake_single_step(step, step_input, step_output, legacy_args, **_):
             _touch_pfiles(Path(step_output))
             return {"pass": True, "step": step, "metrics": {}, "output": {}}
 
@@ -672,7 +683,7 @@ class TestStepOutcomesReachTheReport:
         runner, geno, out = _make_runner(tmp_path, warn_only=False)
         ran: list[str] = []
 
-        def recording_step(step, step_input, step_output, legacy_args):
+        def recording_step(step, step_input, step_output, legacy_args, **_):
             ran.append(step)
             _touch_pfiles(Path(step_output))
             return {"pass": True, "step": step, "metrics": {}, "output": {}}
@@ -693,7 +704,7 @@ class TestStepOutcomesReachTheReport:
         runner, geno, out = _make_runner(tmp_path, warn_only=False)
         inputs: dict[str, str] = {}
 
-        def recording_step(step, step_input, step_output, legacy_args):
+        def recording_step(step, step_input, step_output, legacy_args, **_):
             inputs[step] = step_input
             _touch_pfiles(Path(step_output))
             return {"pass": True, "step": step, "metrics": {}, "output": {}}
@@ -846,7 +857,7 @@ class TestSkipAtTheEndOfTheChain:
         runner, geno, out = _make_runner(tmp_path, warn_only=False)
         outputs: dict[str, str] = {}
 
-        def recording_step(step, step_input, step_output, legacy_args):
+        def recording_step(step, step_input, step_output, legacy_args, **_):
             outputs[step] = step_output
             _touch_pfiles(Path(step_output))
             return {"pass": True, "step": step, "metrics": {}, "output": {}}
@@ -1251,3 +1262,296 @@ class TestPerGroupSex:
         assert "12 samples" in reasons["het"]
         assert reasons["sex"] == "no sample sex data is available"
         assert "not both" in reasons["case_control"]
+
+
+class _StubResult:
+    """Minimal stand-in for FilterResult, enough for _run_qc_pipeline."""
+
+    def __init__(self, out_path: str) -> None:
+        self.out_path = out_path
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "pass": True,
+            "step": "het_prune",
+            "metrics": {},
+            "output": {"plink_out": self.out_path},
+        }
+
+
+class TestHetConfigReachesEveryRunShape:
+    """Regression: --amr-het was read in exactly one place, inside
+    ``_run_with_ancestry``. ``_run_qc_only`` never passed het values at all, so
+    the flag was silently inert in a flat run - and the per-ancestry production
+    workflow runs ancestry once, then QCs each group as a separate *flat* job.
+    That is precisely the path where it did nothing, with no warning.
+
+    The fix routes both paths through ``SampleQCArgs.het_config_for``, so these
+    tests assert the resolved config *arrives at the step*, not merely that the
+    parser built it.
+    """
+
+    def _flat_runner(self, tmp_path: Path, sample_qc: SampleQCArgs):
+        geno = tmp_path / "geno"
+        out = tmp_path / "out"
+        _touch_pfiles(geno)
+        # het is auto-skipped below PLINK's 50-sample LD floor, and a skipped
+        # step never reaches the config at all.
+        _psam_with(geno, 200)
+        args = PipelineArgs(
+            input=InputArgs(pfile=geno),
+            output=OutputArgs(out_path=out, full_output=True),
+            sample_qc=sample_qc,
+        )
+        runner = PipelineRunner(args)
+        runner.state = PipelineState(geno_path=geno, out_path=out, tmp_dir=None)
+        return runner, geno, out
+
+    @staticmethod
+    def _capture_het(runner, monkeypatch) -> Dict[str, Any]:
+        """Record the HetConfig filter_heterozygosity is actually called with.
+
+        Stubs at the module boundary rather than at ``_run_single_step`` so the
+        assertion covers the real config-building branch, not the plumbing
+        around it.
+        """
+        runner._initialize_modules()
+        seen: Dict[str, Any] = {}
+
+        class _StubGenotypeData:
+            @staticmethod
+            def from_path(path):
+                return path
+
+        def fake_filter(data, config, out_path):
+            seen["config"] = config
+            _touch_pfiles(Path(out_path))
+            return _StubResult(str(out_path))
+
+        monkeypatch.setitem(
+            runner._new_modules, "GenotypeData", _StubGenotypeData
+        )
+        monkeypatch.setitem(
+            runner._new_modules, "filter_heterozygosity", fake_filter
+        )
+        return seen
+
+    def test_flat_run_reaches_the_step_with_derived_bounds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE regression. A flat ``--het sd`` run must reach
+        filter_heterozygosity with auto_detect set.
+
+        Drives ``_run_qc_only`` - the entry point the bug lived in - rather
+        than handing ``_run_qc_pipeline`` a config directly, which would pass
+        against the broken code and pin nothing.
+
+        Revert check: drop ``het_config=`` from ``_run_qc_only``'s call and
+        this fails with ``auto_detect=False`` and the base fixed bounds,
+        exactly as --amr-het did.
+        """
+        runner, _, _ = self._flat_runner(
+            tmp_path, SampleQCArgs(run_het=True, het_auto=True, het_auto_sd=2.0)
+        )
+        seen = self._capture_het(runner, monkeypatch)
+        monkeypatch.setattr(runner, "_build_output", lambda: None)
+
+        runner._run_qc_only(["het"])
+
+        assert seen["config"].auto_detect is True
+        assert seen["config"].auto_sd == 2.0
+
+    def test_run_qc_only_passes_a_resolved_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bug was in _run_qc_only specifically: it called the pipeline
+        without any het argument. Pin the call itself."""
+        runner, _, _ = self._flat_runner(
+            tmp_path, SampleQCArgs(run_het=True, het_auto=True, het_auto_sd=2.5)
+        )
+        monkeypatch.setattr(runner, "_build_output", lambda: None)
+
+        captured: Dict[str, Any] = {}
+
+        def fake_pipeline(**kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        monkeypatch.setattr(runner, "_run_qc_pipeline", fake_pipeline)
+        runner._run_qc_only(["het"])
+
+        assert "het_config" in captured, (
+            "_run_qc_only must pass a resolved HetConfig; omitting it is the "
+            "original bug"
+        )
+        assert captured["het_config"].auto_detect is True
+        assert captured["het_config"].auto_sd == 2.5
+
+    def test_fixed_base_still_reaches_the_step_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The default path must not have moved."""
+        runner, _, _ = self._flat_runner(
+            tmp_path, SampleQCArgs(run_het=True, het_lower=-0.2, het_upper=0.2)
+        )
+        seen = self._capture_het(runner, monkeypatch)
+        monkeypatch.setattr(runner, "_build_output", lambda: None)
+
+        runner._run_qc_only(["het"])
+
+        assert seen["config"].auto_detect is False
+        assert (seen["config"].f_lower, seen["config"].f_upper) == (-0.2, 0.2)
+
+    def test_pipeline_without_het_config_falls_back_to_the_base(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Any caller that forgets the argument still gets the base spec, not
+        the defaults - the old failure mode was reverting to fixed bounds."""
+        runner, geno, out = self._flat_runner(
+            tmp_path, SampleQCArgs(run_het=True, het_auto=True, het_auto_sd=1.5)
+        )
+        seen = self._capture_het(runner, monkeypatch)
+
+        runner._run_qc_pipeline(
+            steps=["het"], geno_path=str(geno), out_path=str(out)
+        )
+
+        assert seen["config"].auto_detect is True
+        assert seen["config"].auto_sd == 1.5
+
+
+class TestPerGroupHetConfig:
+    """--het-ancestry resolves per group across the ancestry loop, on any
+    label. The retired --amr-het hardcoded ``label == "AMR"``, the only
+    user-facing feature that assumed one reference panel's naming - so it could
+    never reach CAH, the synthetic admixed label admixture detection invents.
+    """
+
+    def _run_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        sample_qc: SampleQCArgs, labels: List[str],
+    ) -> Dict[str, Any]:
+        geno = tmp_path / "geno"
+        out = tmp_path / "out"
+        _touch_pfiles(geno)
+        work = tmp_path / "tmpwork"
+        work.mkdir(exist_ok=True)
+
+        args = PipelineArgs(
+            input=InputArgs(pfile=geno),
+            output=OutputArgs(out_path=out, full_output=False),
+            sample_qc=sample_qc,
+            ancestry=AncestryArgs(run_ancestry=True),
+        )
+        runner = PipelineRunner(args)
+        runner.state = PipelineState(
+            geno_path=geno, out_path=out, tmp_dir=_StubTmpDir(work)
+        )
+        for label in labels:
+            _psam_with(work / f"out_ancestry_{label}", 200)
+
+        monkeypatch.setattr(runner, "_begin_section", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_end_section", lambda *a, **k: None)
+        monkeypatch.setattr(
+            runner,
+            "_run_ancestry_prediction_new",
+            lambda: {"data": {"labels_list": labels}},
+        )
+        monkeypatch.setattr(runner, "_build_output", lambda: None)
+
+        seen: Dict[str, Any] = {}
+
+        def fake_qc(**kwargs: Any) -> None:
+            seen[kwargs["ancestry_label"]] = kwargs["het_config"]
+
+        monkeypatch.setattr(runner, "_run_qc_pipeline", fake_qc)
+        runner._run_with_ancestry(["het"])
+        return seen
+
+    def test_override_applies_only_to_its_group(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = self._run_loop(
+            tmp_path,
+            monkeypatch,
+            SampleQCArgs(
+                run_het=True,
+                het_lower=-0.2,
+                het_upper=0.2,
+                het_by_ancestry={"AMR": HetSpec(auto=True, sd=3.0)},
+            ),
+            ["AMR", "EUR"],
+        )
+        assert seen["AMR"].auto_detect is True
+        assert seen["EUR"].auto_detect is False
+        assert (seen["EUR"].f_lower, seen["EUR"].f_upper) == (-0.2, 0.2)
+
+    def test_mixed_overrides_on_an_adaptive_base(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = self._run_loop(
+            tmp_path,
+            monkeypatch,
+            SampleQCArgs(
+                run_het=True,
+                het_auto=True,
+                het_auto_sd=2.0,
+                het_by_ancestry={
+                    "AMR": HetSpec(auto=True, sd=1.5),
+                    "CAH": HetSpec(lower=-0.3, upper=0.3),
+                },
+            ),
+            ["AMR", "CAH", "EUR"],
+        )
+        assert seen["AMR"].auto_sd == 1.5
+        assert seen["CAH"].auto_detect is False
+        assert (seen["CAH"].f_lower, seen["CAH"].f_upper) == (-0.3, 0.3)
+        assert seen["EUR"].auto_sd == 2.0, "non-overridden group keeps the base"
+
+    def test_non_amr_label_is_reachable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CAH is invented by admixture detection and appears in no reference
+        panel, so --amr-het could not name it."""
+        seen = self._run_loop(
+            tmp_path,
+            monkeypatch,
+            SampleQCArgs(
+                run_het=True, het_by_ancestry={"CAH": HetSpec(auto=True)}
+            ),
+            ["CAH", "EUR"],
+        )
+        assert seen["CAH"].auto_detect is True
+        assert seen["EUR"].auto_detect is False
+
+    def test_unknown_label_warns_and_names_the_predicted_groups(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        """An override matching no predicted group would otherwise do nothing
+        silently - --amr-het's failure on any panel not spelling it "AMR"."""
+        with caplog.at_level(logging.WARNING, logger="genotools"):
+            seen = self._run_loop(
+                tmp_path,
+                monkeypatch,
+                SampleQCArgs(
+                    run_het=True, het_by_ancestry={"AMRR": HetSpec(auto=True)}
+                ),
+                ["AMR", "EUR"],
+            )
+        assert "AMRR" in caplog.text
+        assert "AMR" in caplog.text and "EUR" in caplog.text
+        assert seen["AMR"].auto_detect is False, "the typo must not match AMR"
+
+    def test_matching_label_does_not_warn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="genotools"):
+            self._run_loop(
+                tmp_path,
+                monkeypatch,
+                SampleQCArgs(
+                    run_het=True, het_by_ancestry={"AMR": HetSpec(auto=True)}
+                ),
+                ["AMR", "EUR"],
+            )
+        assert "no such ancestry group" not in caplog.text
+

--- a/tests/unit/test_qc/test_heterozygosity.py
+++ b/tests/unit/test_qc/test_heterozygosity.py
@@ -1,0 +1,211 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for heterozygosity outlier selection.
+
+``select_het_outliers`` is split out of ``filter_heterozygosity`` so the bound
+arithmetic can be exercised against a frame with a known mean and sigma,
+without PLINK in the loop. These pin the ``sd`` multiplier to real behaviour
+rather than to config plumbing.
+"""
+
+from typing import List
+
+import pandas as pd
+import pytest
+
+from genotools.qc.config import HetConfig
+from genotools.qc.steps.heterozygosity import select_het_outliers
+
+
+def _het_frame(f_values: List[float], obs_hom: List[int] = None) -> pd.DataFrame:
+    """Build a frame shaped like PLINK's .het output.
+
+    F and the derived rate are independent here, which is the point: the two
+    modes threshold different statistics, so a frame can separate them.
+    """
+    n = len(f_values)
+    hom = obs_hom if obs_hom is not None else [5000] * n
+    return pd.DataFrame(
+        {
+            "#FID": [f"F{i}" for i in range(n)],
+            "IID": [f"I{i}" for i in range(n)],
+            "O(HOM)": hom,
+            "E(HOM)": [5000.0] * n,
+            "OBS_CT": [10000] * n,
+            "F": f_values,
+        }
+    )
+
+
+class TestFixedBounds:
+    """The default path, unchanged."""
+
+    def test_bounds_are_inclusive(self) -> None:
+        het = _het_frame([-0.2, -0.15, 0.0, 0.15, 0.2])
+        outliers, metrics = select_het_outliers(het, HetConfig())
+        assert sorted(outliers["F"]) == [-0.2, -0.15, 0.15, 0.2]
+        assert metrics["het_mode"] == "fixed"
+        assert metrics["het_statistic"] == "F"
+
+    def test_custom_bounds(self) -> None:
+        het = _het_frame([-0.25, 0.0, 0.25])
+        outliers, _ = select_het_outliers(
+            het, HetConfig(f_lower=-0.3, f_upper=0.3)
+        )
+        assert outliers.empty
+
+
+class TestAutoDetectThresholdsF:
+    """``auto_detect=True`` bounds F, so both CLI spellings of --het bound the
+    same statistic. Selected without the legacy [-1, -1] sentinel."""
+
+    def test_auto_detect_without_the_sentinel(self) -> None:
+        het = _het_frame([0.0] * 20 + [1.0])
+        outliers, metrics = select_het_outliers(het, HetConfig(auto_detect=True))
+        assert metrics["het_mode"] == "sd"
+        assert metrics["het_statistic"] == "F"
+        assert metrics["het_sd"] == 3.0
+        assert not outliers.empty
+
+    def test_auto_detect_ignores_the_rate(self) -> None:
+        """F constant, rate wildly variable: the F branch must prune nothing.
+
+        If auto_detect ever fell through to the rate branch this would flag the
+        rate outlier, silently swapping which statistic is bounded.
+        """
+        het = _het_frame([0.01] * 20, obs_hom=[5000] * 19 + [100])
+        outliers, metrics = select_het_outliers(het, HetConfig(auto_detect=True))
+        assert outliers.empty
+        assert metrics["het_statistic"] == "F"
+
+    def test_fixed_bounds_are_ignored_in_auto_mode(self) -> None:
+        """f_lower/f_upper ride along unused rather than being consulted."""
+        het = _het_frame([0.0] * 20 + [1.0])
+        wide, _ = select_het_outliers(
+            het, HetConfig(f_lower=-10.0, f_upper=10.0, auto_detect=True)
+        )
+        narrow, _ = select_het_outliers(
+            het, HetConfig(f_lower=-0.001, f_upper=0.001, auto_detect=True)
+        )
+        assert len(wide) == len(narrow)
+
+
+class TestAutoSdMovesTheCutoff:
+    """The multiplier has to move real behaviour, not just ride in the config."""
+
+    @staticmethod
+    def _frame_with_probe_between_2_and_3_sd():
+        """A frame whose last sample sits between 2 and 3 sd of the whole set.
+
+        Built by construction rather than assumed: mean and sd are computed
+        over every sample, the probe included, so the probe widens the very
+        bounds that judge it.
+        """
+        values = [-0.01, 0.01] * 50 + [0.025]
+        het = _het_frame(values)
+        mean = het["F"].mean()
+        std = het["F"].std()
+        z = (0.025 - mean) / std
+        assert 2.0 < z < 3.0, f"probe must sit between 2 and 3 sd, got {z}"
+        return het
+
+    def test_probe_kept_at_sd_3_pruned_at_sd_2(self) -> None:
+        het = self._frame_with_probe_between_2_and_3_sd()
+
+        kept, _ = select_het_outliers(
+            het, HetConfig(auto_detect=True, auto_sd=3.0)
+        )
+        pruned, _ = select_het_outliers(
+            het, HetConfig(auto_detect=True, auto_sd=2.0)
+        )
+
+        assert kept.empty, "a 2.5 sd sample survives a 3 sd cut"
+        assert 0.025 in list(pruned["F"]), "and is pruned by a 2 sd cut"
+
+    def test_tightening_the_multiplier_can_only_prune_more(self) -> None:
+        het = _het_frame([-0.03, -0.01, 0.0, 0.01, 0.02, 0.03] * 10 + [0.09])
+        counts = [
+            len(select_het_outliers(het, HetConfig(auto_detect=True, auto_sd=sd))[0])
+            for sd in (1.0, 1.5, 2.0, 3.0, 4.0)
+        ]
+        assert counts == sorted(counts, reverse=True), counts
+
+    def test_reported_bounds_match_the_multiplier(self) -> None:
+        het = _het_frame([-0.01, 0.01] * 50)
+        _, metrics = select_het_outliers(
+            het, HetConfig(auto_detect=True, auto_sd=2.0)
+        )
+        mean, std = het["F"].mean(), het["F"].std()
+        assert metrics["het_lower"] == pytest.approx(mean - 2.0 * std)
+        assert metrics["het_upper"] == pytest.approx(mean + 2.0 * std)
+
+
+class TestLegacySentinel:
+    """``f_lower == f_upper == -1.0`` is the 1.x way to ask for derived bounds.
+
+    It thresholds the derived heterozygosity *rate* at 3 sd. Preserved verbatim
+    for Python-API callers that already pass it; the CLI no longer produces it.
+    """
+
+    def test_sentinel_selects_the_rate_branch(self) -> None:
+        het = _het_frame([0.01] * 20, obs_hom=[5000] * 19 + [100])
+        outliers, metrics = select_het_outliers(
+            het, HetConfig(f_lower=-1.0, f_upper=-1.0)
+        )
+        assert metrics["het_statistic"] == "rate"
+        assert metrics["het_sd"] == 3.0
+        assert len(outliers) == 1
+
+    def test_sentinel_keeps_the_HET_column(self) -> None:
+        """Existing callers read it out of the .outliers file."""
+        het = _het_frame([0.01] * 20, obs_hom=[5000] * 19 + [100])
+        outliers, _ = select_het_outliers(
+            het, HetConfig(f_lower=-1.0, f_upper=-1.0)
+        )
+        assert "HET" in outliers.columns
+
+    def test_sentinel_ignores_auto_sd(self) -> None:
+        """The legacy path is fixed at 3 sd; the knob is a CLI-era addition."""
+        het = _het_frame([0.01] * 20, obs_hom=[5000] * 19 + [100])
+        _, metrics = select_het_outliers(
+            het, HetConfig(f_lower=-1.0, f_upper=-1.0, auto_sd=1.0)
+        )
+        assert metrics["het_sd"] == 3.0
+
+    def test_auto_detect_wins_over_the_sentinel(self) -> None:
+        """Precedence has to be explicit, or a config setting both would pick
+        its statistic by accident of branch order."""
+        het = _het_frame([0.01] * 20, obs_hom=[5000] * 19 + [100])
+        _, metrics = select_het_outliers(
+            het, HetConfig(f_lower=-1.0, f_upper=-1.0, auto_detect=True)
+        )
+        assert metrics["het_statistic"] == "F"
+
+
+class TestAutoSdValidation:
+    """HetConfig rejects a non-positive multiplier at construction."""
+
+    @pytest.mark.parametrize("bad", [0.0, -1.0])
+    def test_non_positive_rejected(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="auto_sd"):
+            HetConfig(auto_detect=True, auto_sd=bad)
+
+    def test_default_is_three(self) -> None:
+        assert HetConfig().auto_sd == 3.0
+
+    def test_validated_even_under_the_sentinel(self) -> None:
+        with pytest.raises(ValueError, match="auto_sd"):
+            HetConfig(f_lower=-1.0, f_upper=-1.0, auto_sd=0.0)


### PR DESCRIPTION
## Summary

Replaces `--amr-het` with a per-ancestry heterozygosity grammar, and fixes the bug that made the old flag silently inert in the run shape production actually uses.

```
--het [LOWER UPPER | sd [N]]                  # base: applies to every dataset
--het-ancestry LABEL [LOWER UPPER | sd [N]]   # repeatable; overrides one group
```

Both flags take the same four-row spec (none → fixed `-0.15 0.15`; `LOWER UPPER` → fixed; `sd` → `mean ± 3σ`; `sd N` → `mean ± N·σ`), resolved by one parser (`_parse_het_spec`), so they cannot drift into different rules. A per-group override always beats the base.

**The bug.** `if self.args.sample_qc.amr_het and label == "AMR"` in `_run_with_ancestry` was the only place the flag was read. `_run_qc_only` never passed het values at all. The per-ancestry production workflow runs ancestry once and then QCs each group as a separate **flat** job — precisely the path where the flag did nothing, with no warning and a normal-looking JSON. Both paths now resolve through `SampleQCArgs.het_config_for(label)`, so that divergence is unrepresentable. (The same structure exists on 1.x, so this is longstanding, not a 2.0 regression.)

**The second defect.** `label == "AMR"` was the only user-facing feature in the codebase assuming a particular reference panel's naming. The label vocabulary is user-supplied — from `--ref-labels` via an unconstrained `LabelEncoder`, or a pickled model's encoder — so the flag was unusable on any panel spelling the group differently, and could never reach `CAH`, the synthetic admixed label admixture detection invents.

**`sd`, not `auto`.** The old mode was called "auto-detect", but only location and scale were data-derived; the `3` was hardcoded. `sd [N]` makes the multiplier a knob and says what it does.

**`sd` thresholds `F`, not the derived rate,** so both spellings of `--het` bound the same statistic. Not bit-for-bit identical to `--amr-het` in principle; measured identical here — on the GP2 r12 10k subset (9,771 samples post-callrate) the two rules select the same 99 samples cohort-wide and the same set within AMR's 340, despite bounds on different scales (`F: [-0.081, 0.160]` vs `rate: [0.258, 0.332]`). `MIGRATION_2.0.md` says so plainly.

**`--amr-het` is removed, not aliased** — it lands in `_REMOVED_FLAGS` and gets a targeted error naming `--het-ancestry AMR sd`, the round-10 `--container` treatment. `--het -1 -1` still works, warning that `--het sd` is the spelling now.

### Resolved semantics

| Case | Behavior |
|---|---|
| `--het-ancestry` without `--ancestry` | error — no labels exist to match |
| `--het-ancestry` with no `--het`/`--all-sample` | implies the het step runs |
| `--het-ancestry LABEL` where LABEL was not predicted | warn once, naming the predicted groups |
| duplicate label across repeats | error at parse time |
| `N <= 0` | error at parse time |
| bare `--het-ancestry LABEL` (no spec) | error — a silent no-op is the thing being removed |

### Why the default multiplier stays 3

Samples pruned on `F`, GP2 r12 10k subset:

| group | n | `sd 2` | `sd 3` | fixed ±0.15 |
|---|---|---|---|---|
| **AMR** | 340 | 21 | **0** | **31** |
| EUR | 6802 | 141 | 85 | 2 |
| **all 10 groups** | 9759 | 287 | **137** | **35** |

`sd` and fixed are not interchangeable defaults (a global `sd 3` prunes 137 where fixed prunes 35), which is why the per-group override is required rather than a nicety — making `sd` the global default was not an option. And `3` is right for AMR: pruning zero there is the intended outcome, not under-pruning. The 31 samples fixed bounds catch sit at ~2.5σ of AMR's own spread and are a structured subgroup (28 of 30 from one contributing cohort); `sd 2` would discard 21 of the very samples the feature exists to keep.

**The documented rationale was wrong.** The feature was justified as "heterozygosity is higher in admixed populations." On this data AMR has the *lowest* mean het rate and the *highest* mean F of the ten groups, and 30 of the 31 samples fixed bounds prune are on the heterozygote-*deficit* side — consistent with Wahlund on a pooled label spanning heterogeneous admixture proportions. The feature is right; the explanation was not. `docs/cli_args.md` carries the corrected one, plus when to reach for `sd` and its non-robustness.

### Also in this PR

A second commit brings `CLAUDE.md` and `docs/default_pipeline_overview.md` current with 2.0 — both still described the pre-2.0 `SampleQC`/`VariantQC`/`run_het_prune`/`shell_do` architecture, so an assistant following them would have written 1.x code. `CLAUDE.md` is rewritten against the source and cut 561 → 184 lines, with a Traps section for the failure modes that have actually cost us (the two run shapes, hardcoded ancestry labels, `str(None)` reaching PLINK, skip-vs-crash, the `python -m` cwd gotcha, flag policy).

Version bumped to 2.0.1.

## Test plan

- `python -m pytest tests/unit -q` — **622 passed** (~25s)
- `python -m pytest tests/regression -q` — **77 passed** (~7min, run on `385b4cb`; only docs changed after)

45 new tests across four layers:

- `test_qc/test_heterozygosity.py` — `TestFixedBounds`, `TestAutoDetectThresholdsF`, `TestAutoSdMovesTheCutoff`, `TestLegacySentinel`, `TestAutoSdValidation` drive `select_het_outliers`, split out of `filter_heterozygosity` so the bound arithmetic is testable against a hand-built frame without PLINK
- `test_cli/test_parser.py` — `TestParseHetSpec`, `TestParseHetAncestryArgs`, `TestHetGrammarEndToEnd`, `TestAmrHetRemoved` cover the dataclass, the `_parse_*` helper, and end-to-end `parse_args`
- `test_cli/test_runner_regression.py` — `TestHetConfigReachesEveryRunShape`, `TestPerGroupHetConfig` gate the bug through `_run_qc_only` and `_run_with_ancestry`, the entry points it lived in

**Revert-checked:** dropping `het_config=` from `_run_qc_only` fails 3 of the 4 `TestHetConfigReachesEveryRunShape` tests. (The first draft of that test passed against the broken code because it drove `_run_qc_pipeline` directly — the item-17 trap.)