### PR TITLE
fix: require --ref-panel and --ref-labels whenever --ancestry is used

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,9 @@ model's encoder. Admixture detection also invents `CAH`, which appears in no
 panel. `label == "AMR"` was the second defect behind `--amr-het`.
 
 **`str(None)` is `"None"`,** which reaches PLINK as a filename and produces
-`Failed to open None.bed`. Validate optional paths up front — this is live in
-inference mode (`REFACTOR.md` item 23).
+`Failed to open None.bed`. Validate optional paths up front, at the CLI
+boundary — this is how `--ancestry` without `--ref-panel` used to fail
+(round 12).
 
 **Data preconditions are skips, not crashes.** A step the data rules out gets a
 `<step>_skip_reason()` in `core/validation.py`, wired into `_skip_reasons()`,

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -854,6 +854,49 @@ the CLI — is now live.
 
 ---
 
+### Round 12 (`--ancestry` needs its reference panel, said up front)
+
+Closes **item 23**, found while running the round-11 verification.
+
+**The finding, corrected.** Item 23 recorded this as a `--model` bug. It is
+not: **training fails the same way.** `--ancestry` alone reports
+`No such file or directory: 'None.bim'` from `get_common_snps`; `--ancestry
+--model ...` reports `Failed to open None.bed` from `get_raw_files`'s
+inference branch. Both are `str(None)` reaching PLINK as a filename. The panel
+is genuinely required in both modes — `ref_labels` is read unconditionally
+(`ancestry/preprocessing.py:137`) and `ref_panel` is used on both sides of the
+`train` branch — so the fix is one check covering both, not a `--model` special
+case.
+
+**Not a 2.0 capability regression, but a diagnosis regression.** 1.3.6 caught
+the same mistake with "Please make sure geno_path, ref_panel, ref_labels, and
+out_path are all set". 2.0 lost that and let the `None` through to PLINK.
+Reproduced on `afad04c` in a clean worktree, with the round-11 work absent.
+
+**Placement.** The check lives in `parse_args`, beside the existing
+"At least one input required" check, rather than in
+`AncestryArgs.__post_init__` where `_UNSUPPORTED_INFERENCE_FLAGS` lives. Two
+reasons. It is a required-*combination* check on CLI input, which is what that
+part of `parse_args` already does; and `AncestryArgs(run_ancestry=True)` is a
+legitimate unit-test fixture when prediction is monkeypatched (round 11's
+`TestPerGroupHetConfig` builds exactly that), so a dataclass-level constraint
+would have forced dummy paths into fixtures that never touch a panel.
+
+It runs *after* `AncestryArgs` is constructed, so `__post_init__` has already
+rejected `--container`/`--singularity`/`--cloud`. A flag that can never work is
+more useful to report than a panel the user could simply supply; the first
+draft had this backwards and reported the missing panel for
+`--ancestry --container`.
+
+**Gating.** 6 parser tests, including the precedence case. **Revert-checked:**
+removing the check fails 3 of them (the two accept-cases correctly pass either
+way). One pre-existing test, `test_ancestry_flag`, was asserting that
+`--ancestry` with no panel parses cleanly — it was pinning the unusable config,
+and now supplies the panel. Round 11's `TestHetGrammarEndToEnd` gained the two
+flags in its `BASE` for the same reason.
+
+---
+
 ## Remaining work (tracked, not yet done)
 
 Priority order for making the refactor mergeable to `main`:
@@ -972,16 +1015,7 @@ Priority order for making the refactor mergeable to `main`:
     serialized, because the QC report is a long `(step, metric, pruned_count)`
     table with no room for a descriptive value (see round 11). Needs a
     dedicated JSON section, which changes the report contract and the goldens.
-23. **`--model` without `--ref-panel`/`--ref-labels` fails inside PLINK.**
-    Inference mode still needs the reference panel — `get_raw_files(train=False)`
-    subsets it to the model's common SNPs and reads its `.raw`
-    (`ancestry/preprocessing.py:110`) — but nothing checks for it, so
-    `runner.py:893`'s `str(self.args.ancestry.ref_panel)` stringifies `None`
-    and PLINK is handed `--bfile None`, reporting
-    `Failed to open None.bed`. Reproduced on `afad04c` with the het work
-    absent, so it predates round 11; 1.3.6 caught the same mistake with
-    "Please make sure geno_path, ref_panel, ref_labels, and out_path are all
-    set", so this is a 2.0 regression in *diagnosis*, not in capability. Wants
-    the same up-front rejection round 10 gave `--container`: validate in
-    `AncestryArgs.__post_init__` that `--model` is accompanied by both.
+23. ✅ **`--ancestry` without `--ref-panel`/`--ref-labels` failed inside
+    PLINK** — RESOLVED in **round 12**. Found to be wider than the `--model`
+    case originally recorded: training fails the same way. See round 12 above.
 

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -312,35 +312,32 @@ should be tightened.
   - *Type*: `path`
   - *Default*: `None`
   - *Description*: Reference panel genotype file path (PLINK format, without
-    extension), used to train the ancestry model.
+    extension). **Required whenever `--ancestry` is used** — training builds
+    the reference PCA from it, and inference (`--model`) re-derives that PCA by
+    subsetting the panel to the model's common SNPs.
 
 - **`--ref-labels`**
   - *Type*: `path`
   - *Default*: `None`
   - *Description*: Reference panel ancestry labels file: tab-separated
-    `FID IID label`, no header.
+    `FID IID label`, no header. **Required whenever `--ancestry` is used**,
+    inference included.
 
 - **`--model`**
   - *Type*: `path`
   - *Default*: `None`
   - *Description*: Pre-trained ancestry model directory (or a legacy `.pkl`
-    file). Runs inference instead of training.
+    file). Runs inference instead of training. Does **not** remove the need for
+    `--ref-panel` and `--ref-labels`.
 
-- **`--container`**
+- **`--container`**, **`--singularity`**, **`--cloud`**
   - *Type*: `flag`
   - *Default*: `False`
-  - *Description*: Run ancestry prediction inside a Docker container. Mutually
-    exclusive with `--model`.
-
-- **`--singularity`**
-  - *Type*: `flag`
-  - *Default*: `False`
-  - *Description*: Run ancestry prediction inside a Singularity container.
-
-- **`--cloud`**
-  - *Type*: `flag`
-  - *Default*: `False`
-  - *Description*: Run ancestry prediction on Google Cloud AI Platform.
+  - *Description*: **Not supported — rejected with an error.** Ancestry
+    prediction always runs locally, in process. The container images were built
+    around a 1.x model format that 2.0 cannot load, and cloud prediction was
+    never implemented in any version. See
+    [MIGRATION_2.0.md](../MIGRATION_2.0.md).
 
 - **`--subset-ancestry [LABEL ...]`**
   - *Type*: `str` (zero or more labels)

--- a/genotools/cli/parser.py
+++ b/genotools/cli/parser.py
@@ -1369,6 +1369,37 @@ def parse_args(args: Optional[Sequence[str]] = None) -> PipelineArgs:
         use_cloud=ns.cloud,
     )
 
+    # Ancestry prediction needs the reference panel in *both* modes. Training
+    # builds the reference PCA from it; inference (--model) still re-derives
+    # that PCA, subsetting the panel to the model's common SNPs
+    # (ancestry/preprocessing.py) and reading the labels TSV. Without this
+    # check the missing path is stringified into a PLINK command and surfaces
+    # as "Failed to open None.bed" / "No such file or directory: 'None.bim'" -
+    # naming neither the flag nor the reason. See REFACTOR.md item 23.
+    #
+    # Deliberately after AncestryArgs is constructed: its __post_init__ rejects
+    # --container/--singularity/--cloud, and a flag that can never work is more
+    # useful to report than a panel the user could supply.
+    if ancestry_args.run_ancestry:
+        missing = [
+            flag
+            for flag, value in (
+                ("--ref-panel", ancestry_args.ref_panel),
+                ("--ref-labels", ancestry_args.ref_labels),
+            )
+            if value is None
+        ]
+        if missing:
+            detail = (
+                "--model still needs it: inference re-derives the reference "
+                "PCA from the panel."
+                if ancestry_args.model_path
+                else "Training builds the reference PCA from it."
+            )
+            raise ValueError(
+                f"--ancestry requires {' and '.join(missing)}. {detail}"
+            )
+
     gwas_args = GWASArgs(
         run_pca=ns.pca is not None,
         n_pcs=ns.pca if ns.pca is not None else 10,

--- a/tests/unit/test_cli/test_parser.py
+++ b/tests/unit/test_cli/test_parser.py
@@ -717,11 +717,18 @@ class TestParseArgs:
         assert args.variant_qc.ld_r2_threshold == 0.2
 
     def test_ancestry_flag(self) -> None:
-        """--ancestry enables ancestry prediction."""
+        """--ancestry enables ancestry prediction.
+
+        The reference panel and labels are supplied because --ancestry now
+        requires them; this test previously asserted that an unusable config
+        parsed cleanly.
+        """
         args = parse_args([
             "--pfile", "/data/test",
             "--out", "/output/test",
             "--ancestry",
+            "--ref-panel", "/tmp/ref",
+            "--ref-labels", "/tmp/lab",
         ])
         assert args.ancestry.run_ancestry is True
 
@@ -778,7 +785,14 @@ class TestHetGrammarEndToEnd:
     """Every row of the --het / --het-ancestry semantics table, through
     parse_args - the layer users actually reach."""
 
-    BASE = ["--pfile", "/data/test", "--out", "/tmp/out"]
+    # --ref-panel/--ref-labels ride along because --ancestry requires them;
+    # they are inert for the rows that do not pass --ancestry.
+    BASE = [
+        "--pfile", "/data/test",
+        "--out", "/tmp/out",
+        "--ref-panel", "/tmp/ref",
+        "--ref-labels", "/tmp/lab",
+    ]
 
     def _sample_qc(self, extra: List[str]):
         return parse_args(self.BASE + extra).sample_qc
@@ -927,6 +941,57 @@ class TestAmrHetRemoved:
         }
         assert "--amr-het" not in options
         assert "--amr_het" not in options
+
+
+class TestAncestryRequiresReferencePanel:
+    """--ancestry needs --ref-panel and --ref-labels in both modes.
+
+    Without the check the missing path is stringified into a PLINK command:
+    training reports "No such file or directory: 'None.bim'" and inference
+    reports "Failed to open None.bed", neither of which names the flag or the
+    reason. Predates the het work - reproduced on afad04c.
+    """
+
+    BASE = ["--pfile", "/data/test", "--out", "/tmp/out"]
+
+    def test_training_mode_needs_both(self) -> None:
+        with pytest.raises(ValueError, match="--ancestry requires") as excinfo:
+            parse_args(self.BASE + ["--ancestry"])
+        message = str(excinfo.value)
+        assert "--ref-panel" in message
+        assert "--ref-labels" in message
+
+    def test_inference_mode_needs_both_too(self) -> None:
+        """--model does not remove the requirement: get_raw_files(train=False)
+        still subsets the panel to the model's common SNPs."""
+        with pytest.raises(ValueError, match="--ancestry requires") as excinfo:
+            parse_args(self.BASE + ["--ancestry", "--model", "/tmp/model"])
+        assert "--model still needs it" in str(excinfo.value)
+
+    def test_names_only_the_missing_flag(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            parse_args(self.BASE + ["--ancestry", "--ref-panel", "/tmp/ref"])
+        message = str(excinfo.value)
+        assert "--ref-labels" in message
+        assert "--ref-panel" not in message.split(".")[0]
+
+    def test_unsupported_flag_wins_over_the_missing_panel(self) -> None:
+        """--container can never work; a panel the user could supply is the
+        less useful thing to report."""
+        with pytest.raises(ValueError, match="--container is not supported"):
+            parse_args(self.BASE + ["--ancestry", "--container"])
+
+    def test_both_supplied_is_accepted(self) -> None:
+        args = parse_args(
+            self.BASE
+            + ["--ancestry", "--ref-panel", "/tmp/ref", "--ref-labels", "/tmp/lab"]
+        )
+        assert args.ancestry.run_ancestry is True
+
+    def test_no_ancestry_needs_nothing(self) -> None:
+        """The flags stay optional for a run that never predicts ancestry."""
+        args = parse_args(self.BASE + ["--callrate"])
+        assert args.ancestry.run_ancestry is False
 
 
 class TestDeprecatedFlagSpellings:


### PR DESCRIPTION
## Summary

`--ancestry` accepted a run with no `--ref-panel` and no `--ref-labels`. The missing path was stringified into a PLINK command and surfaced as a filename error naming neither the flag nor the reason:

```
--ancestry             → No such file or directory: 'None.bim'
--ancestry --model X   → Failed to open None.bed
```

`parse_args` now rejects it up front:

```
ERROR: --ancestry requires --ref-panel and --ref-labels. Training builds the
reference PCA from it.
```

**Wider than REFACTOR.md item 23 recorded.** That item logged it as a `--model` bug; training fails the same way. The panel is genuinely needed in both modes — `ref_labels` is read unconditionally at `ancestry/preprocessing.py:137`, and `ref_panel` is used on both sides of the train branch — so one check covers both, with the detail sentence naming the mode-specific reason.

Reproduced on `afad04c`, so it predates the heterozygosity work. 1.3.6 caught the same mistake with a clear message, which makes this a regression in diagnosis rather than in capability.

**Where the check lives.** In `parse_args`, beside the existing "At least one input required" check, not in `AncestryArgs.__post_init__` — it is a required-*combination* check on CLI input, and `AncestryArgs(run_ancestry=True)` is a legitimate fixture when prediction is monkeypatched. It runs *after* `AncestryArgs` is constructed so the `--container`/`--singularity`/`--cloud` rejection still wins: a flag that can never work is more useful to report than a panel the user could supply.

Also corrects `docs/cli_args.md`, where `--ref-panel` was documented as training-only and `--container`/`--singularity`/`--cloud` were still described as working features rather than rejected flags.

## Test plan

- `.venv/bin/python -m pytest tests/unit -q` — **622 passed** (~21s), on this branch rebased onto the post-merge `main`

6 new parser tests in `TestAncestryRequiresRefPanel`: both modes, the message naming only the missing flag, the `--container` precedence case, both-supplied accepted, and no-`--ancestry` unaffected.

**Revert-checked:** removing the check fails 3 of the 6.

Two existing tests were updated rather than added to: `test_ancestry_flag` was pinning the unusable config, and `TestHetGrammarEndToEnd`'s `BASE` gains the two flags since every case in it passes `--ancestry`.
