### PR TITLE
feat: record what software produced a result

### DIFF
--- a/MIGRATION_2.0.md
+++ b/MIGRATION_2.0.md
@@ -259,6 +259,29 @@ Retrain once against your reference panel and reuse the resulting directory.
 (1.x's `--model` also required a sibling `.common_snps` file; 2.0 keeps
 `common_snps.txt` inside the model directory instead.)
 
+### A model records the libraries it was fitted under
+
+`metadata.json` now carries a `versions` block — umap-learn, scikit-learn,
+xgboost, numpy, pandas, scipy, GenoTools and Python — captured at fit time.
+Loading a model compares them against the environment and warns on any
+difference:
+
+```
+Model version drift: umap-learn 0.5.3 -> 0.5.7. This model was fitted under the
+recorded versions, and the embedding can differ under different ones, so
+ancestry calls may not match what this model was validated on. Reinstall the
+recorded versions, or retrain, to reproduce them.
+```
+
+This is a **warning, never an error** — the load always succeeds. It exists
+because the failure it describes is otherwise silent: a model fitted under one
+umap and loaded under another unpickles cleanly and embeds differently, so the
+run finishes with no error and different ancestry calls.
+
+A model trained before this block existed loads with a *provenance unknown*
+warning instead, since "cannot tell" and "no drift" are different answers.
+Retrain to record it.
+
 ### GWAS p-values shift slightly
 
 PCA now prunes high-LD and MHC regions that 1.x left in, so association

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1018,6 +1018,81 @@ Tracked as item 26.
 
 ---
 
+### Round 15 (what software produced this result)
+
+Resolves items 12 and 14. Round 13 recorded *what settings* a run used; this
+records *what software*. Both halves were the same gap on two different paths,
+and both fail silently rather than loudly.
+
+**A trained model records the libraries behind the fit (item 14).**
+`metadata.json` held `config`, `best_params`, `training_metrics` and
+`n_common_snps` — hyperparameters, but nothing about the environment. That
+matters because `umap_learn` is the one pinned dependency in `setup.py`: a
+model fitted under `umap-learn==0.5.3` and loaded under a newer umap unpickles
+*successfully* and produces a different embedding, so the run finishes clean
+and makes different ancestry calls. No error, no warning, no way to tell
+afterwards.
+
+`fit()` now captures umap-learn, scikit-learn, xgboost, numpy, pandas, scipy,
+GenoTools and Python into `model.versions`. Captured at **fit**, not at save:
+these are the versions that produced *this* fit, and living on the model means
+the single-file `.pkl` format carries provenance too, not just the directory
+format's `metadata.json`. `AncestryModel.load` compares them and warns on any
+difference, naming each package and both versions.
+
+*Warn, never block* — decided deliberately. Drift is usually harmless, deps
+float by design (item 16), and a hard failure would strand every existing model
+the moment a dependency moved. A model with no `versions` block gets its own
+"provenance unknown" warning rather than silence: "cannot tell" and "no drift"
+are different answers, and every model trained before this round is in the
+first category.
+
+**Every run records the executables it resolved (item 12).** GenoTools resolves
+plink/plink2/KING only from `$GENOTOOLS_DEP_DIR` or
+`~/.genotools/misc/executables/`, downloading a pinned build if absent, and
+never consults `PATH`. Reproducible, but nothing recorded which build ran. The
+consolidated log now opens with a `===== software =====` section listing the
+interpreter and each tool's resolved path and `--version` — and, when `PATH`
+holds a *different* binary of the same name, says so explicitly. That last line
+is the point: the dev box this was written on has a newer plink2 and plink on
+`PATH` that the pipeline ignores, which makes "I upgraded plink2 and nothing
+changed" very hard to work out from a log.
+
+Describing a tool never fetches one. A tool not yet downloaded is named as
+such, so a callrate-only run does not pull PLINK 1.9 just to describe it. The
+whole section is file-only (the console stays the curated progress stream) and
+wrapped so that provenance can never be the reason a run fails.
+
+**Shared module.** Both halves live in `core/provenance.py` — `package_versions`
+/ `version_drift` for libraries, `describe_tool` / `tool_lines` for
+executables. `executable_folder()` deliberately mirrors
+`dependencies.__get_executable_folder` so it can probe without triggering a
+download; a test pins the two together on both branches, because a divergence
+would have every run log confidently naming a plink2 that is not the one that
+ran.
+
+**Deliberately not in the JSON report.** Tool paths are machine-specific
+(`$GENOTOOLS_DEP_DIR`, `$HOME`), so putting them in `run_info` would reintroduce
+exactly the golden churn round 14 removed. The run log is the right home for
+them; the goldens are unchanged by this round.
+
+**Gating.** 31 tests — 20 in `tests/unit/test_provenance.py`, 6 in
+`test_ancestry/test_model_loading.py`, 5 in
+`test_cli/test_runner_regression.py`. All revert-checked. The first draft of
+the runner tests hit the item-17 trap exactly: all four drove
+`_log_software_provenance` directly, so deleting the call from `run()` left
+them all green. `test_a_real_run_records_provenance` goes through `run()` and
+is the one that catches it.
+
+`AncestryModel.fit` is not unit-tested for this — a minimal fit is a 1080-fit
+grid search taking ~150s. It was verified by hand instead, and a source-level
+check gates the recording call so it cannot be dropped silently.
+
+**Unblocks item 15** (unpinning `umap_learn==0.5.3`): a model can now say what
+it was trained under, which is the prerequisite for changing that.
+
+---
+
 ## Remaining work (tracked, not yet done)
 
 Priority order for making the refactor mergeable to `main`:
@@ -1077,12 +1152,11 @@ Priority order for making the refactor mergeable to `main`:
     Applies to all three per-dataset checks. Not a regression — 1.x's guard never
     fired at all — and the step's own error is the backstop. Fixing it properly
     means re-deciding between steps.
-12. **No plink2 provenance in the run log** — `dependencies.__check_package`
-    resolves only from `$GENOTOOLS_DEP_DIR`/`~/.genotools/misc/executables/`,
-    downloading a pinned build if absent, and never consults `PATH`. Good for
-    reproducibility, but nothing records *which* plink2 produced a result, and a
-    dev box commonly has a newer one on `PATH` that the pipeline ignores. Log the
-    resolved path + `--version` into the run log.
+12. ✅ **No plink2 provenance in the run log** — RESOLVED in **round 15**.
+    Every run now opens its consolidated log with a `software` section giving
+    each tool's resolved path and `--version`, and naming a different binary of
+    the same name on `PATH`. Widened past plink2 to plink and KING, since all
+    three resolve the same way. See round 15 above.
 13. **Palindromic SNPs not excluded in ancestry matching** — a faithful 1.x port
     and a real issue, not a 2.0.0 blocker. Related:
     `ancestry/preprocessing.py:53`'s `drop_duplicates(subset=["chr","pos"])`
@@ -1090,14 +1164,11 @@ Priority order for making the refactor mergeable to `main`:
     positions. `test_get_common_snps_matches_legacy` asserts byte-identical
     output against the legacy function but passes the same bfile as both inputs,
     so the ambiguous-ordering path is barely exercised.
-14. **No provenance on a trained model** — `metadata.json` records
-    hyperparameters but not the library versions that produced the fit. A model
-    trained under `umap_learn==0.5.3` and loaded under a newer umap will
-    unpickle *successfully* and yield subtly different embeddings: wrong
-    ancestry calls, no error. Add a `versions` block (umap, sklearn, xgboost,
-    numpy, pandas, genotools) and check it in `AncestryModel.load`. This is the
-    prerequisite for unpinning umap (see below) — same "record what produced
-    this result" gap as item 12.
+14. ✅ **No provenance on a trained model** — RESOLVED in **round 15**.
+    `fit()` records a `versions` block onto the model itself (so the
+    single-file format carries it too, not just `metadata.json`), and
+    `AncestryModel.load` warns on drift, naming each package. Warn, never
+    block — see round 15 for why. Unblocks item 15.
 15. **Unpin `umap_learn==0.5.3`** — it works under pandas 3 today, but needs
     `pkg_resources` (which setuptools is removing) and its numba floor caps
     numpy. UMAP output feeds the classifier, so this can shift ancestry labels:

--- a/TESTING.md
+++ b/TESTING.md
@@ -349,12 +349,17 @@ external download hosts are hit at most once per cache key.
   default (`--warn` behavior); pass `--no-warn` to fail fast. The old CLI's
   equivalent is `--warn True`/absent.
 - **Where are the run logs?** — `{out}_all_logs.log` is the consolidated,
-  step-tagged log; `{out}.json` has the structured metrics.
+  step-tagged log; `{out}.json` has the structured metrics. The log opens with a
+  `software` section recording the interpreter and each external tool's resolved
+  path and version.
 - **A new test passes — does it actually test the fix?** Revert the fix and
   re-run it. A test written against a helper rather than its call site will
   happily pass with the bug restored; this has caught several. Keep deliberate
   negative controls (which pass either way) but know which ones they are.
-- **Which plink2 ran?** GenoTools resolves **only** from `$GENOTOOLS_DEP_DIR` or
+- **Which plink2 ran?** Read the `===== software =====` section at the top of
+  `{out}_all_logs.log`: every run records the resolved path and `--version` of
+  each tool it can see, and names a *different* binary of the same name sitting
+  on `PATH`. GenoTools resolves **only** from `$GENOTOOLS_DEP_DIR` or
   `~/.genotools/misc/executables/`, downloading a pinned build if absent — it
   never consults `PATH`. The comparators' `_resolve_plink2` prefers `PATH`, so a
   box with both can have your shell and the pipeline on different versions

--- a/genotools/ancestry/model.py
+++ b/genotools/ancestry/model.py
@@ -74,9 +74,46 @@ from genotools.ancestry.results import (
 from genotools.core.exceptions import AncestryError
 from genotools.core.genotypes import GenotypeData
 from genotools.core.logging import get_logger
+from genotools.core.provenance import package_versions, version_drift
 
 
 logger = get_logger(__name__)
+
+
+def _warn_on_version_drift(model: "AncestryModel") -> None:
+    """Say so when a model was fitted under different libraries than are loaded.
+
+    This is the whole point of recording versions. A model fitted under
+    ``umap-learn==0.5.3`` and loaded under a newer umap unpickles *successfully*
+    and produces a different embedding, so the run finishes clean while making
+    different ancestry calls. Nothing here blocks the load — the drift is often
+    harmless, and a hard failure would strand every model the moment a floating
+    dependency moved — but it stops being invisible.
+
+    A model with no recorded versions gets its own warning rather than silence:
+    "cannot tell" and "no drift" are different answers.
+    """
+    recorded = getattr(model, "versions", None)
+    if not recorded:
+        logger.warning(
+            "Model provenance unknown: this model records no library versions, "
+            "so GenoTools cannot tell whether it was fitted under different "
+            "ones than are installed here. Ancestry calls can differ silently "
+            "across library versions; retrain to record provenance."
+        )
+        return
+
+    drift = version_drift(recorded)
+    if not drift:
+        return
+
+    changes = "; ".join(f"{name} {was} -> {now}" for name, was, now in drift)
+    logger.warning(
+        f"Model version drift: {changes}. This model was fitted under the "
+        f"recorded versions, and the embedding can differ under different "
+        f"ones, so ancestry calls may not match what this model was validated "
+        f"on. Reinstall the recorded versions, or retrain, to reproduce them."
+    )
 
 
 @dataclass
@@ -99,6 +136,8 @@ class AncestryModel:
         label_encoder: Fitted LabelEncoder (set after fit).
         best_params: Best hyperparameters from grid search (set after fit).
         training_metrics: Metrics from training (set after fit).
+        versions: Library versions present when the model was fitted (set
+            after fit); None for a model saved before they were recorded.
     """
 
     config: AncestryConfig = field(default_factory=AncestryConfig)
@@ -112,6 +151,10 @@ class AncestryModel:
     _is_fitted: bool = field(default=False, repr=False)
     _train_pca: Optional[pd.DataFrame] = field(default=None, repr=False)
     common_snps: Optional[List[str]] = field(default=None, repr=False)
+    # Library versions behind the fit, captured by fit() and checked by load().
+    # None on a model written before they were recorded, which is why load()
+    # distinguishes "no drift" from "cannot tell".
+    versions: Optional[Dict[str, str]] = field(default=None, repr=False)
 
     @property
     def is_fitted(self) -> bool:
@@ -471,6 +514,11 @@ class AncestryModel:
             y_test=split_data["y_test"],
         )
 
+        # Captured at fit rather than at save: these are the versions that
+        # produced *this* fit, and they travel with the pickle so the
+        # single-file format carries provenance too.
+        self.versions = package_versions()
+
         self._is_fitted = True
         logger.info("Ancestry model fitted successfully")
 
@@ -559,7 +607,8 @@ class AncestryModel:
         Creates a directory at ``path`` containing:
         - ``pipeline.pkl``: Full pickled AncestryModel.
         - ``common_snps.txt``: Plain text rsIDs, one per line.
-        - ``metadata.json``: Config, best_params, training_metrics.
+        - ``metadata.json``: Config, best_params, training_metrics, and the
+          library versions the fit ran under.
 
         Args:
             path: Output directory path.
@@ -611,6 +660,9 @@ class AncestryModel:
 
         if self.common_snps is not None:
             metadata["n_common_snps"] = len(self.common_snps)
+
+        if self.versions is not None:
+            metadata["versions"] = dict(self.versions)
 
         return metadata
 
@@ -680,6 +732,8 @@ class AncestryModel:
                 f"Invalid model file: expected AncestryModel, got "
                 f"{type(model)}.{hint}"
             )
+
+        _warn_on_version_drift(model)
 
         logger.info(f"Model loaded from: {path}")
         return model

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -44,6 +44,7 @@ from ..core.logging import (
     summary_tag,
     summary_tally,
 )
+from ..core.provenance import package_versions, tool_lines
 from ..core.validation import (
     ValidationDecisions,
     case_control_skip_reason,
@@ -230,6 +231,9 @@ class PipelineRunner:
         # Set up logging (builds the RunLog, installs handlers, writes banner).
         self._setup_logging()
 
+        # Record what software is about to produce the results, before it does.
+        self._log_software_provenance()
+
         # Pre-flight: convert input + validate (logged into the consolidated log),
         # then confirm there is work to do. A failure here happens *before* any
         # output is produced, so tear down and REMOVE the freshly-created log so
@@ -411,6 +415,40 @@ class PipelineRunner:
                 except OSError:
                     pass
             runlog.restore_rotated()
+
+    def _log_software_provenance(self) -> None:
+        """Record the interpreter, GenoTools, and the external tools resolved.
+
+        GenoTools resolves plink/plink2/KING from its own executable folder and
+        never consults ``PATH``, which is good for reproducibility and bad for
+        working out after the fact *which* build produced a result — especially
+        on a box that has a different, newer plink2 on ``PATH`` that the
+        pipeline quietly ignores. Recording it costs one ``--version`` call per
+        tool that is already on disk; a tool that has not been fetched yet is
+        named as such rather than downloaded here, so a callrate-only run does
+        not pull PLINK 1.9 just to describe it.
+
+        File-only: the console stream is the curated progress view, and this
+        belongs in the durable log. Best-effort throughout — provenance must
+        never be the reason a run fails.
+        """
+        self._begin_section("software")
+        try:
+            with step_context("software"):
+                versions = package_versions(())
+                logger.info(
+                    f"GenoTools {versions['genotools']} "
+                    f"(python {versions['python']}, {platform.platform()})",
+                    extra={"file_only": True},
+                )
+                for line in tool_lines():
+                    logger.info(line, extra={"file_only": True})
+        except Exception as e:
+            # Best-effort by design: a run that cannot describe its own tools
+            # is still a run worth finishing.
+            logger.debug(f"Could not record software provenance: {e}")
+        finally:
+            self._end_section()
 
     def _begin_section(self, title: str) -> None:
         """Open a consolidated-log section (no-op when logging isn't installed)."""

--- a/genotools/core/provenance.py
+++ b/genotools/core/provenance.py
@@ -1,0 +1,258 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""What software produced a result.
+
+The previous round recorded *what settings* a run used. This one records *what
+software*, on the two paths where the answer was previously unrecoverable:
+
+- **A trained ancestry model** (:func:`package_versions`, :func:`version_drift`).
+  ``metadata.json`` held hyperparameters but not the library versions behind the
+  fit. A model fit under ``umap-learn==0.5.3`` and loaded under a newer umap
+  unpickles *successfully* and embeds differently, so the run yields different
+  ancestry calls with no error and no warning. Recording the versions at fit
+  time makes that drift visible at load time.
+
+- **The external executables** (:func:`describe_tool`, :func:`tool_lines`).
+  ``dependencies.__check_package`` resolves plink/plink2/KING from
+  ``$GENOTOOLS_DEP_DIR`` or ``~/.genotools/misc/executables`` and never consults
+  ``PATH`` — good for reproducibility, but nothing recorded *which* build
+  produced a result, and a dev box commonly has a different plink2 on ``PATH``
+  that the pipeline quietly ignores.
+
+Both halves are best-effort: provenance must never be the reason a run fails.
+Every lookup here degrades to a string rather than raising.
+"""
+
+import os
+import pathlib
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .. import __version__
+
+__all__ = [
+    "MODEL_PACKAGES",
+    "ToolInfo",
+    "describe_tool",
+    "package_versions",
+    "tool_lines",
+    "version_drift",
+]
+
+
+# The libraries that shape a fitted ancestry model. umap-learn is the one that
+# actually motivated this: it is the only pinned dependency in setup.py, and
+# unpinning it is tracked separately. scipy is in the list because umap and
+# scikit-learn both compute through it.
+MODEL_PACKAGES: Tuple[str, ...] = (
+    "umap-learn",
+    "scikit-learn",
+    "xgboost",
+    "numpy",
+    "pandas",
+    "scipy",
+)
+
+# What a package resolves to when it is not installed at all. Recorded rather
+# than omitted so that "was absent then, present now" is still visible drift.
+NOT_INSTALLED = "not installed"
+
+_UNKNOWN = "unknown"
+
+
+def package_versions(
+    packages: Sequence[str] = MODEL_PACKAGES,
+) -> Dict[str, str]:
+    """Return installed versions of ``packages``, plus genotools and python.
+
+    Distribution names are used as given (``umap-learn``, not ``umap``), since
+    that is what :mod:`importlib.metadata` and ``pip`` both speak.
+
+    Args:
+        packages: Distribution names to look up.
+
+    Returns:
+        Ordered mapping of name to version string. A package that is not
+        installed maps to :data:`NOT_INSTALLED`; the mapping always carries
+        ``genotools`` and ``python`` keys.
+    """
+    versions: Dict[str, str] = {}
+    for name in packages:
+        try:
+            versions[name] = metadata.version(name)
+        except Exception:
+            # PackageNotFoundError, but also a broken dist-info: provenance is
+            # never worth failing a fit over.
+            versions[name] = NOT_INSTALLED
+    versions["genotools"] = __version__
+    versions["python"] = platform.python_version()
+    return versions
+
+
+def version_drift(
+    recorded: Dict[str, str],
+    current: Optional[Dict[str, str]] = None,
+) -> List[Tuple[str, str, str]]:
+    """Compare recorded versions against the current environment.
+
+    Only packages present in *both* mappings are compared, so an explicitly
+    passed ``current`` that omits a key treats it as uncomparable rather than
+    as drift. The default ``current`` looks up exactly the keys ``recorded``
+    holds, so a package that was recorded and has since been uninstalled does
+    show up, as drift to :data:`NOT_INSTALLED` — that is a real change to the
+    environment, not a change in what gets recorded.
+
+    Args:
+        recorded: Versions stored when the model was fitted.
+        current: Versions to compare against. Defaults to this environment's,
+            looked up for exactly the keys ``recorded`` holds (``genotools``
+            and ``python`` included, from the interpreter rather than from
+            distribution metadata).
+
+    Returns:
+        ``(package, recorded_version, current_version)`` for each package whose
+        version differs, in the order ``recorded`` lists them.
+    """
+    if current is None:
+        keys = [k for k in recorded if k not in ("genotools", "python")]
+        current = package_versions(keys)
+    return [
+        (name, was, current[name])
+        for name, was in recorded.items()
+        if name in current and current[name] != was
+    ]
+
+
+# ---------------------------------------------------------------------------
+# External executables
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolInfo:
+    """Where an external tool came from and what it says it is.
+
+    Attributes:
+        name: Tool name as GenoTools refers to it ("plink2").
+        path: Resolved executable, or None if not present in the executable
+            folder. None means "not fetched yet", not "unavailable" —
+            GenoTools downloads a pinned build on first use.
+        version: First line of the tool's ``--version`` output, or a short
+            explanation of why there isn't one.
+        shadowed_by: A *different* executable of the same name found on
+            ``PATH``. GenoTools does not use it; it is recorded because a dev
+            box commonly has one and it explains a surprising result.
+    """
+
+    name: str
+    path: Optional[pathlib.Path]
+    version: str
+    shadowed_by: Optional[pathlib.Path] = None
+
+
+def executable_folder() -> pathlib.Path:
+    """Return the folder GenoTools resolves its executables from.
+
+    Mirrors ``dependencies.__get_executable_folder``. Kept here as a read-only
+    probe so provenance can report a tool that has not been fetched without
+    triggering the download that resolving it would.
+    """
+    override = os.environ.get("GENOTOOLS_DEP_DIR")
+    if override:
+        return pathlib.Path(os.path.abspath(override))
+    return pathlib.Path.home() / ".genotools" / "misc" / "executables"
+
+
+def tool_version(path: pathlib.Path) -> str:
+    """Return the first line of ``path --version``, or why it isn't available."""
+    try:
+        result = subprocess.run(
+            [str(path), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return _UNKNOWN
+    # PLINK 1.9 and KING both answer on stdout; fall back to stderr for
+    # anything that does not.
+    output = result.stdout.strip() or result.stderr.strip()
+    if not output:
+        return _UNKNOWN
+    return output.splitlines()[0].strip()
+
+
+def describe_tool(name: str) -> ToolInfo:
+    """Describe one external tool without fetching it.
+
+    Args:
+        name: Executable name as it lives in the executable folder
+            ("plink", "plink2", "king").
+
+    Returns:
+        A :class:`ToolInfo`. ``path`` is None when the tool has not been
+        downloaded yet, in which case GenoTools will fetch a pinned build the
+        first time a step needs it.
+    """
+    binary = executable_folder() / name
+    on_path = shutil.which(name)
+    shadowed_by: Optional[pathlib.Path] = None
+    if on_path:
+        candidate = pathlib.Path(on_path)
+        try:
+            different = not binary.exists() or not candidate.samefile(binary)
+        except OSError:  # pragma: no cover - racing filesystem
+            different = True
+        if different:
+            shadowed_by = candidate
+
+    if not binary.exists():
+        return ToolInfo(
+            name=name,
+            path=None,
+            version="not fetched yet; a pinned build is downloaded on first use",
+            shadowed_by=shadowed_by,
+        )
+    return ToolInfo(
+        name=name,
+        path=binary,
+        version=tool_version(binary),
+        shadowed_by=shadowed_by,
+    )
+
+
+def tool_lines(names: Sequence[str] = ("plink2", "plink", "king")) -> List[str]:
+    """Render one provenance line per tool, for the consolidated run log.
+
+    A tool GenoTools ignores in favour of its own copy gets a second line
+    naming the one on ``PATH``, because "I upgraded plink2 and nothing changed"
+    is otherwise a genuinely hard thing to work out.
+    """
+    lines: List[str] = []
+    for name in names:
+        info = describe_tool(name)
+        where = str(info.path) if info.path is not None else "not resolved"
+        lines.append(f"{info.name}: {where} -- {info.version}")
+        if info.shadowed_by is not None:
+            lines.append(
+                f"    note: a different {info.name} is on PATH "
+                f"({info.shadowed_by}); GenoTools does not use it"
+            )
+    return lines

--- a/tests/regression/test_logging.py
+++ b/tests/regression/test_logging.py
@@ -72,6 +72,10 @@ def test_consolidated_log_is_sectioned_with_raw(test_geno_path: Path, tmp_path: 
     # Materially longer than a bare banner.
     assert len(content) > 400, f"consolidated log looks header-only:\n{content!r}"
 
+    # Round 15: what software produced this result, recorded before it does.
+    assert "===== software =====" in content, "missing software provenance section"
+    assert "plink2:" in content, "the tool behind every run is unrecorded"
+
     # Per-step section headers.
     assert "===== callrate =====" in content, "missing callrate section header"
     assert "===== geno =====" in content, "missing geno section header"
@@ -85,9 +89,16 @@ def test_consolidated_log_is_sectioned_with_raw(test_geno_path: Path, tmp_path: 
     assert "PLINK v" in content, "raw PLINK output not inlined in consolidated log"
 
     # For each step, its structured summary precedes its raw PLINK block.
-    i_marker = content.index("[callrate_prune]")
-    i_raw = content.index("PLINK v")
-    assert i_marker < i_raw, "raw PLINK block should follow the structured summary"
+    # Scoped to the step's own section rather than the whole file: the log now
+    # opens with a `software` section that reports plink's own version string,
+    # so a file-wide search for "PLINK v" finds that header, not a raw block.
+    callrate_section = content[
+        content.index("===== callrate ====="): content.index("===== geno =====")
+    ]
+    assert "PLINK v" in callrate_section, "callrate section has no raw PLINK block"
+    assert callrate_section.index("[callrate_prune]") < callrate_section.index(
+        "PLINK v"
+    ), "raw PLINK block should follow the structured summary"
 
     # End-of-run summary table.
     assert "run summary" in content.lower(), "missing run summary block"

--- a/tests/unit/test_ancestry/test_model_loading.py
+++ b/tests/unit/test_ancestry/test_model_loading.py
@@ -81,3 +81,119 @@ def test_directory_without_pipeline_pkl_says_which_file_is_missing(
 
     with pytest.raises(FileNotFoundError, match="pipeline.pkl"):
         AncestryModel.load(empty)
+
+
+# ---------------------------------------------------------------------------
+# Version provenance
+#
+# A model fitted under umap-learn 0.5.3 and loaded under a newer umap unpickles
+# *successfully* and produces a different embedding: wrong ancestry calls, no
+# error, no warning. Recording the versions at fit time is what makes that
+# visible, so these tests assert on the warning, not on the stored dict.
+# ---------------------------------------------------------------------------
+
+
+def _model_with_versions(
+    tmp_path: Path, versions: object, name: str = "model.pkl"
+) -> Path:
+    """Pickle a bare AncestryModel carrying ``versions`` (no fit required)."""
+    model = AncestryModel()
+    model.versions = versions  # type: ignore[assignment]
+    return _pickle(model, tmp_path / name)
+
+
+def _warnings(caplog: "pytest.LogCaptureFixture") -> str:
+    return "\n".join(
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    )
+
+
+def test_drifted_versions_warn_and_name_the_package(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The warning has to say which package moved and to what - "versions
+    differ" leaves the user with nothing to act on."""
+    path = _model_with_versions(tmp_path, {"umap-learn": "0.0.1-ancient"})
+
+    with caplog.at_level("WARNING", logger="genotools"):
+        AncestryModel.load(path)
+
+    message = _warnings(caplog)
+    assert "umap-learn" in message
+    assert "0.0.1-ancient" in message, "must name the version the fit ran under"
+    assert "ancestry calls" in message.lower(), "say what is actually at risk"
+
+
+def test_matching_versions_load_quietly(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A false drift warning on every load would train users to ignore it."""
+    from genotools.core.provenance import package_versions
+
+    path = _model_with_versions(tmp_path, package_versions())
+
+    with caplog.at_level("WARNING", logger="genotools"):
+        AncestryModel.load(path)
+
+    assert _warnings(caplog) == ""
+
+
+def test_a_model_without_versions_says_it_cannot_tell(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Models predating version recording must not read as "no drift":
+    "cannot tell" and "no drift" are different answers."""
+    path = _model_with_versions(tmp_path, None)
+
+    with caplog.at_level("WARNING", logger="genotools"):
+        AncestryModel.load(path)
+
+    message = _warnings(caplog)
+    assert "provenance unknown" in message.lower()
+    assert "retrain" in message.lower(), "name the way out"
+
+
+def test_drift_never_blocks_the_load(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Drift is often harmless, and hard-failing would strand every existing
+    model the moment a floating dependency moved."""
+    path = _model_with_versions(
+        tmp_path, {"umap-learn": "0.0.1", "numpy": "0.0.1", "scipy": "0.0.1"}
+    )
+
+    with caplog.at_level("WARNING", logger="genotools"):
+        model = AncestryModel.load(path)
+
+    assert isinstance(model, AncestryModel)
+
+
+def test_saved_metadata_carries_the_versions(tmp_path: Path) -> None:
+    """metadata.json is the human-readable half; provenance has to reach it or
+    nobody reads it without unpickling."""
+    import json
+
+    model = AncestryModel()
+    model.versions = {"umap-learn": "0.5.3"}
+    model._is_fitted = True
+
+    out = model.save(tmp_path / "saved")
+    metadata = json.loads((out / "metadata.json").read_text())
+
+    assert metadata["versions"] == {"umap-learn": "0.5.3"}
+
+
+def test_fit_is_what_records_the_versions() -> None:
+    """Captured at fit, not at save: these are the versions that produced
+    *this* fit, and they must travel with the pickle for the single-file
+    format to carry provenance too.
+    """
+    import inspect
+
+    from genotools.ancestry import model as model_module
+
+    source = inspect.getsource(model_module.AncestryModel.fit)
+    assert "package_versions()" in source, (
+        "fit() no longer records versions; every model trained from here on "
+        "would load with unknown provenance"
+    )

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -1818,3 +1818,142 @@ class TestFlattenConfig:
         from genotools.cli.runner import _flatten_config
 
         assert _flatten_config(None) == {}
+
+
+class TestSoftwareProvenance:
+    """Round 15: which software produced this result.
+
+    GenoTools resolves plink/plink2/KING from its own executable folder and
+    never consults PATH. That is good for reproducibility and bad for working
+    out after the fact which build ran - especially on a box carrying a newer
+    plink2 on PATH that the pipeline quietly ignores.
+    """
+
+    def _provenance_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> str:
+        from genotools.core.logging import raw_sink
+
+        runner, _geno, out = _make_runner(tmp_path, warn_only=False)
+        runner._setup_logging()
+        try:
+            runner._log_software_provenance()
+        finally:
+            if runner._runlog is not None:
+                runner._runlog.close()
+            raw_sink.set(None)
+        return Path(f"{out}_all_logs.log").read_text()
+
+    def test_run_log_records_the_tools_and_the_interpreter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from genotools import __version__
+
+        content = self._provenance_log(tmp_path, monkeypatch)
+
+        assert "===== software =====" in content
+        assert f"GenoTools {__version__}" in content
+        assert "plink2:" in content, "the tool behind every run is unrecorded"
+
+    def test_a_shadowing_path_binary_is_named(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """"I upgraded plink2 and nothing changed" is otherwise very hard to
+        work out from a run log."""
+        import stat
+
+        owned = tmp_path / "deps"
+        owned.mkdir()
+        for name in ("plink2", "plink", "king"):
+            binary = owned / name
+            binary.write_text('#!/bin/sh\necho "fake 1.0"\n')
+            binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+        other = tmp_path / "elsewhere" / "plink2"
+        other.parent.mkdir()
+        other.write_text('#!/bin/sh\necho "fake 2.0"\n')
+        other.chmod(other.stat().st_mode | stat.S_IXUSR)
+
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(owned))
+        monkeypatch.setattr(
+            "shutil.which", lambda name: str(other) if name == "plink2" else None
+        )
+
+        content = self._provenance_log(tmp_path, monkeypatch)
+
+        assert str(other) in content
+        assert "does not use it" in content
+        assert "fake 1.0" in content, "must report the build GenoTools runs"
+
+    def test_provenance_is_never_fatal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run must not die because it could not describe its own tools."""
+        monkeypatch.setattr(
+            "genotools.cli.runner.tool_lines",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        content = self._provenance_log(tmp_path, monkeypatch)
+        assert "===== software =====" in content
+
+    @pytest.mark.skipif(not _plink2_available(), reason="plink2 not available")
+    def test_a_real_run_records_provenance(self, tmp_path: Path) -> None:
+        """Through run(), not through the helper.
+
+        Every test above drives _log_software_provenance directly, so all of
+        them still pass if run() stops calling it - the item-17 trap. This one
+        goes through the entry point the wiring actually lives in.
+        """
+        if not SYNTHETIC.with_suffix(".pgen").exists():
+            pytest.skip("synthetic test data not found")
+
+        local = tmp_path / "cohort"
+        for ext in (".pgen", ".pvar", ".psam"):
+            shutil.copy2(SYNTHETIC.with_suffix(ext), local.with_suffix(ext))
+
+        out = tmp_path / "out"
+        args = PipelineArgs(
+            input=InputArgs(pfile=local),
+            output=OutputArgs(out_path=out, full_output=True),
+            sample_qc=SampleQCArgs(run_callrate=True, callrate_threshold=0.05),
+        )
+        PipelineRunner(args).run()
+
+        content = Path(f"{out}_all_logs.log").read_text()
+        assert "===== software =====" in content, (
+            "run() did not record what software produced this result"
+        )
+        assert "plink2:" in content
+
+    def test_provenance_stays_out_of_the_console(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The console is the curated progress stream; provenance belongs in
+        the durable log."""
+        import logging as _logging
+
+        from genotools.core.logging import raw_sink
+
+        runner, _geno, out = _make_runner(tmp_path, warn_only=False)
+        runner._setup_logging()
+
+        captured: List[_logging.LogRecord] = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record: _logging.LogRecord) -> None:
+                if not getattr(record, "file_only", False):
+                    captured.append(record)
+
+        cap = _Capture()
+        _logging.getLogger("genotools").addHandler(cap)
+        try:
+            runner._log_software_provenance()
+        finally:
+            _logging.getLogger("genotools").removeHandler(cap)
+            if runner._runlog is not None:
+                runner._runlog.close()
+            raw_sink.set(None)
+
+        assert not [r for r in captured if "plink2:" in r.getMessage()], (
+            "provenance leaked into the console stream"
+        )
+        assert "plink2:" in Path(f"{out}_all_logs.log").read_text()

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -1,0 +1,271 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""What software produced a result: library versions and external executables.
+
+Both halves exist because the answer used to be unrecoverable after the fact —
+a model fit under one umap and loaded under another produces different ancestry
+calls with no error, and nothing recorded which plink2 ran.
+"""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from genotools import __version__
+from genotools.core.provenance import (
+    MODEL_PACKAGES,
+    NOT_INSTALLED,
+    describe_tool,
+    executable_folder,
+    package_versions,
+    tool_lines,
+    tool_version,
+    version_drift,
+)
+
+
+def _fake_tool(directory: Path, name: str, says: str) -> Path:
+    """Write an executable that answers --version with ``says``."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(f'#!/bin/sh\necho "{says}"\n')
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+class TestPackageVersions:
+    def test_records_the_libraries_that_shape_a_fit(self) -> None:
+        versions = package_versions()
+        # umap-learn is the one that motivated this: it is pinned precisely
+        # because a different version embeds differently.
+        assert "umap-learn" in versions
+        for package in MODEL_PACKAGES:
+            assert package in versions, f"{package} is not recorded"
+
+    def test_always_carries_genotools_and_python(self) -> None:
+        versions = package_versions(())
+        assert versions["genotools"] == __version__
+        assert versions["python"].count(".") == 2, versions["python"]
+
+    def test_a_missing_package_is_recorded_not_dropped(self) -> None:
+        """Dropping it would make "absent then, present now" invisible."""
+        versions = package_versions(["definitely-not-a-real-distribution"])
+        assert versions["definitely-not-a-real-distribution"] == NOT_INSTALLED
+
+
+class TestVersionDrift:
+    def test_reports_only_what_changed(self) -> None:
+        recorded = {"umap-learn": "0.5.3", "numpy": "1.23.5"}
+        current = {"umap-learn": "0.5.3", "numpy": "2.3.5"}
+        assert version_drift(recorded, current) == [("numpy", "1.23.5", "2.3.5")]
+
+    def test_identical_environments_have_no_drift(self) -> None:
+        recorded = package_versions()
+        assert version_drift(recorded) == []
+
+    def test_a_key_missing_from_current_is_not_drift(self) -> None:
+        """An explicit ``current`` that omits a key cannot speak to it."""
+        recorded = {"umap-learn": "0.5.3", "retired-metric": "1.0"}
+        drift = version_drift(recorded, {"umap-learn": "0.5.3"})
+        assert drift == []
+
+    def test_an_uninstalled_package_is_drift(self) -> None:
+        """Recorded then, gone now, is a real change to the environment."""
+        drift = version_drift({"definitely-not-a-real-distribution": "1.0"})
+        assert drift == [
+            ("definitely-not-a-real-distribution", "1.0", NOT_INSTALLED)
+        ]
+
+    def test_preserves_the_recorded_order(self) -> None:
+        recorded = {"a": "1", "b": "1", "c": "1"}
+        current = {"a": "2", "b": "2", "c": "2"}
+        assert [name for name, _, _ in version_drift(recorded, current)] == [
+            "a", "b", "c"
+        ]
+
+
+class TestExecutableFolder:
+    def test_honours_the_dep_dir_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Must match dependencies.__get_executable_folder, or provenance
+        describes a different plink2 than the one that actually runs."""
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(tmp_path))
+        assert executable_folder() == tmp_path
+
+    def test_defaults_to_the_genotools_home(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GENOTOOLS_DEP_DIR", raising=False)
+        assert executable_folder() == (
+            Path.home() / ".genotools" / "misc" / "executables"
+        )
+
+    def test_matches_what_dependencies_actually_resolves(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pin the two implementations together rather than trusting the copy.
+
+        ``executable_folder`` mirrors ``dependencies.__get_executable_folder``
+        so it can probe without downloading. If the two ever diverge, every run
+        log confidently names a plink2 that is not the one that ran.
+        """
+        import importlib
+
+        import genotools.dependencies as dependencies
+
+        deps_dir = tmp_path / "deps"
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(deps_dir))
+        try:
+            importlib.reload(dependencies)
+            # Module-level double-underscore names are not mangled at module
+            # scope, but a lookup from inside this method would be - hence
+            # __dict__. A KeyError here means dependencies was restructured
+            # and this test needs rewriting, not deleting.
+            resolved = Path(dependencies.__dict__["__executable_folder"])
+            assert resolved == deps_dir, "the reload did not pick up the override"
+            assert resolved == executable_folder()
+
+            # And the default branch, which is the one a real user hits.
+            monkeypatch.delenv("GENOTOOLS_DEP_DIR", raising=False)
+            importlib.reload(dependencies)
+            default = Path(dependencies.__dict__["__executable_folder"])
+            assert default == executable_folder()
+        finally:
+            monkeypatch.delenv("GENOTOOLS_DEP_DIR", raising=False)
+            importlib.reload(dependencies)
+
+
+class TestDescribeTool:
+    def test_an_unfetched_tool_is_named_not_downloaded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Describing a tool must never trigger the download that resolving it
+        would - a callrate-only run should not pull PLINK 1.9 to name it."""
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(tmp_path))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+
+        info = describe_tool("plink")
+        assert info.path is None
+        assert "not fetched" in info.version
+        assert not any(tmp_path.iterdir()), "describe_tool downloaded something"
+
+    def test_reports_the_resolved_path_and_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = _fake_tool(tmp_path, "plink2", "PLINK v2.00a5.10LM 64-bit")
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(tmp_path))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+
+        info = describe_tool("plink2")
+        assert info.path == binary
+        assert info.version == "PLINK v2.00a5.10LM 64-bit"
+        assert info.shadowed_by is None
+
+    def test_a_different_tool_on_path_is_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The point of item 12: GenoTools ignores PATH, and "I upgraded
+        plink2 and nothing changed" is otherwise very hard to work out."""
+        owned = tmp_path / "owned"
+        _fake_tool(owned, "plink2", "PLINK v2.00a5.10LM 64-bit")
+        other = _fake_tool(tmp_path / "elsewhere", "plink2", "PLINK v2.00a6LM")
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(owned))
+        monkeypatch.setattr("shutil.which", lambda name: str(other))
+
+        info = describe_tool("plink2")
+        assert info.shadowed_by == other
+        assert info.version == "PLINK v2.00a5.10LM 64-bit", (
+            "must report the build GenoTools runs, not the one on PATH"
+        )
+
+    def test_the_same_tool_on_path_is_not_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A false 'a different plink2 is on PATH' would train users to ignore
+        the note that matters."""
+        binary = _fake_tool(tmp_path, "plink2", "PLINK v2.00a5.10LM 64-bit")
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(tmp_path))
+        monkeypatch.setattr("shutil.which", lambda name: str(binary))
+
+        assert describe_tool("plink2").shadowed_by is None
+
+    def test_a_tool_that_cannot_run_degrades_to_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Provenance must never be the reason a run fails."""
+        broken = tmp_path / "plink2"
+        broken.write_text("not an executable")
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(tmp_path))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+
+        assert describe_tool("plink2").version == "unknown"
+
+    def test_version_read_from_stderr_when_stdout_is_empty(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "noisy"
+        path.write_text('#!/bin/sh\necho "KING 2.3.2" >&2\n')
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+        assert tool_version(path) == "KING 2.3.2"
+
+    def test_only_the_first_line_is_kept(self, tmp_path: Path) -> None:
+        """PLINK 1.9 prints a licence blurb after its version line."""
+        path = _fake_tool(tmp_path, "plink", "PLINK v1.9.0-b.8\nGPLv3 blurb")
+        assert tool_version(path) == "PLINK v1.9.0-b.8"
+
+
+class TestToolLines:
+    def test_one_line_per_tool_plus_a_shadow_note(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        owned = tmp_path / "owned"
+        _fake_tool(owned, "plink2", "PLINK v2.00a5.10LM 64-bit")
+        other = _fake_tool(tmp_path / "elsewhere", "plink2", "PLINK v2.00a6LM")
+        monkeypatch.setenv("GENOTOOLS_DEP_DIR", str(owned))
+        monkeypatch.setattr("shutil.which", lambda name: str(other))
+
+        lines = tool_lines(["plink2"])
+        assert len(lines) == 2
+        assert lines[0].startswith("plink2: ")
+        assert str(owned / "plink2") in lines[0]
+        assert "PATH" in lines[1] and str(other) in lines[1]
+
+    def test_covers_every_tool_the_executors_resolve(self) -> None:
+        """A tool missing from the default list leaves a silent gap in the
+        provenance of every run that uses it.
+
+        The executors are the only place GenoTools resolves an external binary,
+        so the set of ``check_*`` calls there is the set worth describing.
+        """
+        import re
+
+        import genotools.core.executors as executors
+
+        source = Path(executors.__file__).read_text()
+        resolved = {
+            name.lower()
+            for name in re.findall(r"check_(\w+)\(\)", source)
+        }
+        assert resolved, "no check_* calls found; executors was restructured"
+
+        described = {line.split(":", 1)[0] for line in tool_lines()}
+        assert resolved <= described, (
+            f"executors resolve {sorted(resolved - described)}, "
+            f"which no run log would record"
+        )


### PR DESCRIPTION
## Summary

Round 13 recorded *what settings* a run used. This records *what software*, on
the two paths where the answer was previously unrecoverable. Both are the same
defect shape as the last four rounds: something that fails silently.

**A trained model records the libraries behind the fit (item 14).**
`metadata.json` held `config`, `best_params`, `training_metrics` and
`n_common_snps` — hyperparameters, but nothing about the environment. That
matters because `umap_learn` is the one pinned dependency in `setup.py`: a model
fitted under `umap-learn==0.5.3` and loaded under a newer umap unpickles
*successfully* and produces a different embedding, so the run finishes clean and
makes different ancestry calls. No error, no warning, no way to tell afterwards.

`fit()` now captures umap-learn, scikit-learn, xgboost, numpy, pandas, scipy,
GenoTools and Python into `model.versions`. Captured at **fit**, not at save:
these are the versions that produced *this* fit, and living on the model means
the single-file `.pkl` format carries provenance too, not just the directory
format's `metadata.json`. `AncestryModel.load` compares them and warns on any
difference, naming each package and both versions.

*Warn, never block* — decided deliberately. Drift is usually harmless, deps
float by design (item 16), and a hard failure would strand every existing model
the moment a dependency moved. A model with no `versions` block gets its own
"provenance unknown" warning rather than silence: "cannot tell" and "no drift"
are different answers, and every model trained before this round is in the first
category.

**Every run records the executables it resolved (item 12).** GenoTools resolves
plink/plink2/KING only from `$GENOTOOLS_DEP_DIR` or
`~/.genotools/misc/executables/`, downloading a pinned build if absent, and
never consults `PATH`. Reproducible, but nothing recorded which build ran. The
consolidated log now opens with:

```
===== software =====
... GenoTools 2.0.1 (python 3.11.2, Linux-6.1.0-52-cloud-amd64-x86_64-with-glibc2.36)
... plink2: /home/.../.genotools/misc/executables/plink2 -- PLINK v2.00a5.10LM 64-bit Intel (5 Jan 2024)
...     note: a different plink2 is on PATH (/usr/local/bin/plink2); GenoTools does not use it
... plink: /home/.../.genotools/misc/executables/plink -- PLINK v1.9.0-b.8 64-bit (19 Aug 2025)
... king: /home/.../.genotools/misc/executables/king -- KING 2.3.2 - (c) 2010-2023 Wei-Min Chen
```

That third line is the point: the dev box this was written on has a newer plink2
and plink on `PATH` that the pipeline ignores, which makes "I upgraded plink2 and
nothing changed" very hard to work out from a log.

Describing a tool never fetches one — a tool not yet downloaded is named as such,
so a callrate-only run does not pull PLINK 1.9 just to describe it. The section
is file-only (the console stays the curated progress stream) and wrapped so that
provenance can never be the reason a run fails.

**Shared module.** Both halves live in `core/provenance.py`. `executable_folder()`
deliberately mirrors `dependencies.__get_executable_folder` so it can probe
without triggering a download; a test pins the two together on both branches,
because a divergence would have every run log confidently naming a plink2 that is
not the one that ran.

**Deliberately not in the JSON report.** Tool paths are machine-specific
(`$GENOTOOLS_DEP_DIR`, `$HOME`), so putting them in `run_info` would reintroduce
exactly the golden churn round 14 removed. Regenerating the goldens produces no
diff.

Resolves REFACTOR.md items 12 and 14; unblocks item 15 (unpinning `umap_learn`).

## Test plan

- `pytest tests/unit -q` → **682 passed** (was 651; +31 here).
- `pytest tests/regression -q` → **77 passed** (~6m40s).
- Goldens regenerated: **no diff**, so the report contract is unchanged and
  round 14's idempotence holds.

**New tests, all revert-checked:**

| File | n | Gates |
|---|---|---|
| `tests/unit/test_provenance.py` | 20 | version recording and drift; tool description without downloading; `PATH`-shadow detection; `executable_folder` pinned to `dependencies` |
| `test_ancestry/test_model_loading.py` | 6 | drift warns and names the package; matching versions load quietly; a version-less model says "cannot tell"; drift never blocks |
| `test_cli/test_runner_regression.py` | 5 | the `software` section reaches the run log via `run()`; shadow note; never fatal; stays off the console |

Breaking each production call site fails the corresponding test. Worth
flagging: the first draft of the runner tests hit the item-17 trap exactly —
all four drove `_log_software_provenance` directly, so deleting the call from
`run()` left them all green. `test_a_real_run_records_provenance` goes through
`run()` and is the one that catches it.

`AncestryModel.fit` is not unit-tested for this: a minimal fit is a 1080-fit grid
search taking ~150s. It was verified by hand (a real fit does record the block)
and a source-level check gates the recording call so it cannot be dropped
silently.

**One existing test changed.** `tests/regression/test_logging.py` asserted "a
step's structured summary precedes its raw PLINK block" using a whole-file
`content.index("PLINK v")`. The software section now reports plink's own version
string near the top of the file, so that search found the header rather than a
raw block. The assertion is now scoped to the callrate section, which is what it
meant to check; the test also now asserts the software section exists.
