### PR TITLE
chore: unpin umap_learn, and measure what it costs

### DIFF
--- a/MIGRATION_2.0.md
+++ b/MIGRATION_2.0.md
@@ -282,6 +282,56 @@ A model trained before this block existed loads with a *provenance unknown*
 warning instead, since "cannot tell" and "no drift" are different answers.
 Retrain to record it.
 
+### umap_learn is no longer pinned — ancestry calls shift by ~1.2%
+
+**This changes ancestry calls. Retrain your models and revalidate.**
+
+1.x and early 2.0 pinned `umap_learn==0.5.3`. That pin is now removed
+(`umap_learn>=0.5.5`), and the `setuptools` runtime dependency with it.
+
+**Why it had to go.** umap-learn below 0.5.5 runs `import pkg_resources` at
+import time, and setuptools deleted `pkg_resources` in 82.0.0. A fresh install
+that resolves a current setuptools therefore cannot import umap at all, so
+`--ancestry` fails before any of your data is touched. The pin had stopped
+protecting reproducibility and started preventing installation.
+
+**What it costs.** Measured on a 10,000-sample GP2 subset across 11 ancestry
+groups, comparing umap-learn 0.5.3 / numpy 2.3.5 / pandas 2.3.3 against
+umap-learn 0.5.12 / numpy 2.4.6 / pandas 3.0.5:
+
+| Comparison | Calls changed |
+|---|---|
+| Same model, both environments (inference drift only) | 129 / 10,000 — 1.29% |
+| Each environment trains its own model (the upgrade path) | 122 / 10,000 — 1.22% |
+
+Model quality is unchanged: test balanced accuracy 0.9850 before, 0.9838 after.
+
+**Retraining does not avoid this.** 113 of the moved samples are the same in
+both comparisons, and the largest single shift — 33 samples from AFR to AAC —
+is the *identical 33 samples* either way. The drift is a systematic property of
+the newer library stack at population boundaries, not an artifact of a stale
+fit, so retraining under the new stack reproduces most of it.
+
+Where the calls move (retrain comparison, groups of 5+):
+
+```
+AFR -> AAC  33      MDE -> AFR  11      EUR -> AMR   7
+EUR -> AFR  17      AJ  -> EUR   9      AJ  -> MDE   6
+EUR -> MDE  13      CAS -> SAS   9
+```
+
+These are adjacent and admixed groups, which is where a slightly different
+embedding would be expected to tip samples across a boundary — but 1.2% is a
+real change to your results, not rounding.
+
+**Reproducing prior results.** Nothing already produced is altered by
+upgrading. A model trained by 2.0.2 or later ships a `requirements.txt` beside
+`pipeline.pkl` recording the exact environment it was fitted under; recreate it
+with `pip install -r <model_dir>/requirements.txt` to get the original calls
+back. For models predating that, `requirements-lock.txt` in the repo root
+pins a validated environment. Development installs stay unpinned so CI keeps
+catching upstream breakage early.
+
 ### GWAS p-values shift slightly
 
 PCA now prunes high-LD and MHC regions that 1.x left in, so association

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1093,6 +1093,63 @@ it was trained under, which is the prerequisite for changing that.
 
 ---
 
+### Round 16 (unpinning umap, and measuring what it costs)
+
+Resolves item 15. Round 15 gave a model the ability to say what it was trained
+under; this spends that, by removing the one pin the codebase had.
+
+**The pin was already failing at its own job.** `umap_learn==0.5.3` was there
+for reproducibility. But umap-learn below 0.5.5 runs `import pkg_resources` at
+import time, and setuptools deleted `pkg_resources` in 82.0.0 — verified by
+inspecting the wheels (81.0.0 ships it, 82.0.0 does not). A fresh install that
+resolves a current setuptools cannot import umap at all, so `--ancestry` dies
+before touching any data. Plain QC is unaffected; umap is reached only through
+the ancestry path.
+
+CI never caught it, and would not have: the runner image ships a setuptools old
+enough to satisfy `setuptools>=65.6.3`, so pip never upgrades it and never sees
+the break. The canary was caged by the very floor that looked like it was
+protecting us.
+
+**What replaced it.** `umap_learn>=0.5.5` (the floor is the fix, not a
+preference), the vestigial `setuptools` runtime dependency dropped — nothing in
+`genotools` imports it, confirmed by running the suite with the module blocked —
+and a validated `requirements-lock.txt` for runs that must reproduce. setup.py
+stays floating so CI resumes being the canary. A saved model additionally
+writes its own `requirements.txt`, pinning `setuptools<82` when the recorded
+umap predates 0.5.5, or the file would faithfully recreate an environment that
+cannot import umap.
+
+**What it costs, measured rather than assumed.**
+`tests/scripts/compare_umap_versions.py` runs one cohort through two
+environments differing only in installed libraries, in two modes: `reuse-model`
+(inference drift alone) and `retrain` (the real upgrade path). On the 10k GP2
+subset, 1.29% and 1.22% of calls move respectively; test balanced accuracy is
+0.9850 vs 0.9838.
+
+**The hypothesis going in was wrong and the data says so.** The expectation was
+that retraining would largely absorb the drift, since model and libraries would
+then agree. It does not: 113 of the moved samples are common to both modes, and
+the largest single shift — 33 samples AFR→AAC — is the *identical 33 samples*
+either way. The drift is a systematic property of the newer stack at population
+boundaries, not a stale-fit artifact. Recorded here because the wrong version of
+this story ("retrain and it goes away") is an easy thing to repeat.
+
+Ratified as a documented breaking change rather than blocked: staying pinned is
+not an option when the pin prevents installation. See `MIGRATION_2.0.md`.
+
+**Two harness bugs, both found by running it.** The driver aborted on a
+non-zero pipeline exit — but GenoTools exits 1 when any step failed, and a step
+failing is itself something the environments can differ on. On AMR_split the
+candidate put 2 samples in EUR, one survived callrate, and KING refused the
+one-sample group; the driver died on exactly the difference it existed to
+measure. The report now decides: absent is fatal, present-but-non-zero is a
+note. Separately, `--full-output` was passed unconditionally, hoarding ~10 GB
+of intermediates per run and filling a 197 GB filesystem; it is now passed only
+when the genotype comparison actually needs it.
+
+---
+
 ## Remaining work (tracked, not yet done)
 
 Priority order for making the refactor mergeable to `main`:
@@ -1169,11 +1226,11 @@ Priority order for making the refactor mergeable to `main`:
     single-file format carries it too, not just `metadata.json`), and
     `AncestryModel.load` warns on drift, naming each package. Warn, never
     block — see round 15 for why. Unblocks item 15.
-15. **Unpin `umap_learn==0.5.3`** — it works under pandas 3 today, but needs
-    `pkg_resources` (which setuptools is removing) and its numba floor caps
-    numpy. UMAP output feeds the classifier, so this can shift ancestry labels:
-    do it after item 14, retrain, re-run the `ancestry` parity scenario, and
-    document the retrain requirement in `MIGRATION_2.0.md`.
+15. ✅ **Unpin `umap_learn==0.5.3`** — RESOLVED in **round 16**. Found to be
+    more urgent than recorded: setuptools had already *removed* `pkg_resources`
+    (in 82.0.0), so the pin blocked installation rather than merely threatening
+    to. Measured cost: ~1.2% of ancestry calls move, and retraining does not
+    avoid it. Documented as a breaking change. See round 16 above.
 16. **Dev/CI dependency drift** — deps float, so CI resolves newest and is the
     de-facto canary (it caught round 9's break). The gap was reproduction, now
     documented in `TESTING.md` §2. Open question: keep floating and keep the

--- a/genotools/ancestry/model.py
+++ b/genotools/ancestry/model.py
@@ -74,13 +74,19 @@ from genotools.ancestry.results import (
 from genotools.core.exceptions import AncestryError
 from genotools.core.genotypes import GenotypeData
 from genotools.core.logging import get_logger
-from genotools.core.provenance import package_versions, version_drift
+from genotools.core.provenance import (
+    package_versions,
+    requirements_lines,
+    version_drift,
+)
 
 
 logger = get_logger(__name__)
 
 
-def _warn_on_version_drift(model: "AncestryModel") -> None:
+def _warn_on_version_drift(
+    model: "AncestryModel", path: Optional[Path] = None
+) -> None:
     """Say so when a model was fitted under different libraries than are loaded.
 
     This is the whole point of recording versions. A model fitted under
@@ -108,11 +114,17 @@ def _warn_on_version_drift(model: "AncestryModel") -> None:
         return
 
     changes = "; ".join(f"{name} {was} -> {now}" for name, was, now in drift)
+    how = "Reinstall the recorded versions, or retrain, to reproduce them."
+    if path is not None and (Path(path) / "requirements.txt").exists():
+        how = (
+            f"To reproduce the original calls: "
+            f"pip install -r {Path(path) / 'requirements.txt'} -- or retrain."
+        )
     logger.warning(
         f"Model version drift: {changes}. This model was fitted under the "
         f"recorded versions, and the embedding can differ under different "
         f"ones, so ancestry calls may not match what this model was validated "
-        f"on. Reinstall the recorded versions, or retrain, to reproduce them."
+        f"on. {how}"
     )
 
 
@@ -609,6 +621,8 @@ class AncestryModel:
         - ``common_snps.txt``: Plain text rsIDs, one per line.
         - ``metadata.json``: Config, best_params, training_metrics, and the
           library versions the fit ran under.
+        - ``requirements.txt``: those same versions as pip requirements, so the
+          fitting environment can be recreated rather than merely identified.
 
         Args:
             path: Output directory path.
@@ -636,6 +650,18 @@ class AncestryModel:
             with open(snps_path, "w") as f:
                 for snp in self.common_snps:
                     f.write(f"{snp}\n")
+
+        # The environment this fit needs, as something pip can consume.
+        # Knowing a model drifted is only half of it; this is the other half.
+        if self.versions is not None:
+            reqs_path = path / "requirements.txt"
+            with open(reqs_path, "w") as f:
+                f.write(
+                    "# Environment this ancestry model was fitted under.\n"
+                    "# Recreate it with: pip install -r requirements.txt\n"
+                )
+                for line in requirements_lines(self.versions):
+                    f.write(f"{line}\n")
 
         # Human-readable metadata
         metadata = self._build_metadata()
@@ -733,7 +759,7 @@ class AncestryModel:
                 f"{type(model)}.{hint}"
             )
 
-        _warn_on_version_drift(model)
+        _warn_on_version_drift(model, path)
 
         logger.info(f"Model loaded from: {path}")
         return model

--- a/genotools/core/provenance.py
+++ b/genotools/core/provenance.py
@@ -52,6 +52,7 @@ __all__ = [
     "ToolInfo",
     "describe_tool",
     "package_versions",
+    "requirements_lines",
     "tool_lines",
     "version_drift",
 ]
@@ -138,6 +139,69 @@ def version_drift(
         for name, was in recorded.items()
         if name in current and current[name] != was
     ]
+
+
+def requirements_lines(recorded: Dict[str, str]) -> List[str]:
+    """Render recorded versions as installable ``pip`` requirement specifiers.
+
+    Detecting drift is not the same as being able to undo it. A warning that
+    says "you are on umap-learn 0.5.12, this model was fitted on 0.5.3" leaves
+    the reader to reconstruct an environment by hand; this turns the same
+    record into something they can feed to ``pip install -r``.
+
+    ``python`` is emitted as a comment rather than a requirement — pip cannot
+    install an interpreter, and silently dropping it would hide a version
+    difference that does affect unpickling.
+
+    Args:
+        recorded: A model's ``versions`` mapping.
+
+    Returns:
+        Lines suitable for a requirements file, interpreter first as a comment.
+        Packages recorded as :data:`NOT_INSTALLED` are emitted as comments too,
+        since "absent" is not a version pip can resolve.
+    """
+    lines: List[str] = []
+    if "python" in recorded:
+        lines.append(f"# python {recorded['python']}")
+    for name, version in recorded.items():
+        if name == "python":
+            continue
+        if version == NOT_INSTALLED:
+            lines.append(f"# {name} was not installed when this model was fitted")
+            continue
+        lines.append(f"{name}=={version}")
+
+    # umap-learn below 0.5.5 does `import pkg_resources` at import time, and
+    # setuptools deleted pkg_resources in 82.0.0. Reinstalling the recorded
+    # umap into a current environment therefore produces a model that cannot
+    # be imported at all -- a reproducibility file that does not reproduce.
+    # Pin the one thing that makes the old pin work again.
+    if _older_than(recorded.get("umap-learn"), (0, 5, 5)):
+        lines.append("setuptools<82  # umap-learn<0.5.5 needs pkg_resources")
+    return lines
+
+
+def _older_than(version: Optional[str], floor: Tuple[int, ...]) -> bool:
+    """Whether ``version`` parses to something below ``floor``.
+
+    Deliberately forgiving: an unparseable or absent version is not treated as
+    old, because guessing wrong here would add a bogus pin to a requirements
+    file rather than merely omit a helpful one.
+    """
+    if not version or version == NOT_INSTALLED:
+        return False
+    parts: List[int] = []
+    for chunk in version.split(".")[: len(floor)]:
+        digits = ""
+        for char in chunk:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            return False
+        parts.append(int(digits))
+    return tuple(parts) < floor
 
 
 # ---------------------------------------------------------------------------

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,99 @@
+# Reproducible environment for GenoTools ancestry work.
+#
+# Generated with: .venv-next/bin/pip freeze
+# Validated on 2026-09-01: tests/unit 682 passed, tests/regression 77 passed.
+#
+# Development installs stay unpinned (setup.py) so CI keeps acting as the
+# canary for upstream breakage. Use this file when a run has to be
+# reproducible: pip install -r requirements-lock.txt
+#
+# A *trained model* additionally ships its own requirements.txt recording the
+# environment that produced that specific fit; prefer it when reproducing
+# results from a particular model.
+#
+altair==6.2.2
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+biopython==1.88
+blinker==1.9.0
+certifi==2026.7.22
+charset-normalizer==3.5.1
+click==8.5.0
+cloudpickle==3.1.2
+colour==0.1.5
+comm==0.2.3
+contourpy==1.3.3
+cycler==0.12.1
+dash==4.4.1
+dash_bio==1.0.2
+Flask==3.1.3
+fonttools==4.64.0
+formulaic==1.2.2
+GEOparse==2.0.4
+h11==0.16.0
+httptools==0.8.0
+idna==3.19
+importlib_metadata==9.0.1
+iniconfig==2.3.0
+interface_meta==2.0.1
+itsdangerous==2.2.0
+janus==2.0.0
+Jinja2==3.1.6
+joblib==1.6.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+kiwisolver==1.5.1
+llvmlite==0.49.0
+MarkupSafe==3.0.3
+matplotlib==3.11.1
+narwhals==2.25.0
+nest-asyncio==1.6.0
+numba==0.67.0
+numpy==2.4.6
+nvidia-nccl-cu12==2.31.2
+packaging==26.3
+pandas==3.0.5
+ParmEd==4.3.1
+patsy==1.0.3
+periodictable==2.1.0
+pillow==12.3.0
+plotly==7.0.0
+pluggy==1.6.0
+protobuf==7.36.1
+psutil==7.2.2
+pyarrow==25.0.1
+pydantic==2.13.5
+pydantic_core==2.46.5
+pydeck==0.9.3
+Pygments==2.21.0
+pynndescent==0.6.0
+pyparsing==3.3.2
+pytest==9.1.1
+python-dateutil==2.9.0.post0
+python-multipart==0.0.32
+referencing==0.37.0
+requests==2.34.2
+retrying==1.4.2
+rpds-py==2026.6.3
+scikit-learn==1.9.0
+scipy==1.17.1
+seaborn==0.13.2
+six==1.17.0
+starlette==1.6.0
+statsmodels==0.15.0
+streamlit==1.63.0
+threadpoolctl==3.6.0
+toml==0.10.2
+tqdm==4.70.0
+typing-inspection==0.4.4
+typing_extensions==4.16.0
+umap-learn==0.5.12
+urllib3==2.7.0
+uvicorn==0.52.4
+watchdog==6.0.0
+websockets==16.1.1
+Werkzeug==3.1.8
+wrapt==2.4.0
+xgboost==3.2.0
+zipp==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,16 @@ setup(
         'scikit_learn>=1.3.0',
         'scipy>=1.9.3',
         'seaborn>=0.12.1',
-        'setuptools>=65.6.3',
         'statsmodels>=0.13.5',
         'streamlit>=1.15.2',
-        'umap_learn==0.5.3',
+        # 0.5.5 is the floor, not a preference: 0.5.4 and earlier do
+        # `import pkg_resources` at import time, and setuptools deleted
+        # pkg_resources in 82.0.0 -- so older umap cannot be imported at all in
+        # a current environment. Floating from there rather than pinned: an
+        # exact pin never covered numpy/scipy/sklearn/xgboost, which move the
+        # embedding just as much, and a trained model now records the versions
+        # it was fitted under (see requirements-lock.txt and MIGRATION_2.0.md).
+        'umap_learn>=0.5.5',
         'xgboost>=1.7.6'
     ],
     # container/ is a Docker build context kept as a historical reference, not

--- a/tests/scripts/compare_umap_versions.py
+++ b/tests/scripts/compare_umap_versions.py
@@ -133,8 +133,25 @@ def run_pipeline(
     # cwd=REPO_ROOT so both environments import the same working tree: the
     # libraries are the variable, the GenoTools source is not.
     result = subprocess.run(command, cwd=REPO_ROOT)
+
+    # A non-zero exit is not a reason to abandon the comparison. GenoTools
+    # exits 1 when any step failed, and a step failing is itself something the
+    # two environments can legitimately differ on: on AMR_split the candidate
+    # put 2 samples in EUR, one survived callrate, and KING then refused a
+    # one-sample group. Aborting there would have thrown away the very
+    # difference the run exists to measure. The report is what matters, so
+    # that is what decides.
+    if not report.exists():
+        raise SystemExit(
+            f"pipeline under {python} produced no report at {report} "
+            f"(exit {result.returncode}) - nothing to compare"
+        )
     if result.returncode != 0:
-        raise SystemExit(f"pipeline failed under {python} (exit {result.returncode})")
+        print(
+            f"  [note]  exit {result.returncode} under {python}: at least one "
+            f"step failed. The report exists, so the comparison continues - "
+            f"check the pass_fail section for what differed."
+        )
 
 
 def main() -> int:

--- a/tests/scripts/compare_umap_versions.py
+++ b/tests/scripts/compare_umap_versions.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Quantify what unpinning ``umap_learn`` does to ancestry calls.
+
+``umap_learn==0.5.3`` was pinned for reproducibility, and unpinning it changes
+the embedding that feeds the classifier — so it can move ancestry labels. This
+runs the same cohort through two Python environments that differ only in their
+installed libraries (the GenoTools source is identical, since both install it
+editable from this working tree) and reports how many calls moved.
+
+Two questions, which are not the same question
+----------------------------------------------
+``--mode retrain`` (default)
+    Each environment trains its own model from the reference panel, then
+    predicts. This is the real upgrade path: what a user gets after upgrading
+    and retraining. It is the number that decides whether to unpin.
+
+``--mode reuse-model``
+    Both environments load the *same* pre-trained model and only predict (the
+    reference panel is still required — prediction re-derives the reference PCA
+    from it — but the classifier is not refitted). This
+    isolates inference drift from training drift, and quantifies the silent
+    failure that model version-recording now warns about: an old model run
+    under a new umap. Much faster, since nothing is trained.
+
+Running both tells you whether a difference came from the fit or the transform.
+
+Usage
+-----
+    python tests/scripts/compare_umap_versions.py \\
+        --baseline-python .venv/bin/python \\
+        --candidate-python .venv-next/bin/python \\
+        --geno ~/parity_data/GP2_r12_subset10k \\
+        --ref-panel ~/.genotools/ref/ref_panel/ref_panel_gp2_prune_rm_underperform_pos_update \\
+        --ref-labels ~/.genotools/ref/ref_panel/ref_panel_ancestry_updated.txt \\
+        --work /tmp/umap-compare
+
+A full ``--ancestry --all-sample`` run on the 10k subset takes roughly 25
+minutes per environment, so ``--mode retrain`` is an hour-plus job. Completed
+runs are reused on re-invocation unless ``--force`` is passed, so an
+interrupted comparison can be resumed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPARATOR = REPO_ROOT / "tests" / "scripts" / "compare_ancestry_run.py"
+
+def environment_versions(python: Path) -> Dict[str, str]:
+    """Return the library versions installed for one interpreter."""
+    code = (
+        "import json, platform\n"
+        "import importlib.metadata as md\n"
+        "out = {}\n"
+        "for p in ['umap-learn','scikit-learn','xgboost','numpy','pandas','scipy','numba']:\n"
+        "    try: out[p] = md.version(p)\n"
+        "    except Exception: out[p] = 'absent'\n"
+        "out['python'] = platform.python_version()\n"
+        "print(json.dumps(out))\n"
+    )
+    result = subprocess.run(
+        [str(python), "-c", code], capture_output=True, text=True, check=True
+    )
+    return json.loads(result.stdout)
+
+
+def describe_difference(base: Dict[str, str], cand: Dict[str, str]) -> List[str]:
+    """Render the environment delta, so attribution is not guesswork."""
+    return [
+        f"  {name:15s} {base[name]:>12s}  ->  {cand[name]}"
+        for name in base
+        if base.get(name) != cand.get(name)
+    ]
+
+
+def run_pipeline(
+    python: Path,
+    out_prefix: Path,
+    geno: Path,
+    ref_panel: Optional[Path],
+    ref_labels: Optional[Path],
+    model: Optional[Path],
+    force: bool,
+) -> None:
+    """Run one ancestry pipeline, reusing a completed run unless forced.
+
+    Reuse is keyed on the JSON report, which the runner writes last — a partial
+    run leaves no report and is redone rather than silently compared.
+    """
+    report = out_prefix.with_suffix(".json")
+    if report.exists() and not force:
+        print(f"  [reuse] {report} already exists")
+        return
+
+    out_prefix.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        str(python), "-m", "genotools",
+        "--pfile", str(geno),
+        "--out", str(out_prefix),
+        "--ancestry",
+        "--all-sample",
+        "--full-output",
+    ]
+    # --ref-panel/--ref-labels are required even with --model: inference
+    # re-derives the reference PCA from the panel (round 12). --model is
+    # additive, not an alternative.
+    command += ["--ref-panel", str(ref_panel), "--ref-labels", str(ref_labels)]
+    if model is not None:
+        command += ["--model", str(model)]
+
+    print(f"  [run]   {' '.join(command)}")
+    # cwd=REPO_ROOT so both environments import the same working tree: the
+    # libraries are the variable, the GenoTools source is not.
+    result = subprocess.run(command, cwd=REPO_ROOT)
+    if result.returncode != 0:
+        raise SystemExit(f"pipeline failed under {python} (exit {result.returncode})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--baseline-python", required=True, type=Path,
+                        help="Interpreter with the pinned umap (e.g. .venv/bin/python)")
+    parser.add_argument("--candidate-python", required=True, type=Path,
+                        help="Interpreter with the new umap (e.g. .venv-next/bin/python)")
+    parser.add_argument("--geno", required=True, type=Path, help="Cohort pfile prefix")
+    parser.add_argument("--ref-panel", required=True, type=Path,
+                        help="Reference panel bfile prefix (needed in both modes)")
+    parser.add_argument("--ref-labels", required=True, type=Path,
+                        help="Reference panel labels TSV (needed in both modes)")
+    parser.add_argument("--model", type=Path, default=None,
+                        help="Pre-trained model, required by --mode reuse-model")
+    parser.add_argument("--work", required=True, type=Path,
+                        help="Directory for both runs' outputs")
+    parser.add_argument("--mode", choices=("retrain", "reuse-model"), default="retrain")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-run even where a completed run exists")
+    parser.add_argument("--skip-genotypes", action="store_true",
+                        help="Passed through to the comparator (much faster)")
+    args = parser.parse_args()
+
+    # Both modes need the panel: prediction re-derives the reference PCA from
+    # it even when the classifier itself is loaded from --model.
+    if not (args.ref_panel and args.ref_labels):
+        parser.error("--ref-panel and --ref-labels are required in both modes")
+    if args.mode == "reuse-model" and not args.model:
+        parser.error("--mode reuse-model needs --model")
+
+    base_versions = environment_versions(args.baseline_python)
+    cand_versions = environment_versions(args.candidate_python)
+
+    print("=" * 72)
+    print(f"umap comparison — mode: {args.mode}")
+    print("=" * 72)
+    delta = describe_difference(base_versions, cand_versions)
+    if delta:
+        print("Environment differences (baseline -> candidate):")
+        print("\n".join(delta))
+    else:
+        print("WARNING: the two environments are identical; this compares nothing.")
+    print()
+
+    baseline_out = args.work / "baseline" / "out"
+    candidate_out = args.work / "candidate" / "out"
+
+    model = args.model if args.mode == "reuse-model" else None
+    print("Baseline run:")
+    run_pipeline(args.baseline_python, baseline_out, args.geno,
+                 args.ref_panel, args.ref_labels, model, args.force)
+    print("Candidate run:")
+    run_pipeline(args.candidate_python, candidate_out, args.geno,
+                 args.ref_panel, args.ref_labels, model, args.force)
+
+    # Reuse the existing report comparator rather than reimplementing it: both
+    # runs emit the same JSON schema, so "old vs new CLI" and "old vs new umap"
+    # are the same comparison.
+    command = [
+        sys.executable, str(COMPARATOR),
+        "--old", str(baseline_out),
+        "--new", str(candidate_out),
+    ]
+    if args.skip_genotypes:
+        command.append("--skip-genotypes")
+    print("\n" + "=" * 72)
+    print("Comparing reports")
+    print("=" * 72)
+    comparison = subprocess.run(command, cwd=REPO_ROOT)
+
+    versions_path = args.work / "environments.json"
+    versions_path.parent.mkdir(parents=True, exist_ok=True)
+    versions_path.write_text(
+        json.dumps({"baseline": base_versions, "candidate": cand_versions}, indent=2)
+    )
+    print(f"\nEnvironments recorded in {versions_path}")
+
+    # A non-zero comparator exit means the calls moved. For this script that is
+    # a finding to read, not a failure to fix, so it is reported rather than
+    # propagated as a crash.
+    if comparison.returncode != 0:
+        print(
+            "\nThe two environments do NOT agree. That is the number this "
+            "script exists to produce - read the per-check detail above and "
+            "record it in MIGRATION_2.0.md."
+        )
+    return comparison.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/compare_umap_versions.py
+++ b/tests/scripts/compare_umap_versions.py
@@ -102,6 +102,7 @@ def run_pipeline(
     ref_labels: Optional[Path],
     model: Optional[Path],
     force: bool,
+    keep_intermediates: bool,
 ) -> None:
     """Run one ancestry pipeline, reusing a completed run unless forced.
 
@@ -120,8 +121,13 @@ def run_pipeline(
         "--out", str(out_prefix),
         "--ancestry",
         "--all-sample",
-        "--full-output",
     ]
+    # --full-output keeps every intermediate pfile, which for this cohort is
+    # ~10 GB per run and filled the disk on the first attempt. Only the
+    # genotype comparison needs them, so it is the genotype comparison that
+    # asks for them.
+    if keep_intermediates:
+        command.append("--full-output")
     # --ref-panel/--ref-labels are required even with --model: inference
     # re-derives the reference PCA from the panel (round 12). --model is
     # additive, not an alternative.
@@ -203,12 +209,13 @@ def main() -> int:
     candidate_out = args.work / "candidate" / "out"
 
     model = args.model if args.mode == "reuse-model" else None
+    keep = not args.skip_genotypes
     print("Baseline run:")
     run_pipeline(args.baseline_python, baseline_out, args.geno,
-                 args.ref_panel, args.ref_labels, model, args.force)
+                 args.ref_panel, args.ref_labels, model, args.force, keep)
     print("Candidate run:")
     run_pipeline(args.candidate_python, candidate_out, args.geno,
-                 args.ref_panel, args.ref_labels, model, args.force)
+                 args.ref_panel, args.ref_labels, model, args.force, keep)
 
     # Reuse the existing report comparator rather than reimplementing it: both
     # runs emit the same JSON schema, so "old vs new CLI" and "old vs new umap"

--- a/tests/unit/test_ancestry/test_model_loading.py
+++ b/tests/unit/test_ancestry/test_model_loading.py
@@ -183,6 +183,51 @@ def test_saved_metadata_carries_the_versions(tmp_path: Path) -> None:
     assert metadata["versions"] == {"umap-learn": "0.5.3"}
 
 
+def test_save_writes_an_installable_requirements_file(tmp_path: Path) -> None:
+    """Knowing a model drifted is only half of it. The point of this file is
+    that reproducing the original calls is one command, not a reconstruction
+    job."""
+    model = AncestryModel()
+    model.versions = {"umap-learn": "0.5.3", "numpy": "1.23.5", "python": "3.11.2"}
+    model._is_fitted = True
+
+    out = model.save(tmp_path / "saved")
+    reqs = (out / "requirements.txt").read_text()
+
+    assert "umap-learn==0.5.3" in reqs
+    assert "numpy==1.23.5" in reqs
+    assert "pip install -r" in reqs, "say how to use the file, in the file"
+    # umap<0.5.5 cannot import without pkg_resources, so the file has to pin
+    # setuptools too or it recreates an environment that does not work.
+    assert "setuptools<82" in reqs
+
+
+def test_a_version_less_model_writes_no_requirements(tmp_path: Path) -> None:
+    """An empty or invented requirements file would be worse than none."""
+    model = AncestryModel()
+    model._is_fitted = True
+
+    out = model.save(tmp_path / "saved")
+    assert not (out / "requirements.txt").exists()
+
+
+def test_drift_warning_points_at_the_requirements_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The warning is where someone finds out; it should carry the fix."""
+    model = AncestryModel()
+    model.versions = {"numpy": "0.0.1-ancient"}
+    model._is_fitted = True
+    out = model.save(tmp_path / "saved")
+
+    with caplog.at_level("WARNING", logger="genotools"):
+        AncestryModel.load(out)
+
+    message = _warnings(caplog)
+    assert "pip install -r" in message
+    assert str(out / "requirements.txt") in message
+
+
 def test_fit_is_what_records_the_versions() -> None:
     """Captured at fit, not at save: these are the versions that produced
     *this* fit, and they must travel with the pickle for the single-file

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -33,6 +33,7 @@ from genotools.core.provenance import (
     describe_tool,
     executable_folder,
     package_versions,
+    requirements_lines,
     tool_lines,
     tool_version,
     version_drift,
@@ -97,6 +98,61 @@ class TestVersionDrift:
         assert [name for name, _, _ in version_drift(recorded, current)] == [
             "a", "b", "c"
         ]
+
+
+class TestRequirementsLines:
+    """Detecting drift is half of it; being able to undo it is the other half."""
+
+    def test_versions_become_installable_pins(self) -> None:
+        lines = requirements_lines({"umap-learn": "0.5.12", "numpy": "2.3.5"})
+        assert "umap-learn==0.5.12" in lines
+        assert "numpy==2.3.5" in lines
+
+    def test_python_is_a_comment_not_a_requirement(self) -> None:
+        """pip cannot install an interpreter, but dropping it silently would
+        hide a difference that does affect unpickling."""
+        lines = requirements_lines({"python": "3.11.2", "numpy": "2.3.5"})
+        assert lines[0] == "# python 3.11.2"
+        assert not any(line.startswith("python==") for line in lines)
+
+    def test_an_absent_package_is_a_comment(self) -> None:
+        """"not installed" is not a version pip can resolve."""
+        lines = requirements_lines({"scipy": NOT_INSTALLED})
+        assert not any(line.startswith("scipy==") for line in lines)
+        assert any("scipy" in line and line.startswith("#") for line in lines)
+
+    def test_old_umap_drags_in_the_setuptools_pin(self) -> None:
+        """Otherwise the file recreates an environment that cannot import umap
+        at all: umap<0.5.5 needs pkg_resources, which setuptools 82 deleted.
+        A reproducibility file that does not reproduce is worse than none."""
+        lines = requirements_lines({"umap-learn": "0.5.3"})
+        assert any(line.startswith("setuptools<82") for line in lines)
+
+    def test_new_umap_does_not(self) -> None:
+        assert not any(
+            line.startswith("setuptools")
+            for line in requirements_lines({"umap-learn": "0.5.5"})
+        )
+
+    def test_version_compare_is_numeric_not_lexicographic(self) -> None:
+        """"0.5.12" < "0.5.5" as strings. Getting this wrong would pin
+        setuptools for every modern umap."""
+        assert not any(
+            line.startswith("setuptools")
+            for line in requirements_lines({"umap-learn": "0.5.12"})
+        )
+
+    def test_an_unparseable_version_adds_no_bogus_pin(self) -> None:
+        """Guessing wrong here corrupts a requirements file; omitting a helpful
+        pin merely leaves it as it was."""
+        for odd in ("weird-build", "", NOT_INSTALLED):
+            assert not any(
+                line.startswith("setuptools")
+                for line in requirements_lines({"umap-learn": odd})
+            )
+
+    def test_a_model_with_no_umap_recorded_is_left_alone(self) -> None:
+        assert requirements_lines({"numpy": "2.3.5"}) == ["numpy==2.3.5"]
 
 
 class TestExecutableFolder:


### PR DESCRIPTION
## Summary

Removes the `umap_learn==0.5.3` pin, and measures what that costs rather than
assuming it.

**The pin was already failing at its own job.** umap-learn below 0.5.5 runs
`import pkg_resources` at import time, and setuptools **deleted**
`pkg_resources` in 82.0.0 — verified by inspecting the wheels (81.0.0 ships it,
82.0.0 does not). A fresh install resolving a current setuptools therefore
cannot import umap at all, so `--ancestry` dies before touching any data. Plain
QC is unaffected; umap is reached only through the ancestry path.

CI never caught this and would not have: the runner image ships a setuptools old
enough to satisfy `setuptools>=65.6.3`, so pip never upgrades it and never sees
the break. The canary was caged by the floor that looked like it was protecting
us.

### What changes

- `umap_learn>=0.5.5` — the floor is the `pkg_resources` fix, not a preference.
- The `setuptools>=65.6.3` runtime dependency is dropped. Nothing in `genotools`
  imports it; it was only propping up umap's `pkg_resources` call. Confirmed by
  running the suite with the module blocked — only umap's importers failed.
- `requirements-lock.txt`, frozen from an environment validated against both
  suites. setup.py stays floating so CI resumes being the canary; the lock is
  what a run uses when it has to reproduce.
- A saved model now writes its own `requirements.txt` beside `pipeline.pkl`, and
  the drift warning added in #257 points at it. Detecting drift was only half
  the job — a warning naming a version the reader must then reconstruct by hand
  is not reproducibility.
- That file pins `setuptools<82` when the recorded umap predates 0.5.5, or it
  would faithfully recreate an environment that cannot import umap.

### What it costs — measured

`tests/scripts/compare_umap_versions.py` (new) runs one cohort through two
environments differing only in installed libraries. On the 10k GP2 subset
(9,759 samples, 11 ancestry groups), umap 0.5.3 / numpy 2.3.5 / pandas 2.3.3
versus umap 0.5.12 / numpy 2.4.6 / pandas 3.0.5:

| Comparison | Calls changed |
|---|---|
| Same model, both environments (inference drift only) | 129 / 10,000 — **1.29%** |
| Each environment trains its own model (the upgrade path) | 122 / 10,000 — **1.22%** |

Test balanced accuracy: 0.9850 → 0.9838. Neither model is better.

```
AFR -> AAC  33      MDE -> AFR  11      EUR -> AMR   7
EUR -> AFR  17      AJ  -> EUR   9      AJ  -> MDE   6
EUR -> MDE  13      CAS -> SAS   9
```

**Retraining does not avoid the drift, and the going-in assumption that it would
was wrong.** 113 of the moved samples are common to both comparisons, and the
largest single shift — 33 samples AFR→AAC — is the *identical 33 samples* either
way. This is a systematic property of the newer stack at population boundaries,
not a stale-fit artifact. Recorded as wrong in REFACTOR.md so the tidier version
of the story does not get repeated.

Ratified as a documented breaking change rather than blocked: staying pinned is
not an option when the pin prevents installation.

### Two harness bugs, both found by running it

- The driver aborted on a non-zero pipeline exit. GenoTools exits 1 when any
  step failed, and a step failing is itself something the environments can
  differ on: on AMR_split the candidate put 2 samples in EUR, one survived
  callrate, and KING refused the one-sample group — so the driver died on
  exactly the difference it existed to measure. The report now decides.
- `--full-output` was passed unconditionally, hoarding ~10 GB of intermediates
  per run and filling a 197 GB filesystem. Now passed only when the genotype
  comparison needs it.

## Test plan

- `tests/unit` → **693 passed** under *both* environments (umap 0.5.3 / numpy
  2.3.5, and umap 0.5.12 / numpy 2.4.6 / pandas 3.0.5).
- `tests/regression` → **77 passed** (~7min).
- Goldens regenerated: **no diff**.
- 11 new unit tests, all revert-checked: `requirements_lines` pins and comment
  forms, the `setuptools<82` rule and its version-comparison boundaries
  (`0.5.12` must not compare below `0.5.5` lexicographically), the model's
  `requirements.txt` round-trip, and the drift warning naming that file.
- End-to-end: the first model trained after this change wrote a correct
  `requirements.txt`, including the `setuptools<82` line, on the first try.
- The ancestry impact above is from real runs on a real cohort, not synthetic
  data; reports are preserved under `~/umap-upgrade-runs/`.
