### PR TITLE
Fix/palindromic snp matching

### DIFF
--- a/MIGRATION_2.0.md
+++ b/MIGRATION_2.0.md
@@ -332,6 +332,34 @@ back. For models predating that, `requirements-lock.txt` in the repo root
 pins a validated environment. Development installs stay unpinned so CI keeps
 catching upstream breakage early.
 
+### Ancestry SNP matching excludes palindromes and prefers better-called probes
+
+**This can change ancestry calls, by very little.** Measured at 1 call in
+10,000 on a 10,000-sample GP2 subset; model accuracy and every QC count were
+unchanged.
+
+Two corrections to how a cohort is matched against the reference panel:
+
+- **Palindromic (A/T, C/G) sites are excluded.** Their alleles survive strand
+  complement unchanged, so nothing downstream can tell which strand they came
+  from, and such a site was previously accepted at whatever orientation it
+  arrived in. If you build panels with the recipe in
+  `docs/prep_reference_panel.md` they were already excluded and nothing changes
+  for you — the GP2 panel has 0 of 209,517. If you use a panel that kept them,
+  this is a correctness fix and your calls may move more than the figure above.
+
+- **A position offering several probes now resolves to the best-called one.**
+  Cohorts routinely carry the same site under multiple probe IDs
+  (`rs301801`, `IlmnSeq_rs301801`, `seq_rs301801`). Previously whichever the
+  merge emitted first won, which was arbitrary and sensitive to the order of
+  variants in your input file; now the one with the lowest missingness wins.
+
+**Existing models are not invalidated.** Only the cohort side of the match
+changed; the reference-panel side is byte-identical, so a saved model's
+common-SNP list, its fitted classifier and its accuracy are all unaffected. You
+do not need to retrain, and predictions from an existing model shift only by
+the amount above.
+
 ### GWAS p-values shift slightly
 
 PCA now prunes high-LD and MHC regions that 1.x left in, so association

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1150,6 +1150,147 @@ when the genotype comparison actually needs it.
 
 ---
 
+### Round 17 (palindromic SNPs, and the tie-break hiding behind them)
+
+Resolves item 13. The headline defect turned out to be unreachable and the
+aside next to it turned out to be the live one, so the measurement is what
+decided which half mattered.
+
+**The palindrome bug is real and currently unreachable.** `get_common_snps`
+kept strand-ambiguous A/T and C/G sites. Complementing such a pair returns the
+same pair, so the four-route match (two allele orderings × unflipped/flipped
+reference) cannot tell which strand the site came from. Worse, the
+allele-switch test in `get_raw_files` — "differs from the reference allele
+*and* from its complement" — can never fire for a palindrome, because one of
+those two comparisons always matches. A palindromic site is therefore accepted
+at whatever orientation it arrived in, and its dosages are silently inverted
+wherever the strands disagree.
+
+It cannot bite on the panel in use. Reference panels built per
+`docs/prep_reference_panel.md` exclude palindromes when the panel is built, and
+the GP2 panel holds up: **0 palindromic variants of 209,517**. Since
+complementing a non-palindromic pair yields another non-palindromic pair
+(`A/G → T/C`), no reference variant can ever *present* as `{A,T}` or `{C,G}`,
+so the cohort's 219,056 palindromic variants (11.26% of it) have nothing to
+match against. Verified three ways rather than argued: zero palindromes among
+the saved parity model's 43,173 common SNPs; zero among the survivors of a real
+`get_common_snps` run on the real inputs; and the replicated intermediate frame
+reproduces that run's output in order, so the replication can be trusted.
+
+Fixed anyway, as a guard for a panel whose prep skipped the step. The exclusion
+is provably a no-op here, which is what makes it safe to land without
+revalidation.
+
+**The live half was the row-order tie-break.** Item 13 recorded
+`drop_duplicates(subset=["chr","pos"])` keeping the first row as a *related*
+concern. It is the one with consequences, for a reason the item did not record:
+`get_common_snps` is called **twice, with its arguments reversed**. The first
+call extracts from the reference panel and decides the model's common-SNP list;
+the second (`preprocessing.py:156`) extracts from the *cohort*, so the written
+ID is a cohort variant — and a cohort carries the same site under several probe
+IDs (`rs301801`, `IlmnSeq_rs301801`, `seq_rs301801`; 98,509 duplicate positions
+in the 10k subset).
+
+On that cohort, **1,078 of 43,173 common SNPs (2.50%)** had their probe decided
+by row order, and the candidates are not redundant copies:
+
+| | |
+|---|---|
+| Contested positions | 1,078 of 43,173 (2.50%) |
+| Whose candidates were bit-identical | **4** (0.4%) |
+| Showing genotype discordance | 1,015 |
+| Differing in missingness | 1,037 |
+| Worst discordance | **49.85%** (`4:115883489`, `exm2269825` vs `rs1430934`) |
+| Worst missingness gap | 6.88% |
+| Feature-matrix cells affected | 105,318 of 431,730,000 (0.0244%) |
+
+Deterministic for a given input file — pandas merge order is stable — so this
+was never run-to-run flakiness. It was *arbitrary*: nobody chose `rs301801`
+over `exm2269825`, row order did, and re-exporting the same cohort with its
+variants in a different order could change the answer.
+
+**Now the best-called probe wins**, with exact ties keeping the earlier row so
+behaviour is unchanged wherever missingness cannot separate the candidates. The
+missingness pass is skipped unless some position's candidates actually name
+different variants, which makes the reference-panel-side call a no-op: its
+output stays **byte-identical**, so a saved model's common-SNP list does not
+move and existing models are not invalidated.
+
+**What it costs, measured.** `tests/scripts/compare_snp_matching.py` is a
+sibling of round 16's comparator asking the same question of the other
+variable: that script holds the source constant and varies the libraries, this
+one holds the libraries constant and varies the source (via `cwd`, since
+`python -m genotools` imports the working directory first). `run_pipeline` grew
+a `cwd` parameter so the two share round 16's fix that decides on the report
+rather than the exit code, instead of duplicating it.
+
+It defaults to `--mode reuse-model`, which here is exact rather than merely
+cheaper: only the cohort-side call changes, so the fitted model and the
+reference PCA are identical in both arms and every moved call is attributable
+to the probe selection. `--mode retrain` would fold in UMAP's own fit
+stochasticity, which round 16 measured at 1.2% — larger than this signal, and
+therefore noise for this question.
+
+On the 10k GP2 subset, reusing the saved parity model, **1 of 10,000 calls
+moved (0.010%)** — one sample from `FIN` to `EUR`. Everything else is
+identical:
+
+```
+[FAIL] ancestry labels: 1/10,000 samples labeled differently
+       old FIN -> new EUR                            1
+[FAIL] ancestry counts: EUR 6927->6928, FIN 12->11
+[PASS] test accuracy: identical (0.985037)
+[PASS] confusion matrix: identical (10x10)
+[PASS] QC metrics: all 55 pruned_counts identical
+[PASS] pruned samples: identical IDs across 3 step(s), 412 total
+[PASS] related samples: identical 52 pairs
+[PASS] step pass/fail: identical across 11 ancestry group(s)
+```
+
+The identical test accuracy and confusion matrix are the useful part: they
+confirm by measurement what the byte-identical first call predicted, that the
+model itself is untouched and the whole effect is on prediction.
+
+So 456 probes changed (of the 1,078 contested positions, the rest already had
+the best-called probe first), 105,318 feature-matrix cells moved, and one call
+changed. The pipeline is far more robust to this than the raw cell count
+suggests — which is the argument for having measured it instead of either
+waving it through or blocking on it. For calibration, round 16's library
+upgrade moved 129 calls; this moves 1.
+
+Worth noting without over-reading: the single moved sample is
+`SYNAPS-KZ_000677`, from a Kazakhstan cohort, and it moved *off* `FIN`, a label
+no Kazakh sample should plausibly carry. That is one sample and there is no
+ground truth here, so it is not evidence the fix is correct — but it is not
+evidence against it either, and it is the direction one would hope for.
+
+**The test that was supposed to cover this asserted the wrong thing.**
+`test_get_common_snps_matches_legacy` compared the port byte-for-byte against
+the legacy function — but passed the same bfile as both inputs, so it never
+exercised ambiguous ordering at all, and it *pinned the bug*: any fix would
+fail it by construction. Replaced by three:
+
+- **legacy parity on unambiguous input** — keeps what the old test was really
+  worth, on a fixture with its palindromes removed, where both must agree
+- **palindrome exclusion** — asserts legacy *kept* them and that only
+  palindromic sites differ, so it cannot pass vacuously
+- **tie-breaking by call rate** — on a hand-built fixture whose 50%-missing
+  probe is deliberately ordered *ahead* of its 5%-missing one, so first-row-wins
+  would take the bad probe
+
+Both production changes were revert-checked (item 17's discipline): neutering
+`_drop_palindromic` fails the second, restoring the old `drop_duplicates` fails
+the third, and the reverted code demonstrably selects `probe_hi`.
+
+The `get_raw_files` goldens are untouched, and structurally so: both golden
+fixtures — the `ref21_22` panel and the `geno21_22` cohort — have zero
+palindromic sites and zero duplicate positions, so neither half of the fix can
+reach either side of the match. That is a property of the fixtures rather than
+luck, which is why this landed without a golden regeneration. It also means the
+goldens would not have caught the bug, and still would not.
+
+---
+
 ## Remaining work (tracked, not yet done)
 
 Priority order for making the refactor mergeable to `main`:
@@ -1214,13 +1355,17 @@ Priority order for making the refactor mergeable to `main`:
     each tool's resolved path and `--version`, and naming a different binary of
     the same name on `PATH`. Widened past plink2 to plink and KING, since all
     three resolve the same way. See round 15 above.
-13. **Palindromic SNPs not excluded in ancestry matching** — a faithful 1.x port
-    and a real issue, not a 2.0.0 blocker. Related:
-    `ancestry/preprocessing.py:53`'s `drop_duplicates(subset=["chr","pos"])`
-    keeps the first row, so row order decides at multi-allelic and palindromic
-    positions. `test_get_common_snps_matches_legacy` asserts byte-identical
-    output against the legacy function but passes the same bfile as both inputs,
-    so the ambiguous-ordering path is barely exercised.
+13. ✅ **Palindromic SNPs not excluded in ancestry matching** — RESOLVED in
+    **round 17**. The recorded headline was unreachable and the aside beside it
+    was the live defect. Reference panels built per the documented recipe are
+    already palindrome-free (0 of 209,517 in the GP2 panel), so no palindromic
+    site can survive the intersection; the palindrome exclusion is therefore a
+    provable no-op here and a guard for panels built differently. The
+    `drop_duplicates` row-order tie-break was the real one, on the *cohort*
+    side — the second `get_common_snps` call passes its arguments reversed — and
+    decided 1,078 of 43,173 common SNPs. Both fixed, and the test that claimed
+    to cover this was found to pin the bug. Measured cost: 1 call in 10,000.
+    See round 17 above.
 14. ✅ **No provenance on a trained model** — RESOLVED in **round 15**.
     `fit()` records a `versions` block onto the model itself (so the
     single-file format carries it too, not just `metadata.json`), and

--- a/docs/prep_reference_panel.md
+++ b/docs/prep_reference_panel.md
@@ -77,6 +77,12 @@ if __name__ == '__main__':
 2. Prune reference genotypes for ```--maf```, ```--geno```, ```--hwe```, and linkage disequilibrium, as well as removing the previously identified palindrome SNPs.
 3. Exclude high-LD regions from reference genotypes.
 
+Step 1 is still worth doing, but it is no longer the only thing standing
+between you and a strand-ambiguous site: `get_common_snps` also excludes
+palindromes when matching a cohort against the panel, so a panel that kept them
+no longer silently mis-orients them. Removing them here keeps the panel smaller
+and its SNP count honest.
+
 ---
 
 ### LD Exclusion Region File Format (hg38)

--- a/genotools/ancestry/preprocessing.py
+++ b/genotools/ancestry/preprocessing.py
@@ -37,12 +37,20 @@ def _drop_palindromic(bim: pd.DataFrame) -> pd.DataFrame:
 
 
 def _variant_missingness(geno_path: str) -> pd.Series:
-    """Per-variant missing-call rate for `geno_path`, keyed by variant ID."""
+    """Per-variant missing-call rate for `geno_path`, keyed by variant ID.
+
+    Reports to a `_missing` prefix rather than `geno_path` itself: plink2 writes
+    a `.log` beside whatever `--out` names, and `geno_path` already has one
+    belonging to the step that produced it (the variant prune, or the user's own
+    reference panel directory). Overwriting that would destroy the audit trail
+    for a different command.
+    """
+    out_prefix = f"{geno_path}_missing"
     run_command(
-        f"{get_plink2()} --bfile {geno_path} --missing variant-only --out {geno_path}",
+        f"{get_plink2()} --bfile {geno_path} --missing variant-only --out {out_prefix}",
         tool_name="plink2",
     )
-    vmiss = pd.read_csv(f"{geno_path}.vmiss", sep="\t", usecols=["ID", "F_MISS"])
+    vmiss = pd.read_csv(f"{out_prefix}.vmiss", sep="\t", usecols=["ID", "F_MISS"])
     return vmiss.set_index("ID")["F_MISS"]
 
 
@@ -277,7 +285,8 @@ def get_raw_files(
     raw_geno["label"] = "new"
 
     # remove intermediate files (concat_logs dropped: structured logging replaces raw .log aggregation)
-    files = [geno_prune_path, f"{geno_prune_path}_flip", f"{out_path}_common_snps_switch"]
+    files = [geno_prune_path, f"{geno_prune_path}_flip", f"{geno_prune_path}_missing",
+             f"{out_path}_common_snps_switch"]
     clean_up_files(files)
 
     return {

--- a/genotools/ancestry/preprocessing.py
+++ b/genotools/ancestry/preprocessing.py
@@ -1,8 +1,10 @@
 """Ancestry PLINK preprocessing (legacy-free port of the Ancestry helpers).
 
-Faithful reimplementations of legacy Ancestry.get_raw_files / clean_up and
-utils.get_common_snps, using core.executors. Genotype output is identical to
-the legacy versions (proven by differential tests).
+Ports of legacy Ancestry.get_raw_files / clean_up and utils.get_common_snps,
+using core.executors. `get_raw_files` output is identical to the legacy version
+(proven by differential tests). `get_common_snps` deliberately diverges: it
+excludes palindromic sites and breaks position ties by missingness, both of
+which the legacy version got wrong. See the helpers below.
 """
 
 import os
@@ -16,6 +18,76 @@ from genotools.core.logging import get_logger
 logger = get_logger(__name__)
 
 
+_PALINDROMIC = frozenset({"AT", "TA", "CG", "GC"})
+
+
+def _drop_palindromic(bim: pd.DataFrame) -> pd.DataFrame:
+    """Drop strand-ambiguous (palindromic) A/T and C/G sites.
+
+    Complementing such a pair returns the same pair, so the four-route match in
+    `get_common_snps` cannot tell which strand the site came from, and the
+    allele-switch test in `get_raw_files` ("differs from the reference allele
+    and from its complement") can never fire for one either. A palindromic site
+    is therefore accepted at whatever orientation it happened to arrive in,
+    which silently inverts its dosages when the strands disagree. Reference
+    panels built per `docs/prep_reference_panel.md` already exclude these, so
+    this is a guard for panels that did not.
+    """
+    return bim.loc[~(bim["a1"] + bim["a2"]).isin(_PALINDROMIC)]
+
+
+def _variant_missingness(geno_path: str) -> pd.Series:
+    """Per-variant missing-call rate for `geno_path`, keyed by variant ID."""
+    run_command(
+        f"{get_plink2()} --bfile {geno_path} --missing variant-only --out {geno_path}",
+        tool_name="plink2",
+    )
+    vmiss = pd.read_csv(f"{geno_path}.vmiss", sep="\t", usecols=["ID", "F_MISS"])
+    return vmiss.set_index("ID")["F_MISS"]
+
+
+def _select_one_per_position(common_snps: pd.DataFrame, geno_path1: str) -> pd.DataFrame:
+    """Keep one candidate row per chr:pos, preferring the lowest missingness.
+
+    A cohort routinely carries the same site under several probe IDs
+    (`rs301801`, `IlmnSeq_rs301801`, `seq_rs301801`), and each match route can
+    contribute its own row, so a position can arrive here several times. Those
+    candidates are *not* redundant copies: on a 10k GP2 cohort only 4 of 1,078
+    contested positions had identical calls, missingness differed by up to 6.9%
+    and genotypes by up to 49.9%. Keeping whichever row the merge emitted first
+    made that choice arbitrary and sensitive to input variant order, so pick the
+    best-called probe instead. Exact ties keep the earlier row, which preserves
+    the previous behaviour whenever missingness cannot separate the candidates.
+    """
+    common_snps = common_snps.reset_index(drop=True)
+    duplicated = common_snps.duplicated(subset=["chr", "pos"], keep=False)
+    # Only positions whose candidates name *different* variants can be decided
+    # by row order; where they all name the same one, the choice cannot matter
+    # and the missingness pass would be wasted work.
+    contested = (
+        common_snps.loc[duplicated].groupby(["chr", "pos"])["rsid_y"].nunique().gt(1)
+        if duplicated.any()
+        else pd.Series(dtype=bool)
+    )
+    if not contested.any():
+        return common_snps.drop_duplicates(subset=["chr", "pos"], ignore_index=True)
+
+    logger.info(
+        f"Resolving {int(contested.sum())} position(s) with competing variants by lowest missingness"
+    )
+    f_miss = _variant_missingness(geno_path1)
+    common_snps["_row"] = range(len(common_snps))
+    # Unscored variants sort last rather than winning by default.
+    common_snps["_f_miss"] = common_snps["rsid_y"].map(f_miss).fillna(1.0)
+    return (
+        common_snps.sort_values(["_f_miss", "_row"], kind="stable")
+        .drop_duplicates(subset=["chr", "pos"])
+        .sort_values("_row")
+        .drop(columns=["_row", "_f_miss"])
+        .reset_index(drop=True)
+    )
+
+
 def get_common_snps(geno_path1: str, geno_path2: str, out_name: str) -> dict:
     """Extract SNPs common to two bfiles from geno_path1. Returns output paths."""
     logger.info("Getting Common SNPs")
@@ -26,6 +98,13 @@ def get_common_snps(geno_path1: str, geno_path2: str, out_name: str) -> dict:
     bim1.columns = ["chr", "rsid", "kb", "pos", "a1", "a2"]
     bim2 = pd.read_csv(f"{geno_path2}.bim", sep="\t", header=None, dtype={0: str}, low_memory=False)
     bim2.columns = ["chr", "rsid", "kb", "pos", "a1", "a2"]
+
+    n_before = len(bim1) + len(bim2)
+    bim1 = _drop_palindromic(bim1)
+    bim2 = _drop_palindromic(bim2)
+    n_palindromic = n_before - len(bim1) - len(bim2)
+    if n_palindromic:
+        logger.info(f"Excluded {n_palindromic} palindromic (strand-ambiguous) variant(s)")
 
     bim1["rsid"].to_csv(f"{geno_path1}.snplist", sep="\t", header=None, index=None)
 
@@ -44,13 +123,14 @@ def get_common_snps(geno_path1: str, geno_path2: str, out_name: str) -> dict:
 
     bim1_flip = pd.read_csv(f"{geno_path1}_flip.bim", sep="\t", header=None)
     bim1_flip.columns = ["chr", "rsid", "kb", "pos", "a1", "a2"]
+    bim1_flip = _drop_palindromic(bim1_flip)
 
     bim1_flip["merge_id"] = bim1_flip["chr"].astype(str) + ":" + bim1_flip["pos"].astype(str) + ":" + bim1_flip["a2"] + ":" + bim1_flip["a1"]
     common_snps1 = bim2[["rsid", "merge_id1", "a1", "a2"]].merge(bim1_flip, how="inner", left_on=["merge_id1"], right_on=["merge_id"])
     common_snps2 = bim2[["rsid", "merge_id2", "a1", "a2"]].merge(bim1_flip, how="inner", left_on=["merge_id2"], right_on=["merge_id"])
 
     common_snps = pd.concat([common_snps, common_snps1, common_snps2], axis=0)
-    common_snps = common_snps.drop_duplicates(subset=["chr", "pos"], ignore_index=True)
+    common_snps = _select_one_per_position(common_snps, geno_path1)
 
     common_snps_file = f"{out_name}.common_snps"
     common_snps["rsid_y"].to_csv(f"{common_snps_file}", sep="\t", header=False, index=False)
@@ -65,7 +145,7 @@ def get_common_snps(geno_path1: str, geno_path2: str, out_name: str) -> dict:
 
 def clean_up_files(files: list) -> None:
     """Remove intermediate PLINK files by known extensions (port of Ancestry.clean_up)."""
-    extensions = ["bim", "bed", "fam", "hh", "snplist", "ref_allele", "alleles", "raw"]
+    extensions = ["bim", "bed", "fam", "hh", "snplist", "ref_allele", "alleles", "raw", "vmiss"]
     for file in files:
         for ext in extensions:
             file_ext = f"{file}.{ext}"

--- a/tests/scripts/compare_snp_matching.py
+++ b/tests/scripts/compare_snp_matching.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Quantify what fixing ``get_common_snps`` does to ancestry calls.
+
+Sibling of ``compare_umap_versions.py``, asking the same question of a
+different variable: that script holds the source constant and varies the
+installed libraries, this one holds the libraries constant and varies the
+source. Both delegate to ``compare_ancestry_run.py``, so the movement table
+means the same thing in both.
+
+The change under measurement (REFACTOR.md item 13) has two halves:
+
+palindromic sites are excluded
+    Unreachable on a reference panel built per ``docs/prep_reference_panel.md``,
+    which already drops them — the GP2 panel in use has 0 of 209,517, so no
+    palindromic site can survive the intersection and this half is expected to
+    move nothing. Run it against a panel that kept them and it will.
+
+position ties are broken by call rate
+    The live half. A cohort carries the same site under several probe IDs, and
+    the previous ``drop_duplicates`` kept whichever row the merge emitted
+    first, which is arbitrary and sensitive to input variant order.
+
+Why ``--mode reuse-model`` is the right measurement here
+-------------------------------------------------------
+``get_common_snps`` is called twice, with its arguments **reversed**. The first
+call extracts from the reference panel and decides the model's common-SNP list;
+the second extracts from the cohort and decides which probe represents each
+position in the feature matrix. Only the second call's output changes (the
+first is byte-identical, since its candidate rows all name the same reference
+variant), so the fitted model and the reference PCA are untouched and the whole
+effect lands on prediction.
+
+That makes ``--mode reuse-model`` exact rather than merely cheaper: both arms
+load the same model, so every moved call is attributable to the changed probe
+selection. ``--mode retrain`` would additionally fold in UMAP's own fit
+stochasticity, which is noise for this question — round 16 measured that noise
+separately and it is larger than the signal here.
+
+Usage
+-----
+    python tests/scripts/compare_snp_matching.py \\
+        --python .venv/bin/python \\
+        --baseline-repo /path/to/worktree/at/main \\
+        --geno ~/parity_data/GP2_r12_subset10k \\
+        --ref-panel ~/.genotools/ref/ref_panel/ref_panel_gp2_prune_rm_underperform_pos_update \\
+        --ref-labels ~/.genotools/ref/ref_panel/ref_panel_ancestry_updated.txt \\
+        --model ~/parity_data/models/new_ancestry_ancestry_model \\
+        --work /tmp/snp-matching-compare
+
+Create the baseline tree with ``git worktree add <dir> <commit>``; it must be a
+checkout of the code *before* the fix, and the candidate defaults to this
+working tree. Completed runs are reused unless ``--force`` is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from compare_umap_versions import COMPARATOR, REPO_ROOT, run_pipeline
+
+PALINDROMIC = {"AT", "TA", "CG", "GC"}
+
+
+def describe_panel(ref_panel: Path) -> dict:
+    """Report the panel's exposure to each half of the fix.
+
+    Printed up front because it decides what the run can possibly show: a
+    palindrome-free, position-unique panel cannot exercise either half on the
+    reference side, and reading a 0.00% movement without that context invites
+    the wrong conclusion ("the fix does nothing") instead of the right one
+    ("this panel was never exposed").
+    """
+    import pandas as pd
+
+    bim = pd.read_csv(
+        f"{ref_panel}.bim", sep="\t", header=None, dtype={0: str}, low_memory=False
+    )
+    bim.columns = ["chr", "rsid", "kb", "pos", "a1", "a2"]
+    return {
+        "variants": len(bim),
+        "palindromic": int((bim["a1"] + bim["a2"]).isin(PALINDROMIC).sum()),
+        "duplicate_positions": int(bim.duplicated(subset=["chr", "pos"]).sum()),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--python", required=True, type=Path,
+                        help="One interpreter, used for both arms")
+    parser.add_argument("--baseline-repo", required=True, type=Path,
+                        help="Source tree WITHOUT the fix (git worktree at the prior commit)")
+    parser.add_argument("--candidate-repo", type=Path, default=REPO_ROOT,
+                        help="Source tree WITH the fix (default: this working tree)")
+    parser.add_argument("--geno", required=True, type=Path, help="Cohort pfile prefix")
+    parser.add_argument("--ref-panel", required=True, type=Path)
+    parser.add_argument("--ref-labels", required=True, type=Path)
+    parser.add_argument("--model", type=Path, default=None,
+                        help="Pre-trained model, required by --mode reuse-model")
+    parser.add_argument("--work", required=True, type=Path,
+                        help="Directory for both runs' outputs")
+    parser.add_argument("--mode", choices=("reuse-model", "retrain"), default="reuse-model")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-run even where a completed run exists")
+    parser.add_argument("--skip-genotypes", action="store_true",
+                        help="Passed through to the comparator (much faster)")
+    args = parser.parse_args()
+
+    if args.mode == "reuse-model" and not args.model:
+        parser.error("--mode reuse-model needs --model")
+    for repo in (args.baseline_repo, args.candidate_repo):
+        if not (repo / "genotools" / "ancestry" / "preprocessing.py").is_file():
+            parser.error(f"{repo} is not a GenoTools source tree")
+    if args.baseline_repo.resolve() == args.candidate_repo.resolve():
+        parser.error("baseline and candidate repos are the same tree; this compares nothing")
+
+    print("=" * 72)
+    print(f"SNP-matching comparison — mode: {args.mode}")
+    print("=" * 72)
+    print(f"  baseline source : {args.baseline_repo}")
+    print(f"  candidate source: {args.candidate_repo}")
+    print(f"  interpreter     : {args.python}")
+
+    panel = describe_panel(args.ref_panel)
+    print(f"\nReference panel exposure ({panel['variants']} variants):")
+    print(f"  palindromic sites   : {panel['palindromic']}")
+    print(f"  duplicate positions : {panel['duplicate_positions']}")
+    if not panel["palindromic"]:
+        print("  -> panel is palindrome-free, so the palindrome half cannot move a call here")
+    print()
+
+    baseline_out = args.work / "baseline" / "out"
+    candidate_out = args.work / "candidate" / "out"
+    model = args.model if args.mode == "reuse-model" else None
+    keep = not args.skip_genotypes
+
+    print("Baseline run (without the fix):")
+    run_pipeline(args.python, baseline_out, args.geno, args.ref_panel,
+                 args.ref_labels, model, args.force, keep, cwd=args.baseline_repo)
+    print("Candidate run (with the fix):")
+    run_pipeline(args.python, candidate_out, args.geno, args.ref_panel,
+                 args.ref_labels, model, args.force, keep, cwd=args.candidate_repo)
+
+    command = [
+        sys.executable, str(COMPARATOR),
+        "--old", str(baseline_out),
+        "--new", str(candidate_out),
+    ]
+    if args.skip_genotypes:
+        command.append("--skip-genotypes")
+    print("\n" + "=" * 72)
+    print("Comparing reports")
+    print("=" * 72)
+    comparison = subprocess.run(command, cwd=REPO_ROOT)
+
+    provenance = args.work / "sources.json"
+    provenance.parent.mkdir(parents=True, exist_ok=True)
+
+    def head(repo: Path) -> str:
+        result = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
+                                capture_output=True, text=True)
+        return result.stdout.strip() or "unknown"
+
+    provenance.write_text(json.dumps({
+        "mode": args.mode,
+        "interpreter": str(args.python),
+        "baseline": {"repo": str(args.baseline_repo), "head": head(args.baseline_repo)},
+        "candidate": {"repo": str(args.candidate_repo), "head": head(args.candidate_repo)},
+        "ref_panel": {"path": str(args.ref_panel), **panel},
+    }, indent=2))
+    print(f"\nSources recorded in {provenance}")
+
+    # A non-zero comparator exit means calls moved, which is the number this
+    # script exists to produce — reported, not propagated as a crash.
+    if comparison.returncode != 0:
+        print(
+            "\nThe two source trees do NOT agree. Read the per-label movement "
+            "table above and record it in REFACTOR.md item 13."
+        )
+    return comparison.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/compare_umap_versions.py
+++ b/tests/scripts/compare_umap_versions.py
@@ -103,11 +103,17 @@ def run_pipeline(
     model: Optional[Path],
     force: bool,
     keep_intermediates: bool,
+    cwd: Path = REPO_ROOT,
 ) -> None:
     """Run one ancestry pipeline, reusing a completed run unless forced.
 
     Reuse is keyed on the JSON report, which the runner writes last — a partial
     run leaves no report and is redone rather than silently compared.
+
+    `cwd` selects which source tree runs, since `python -m genotools` puts the
+    working directory first on `sys.path`. This script holds it at REPO_ROOT so
+    the libraries are the only variable; `compare_snp_matching.py` varies it
+    instead, to compare two source trees under one interpreter.
     """
     report = out_prefix.with_suffix(".json")
     if report.exists() and not force:
@@ -136,9 +142,9 @@ def run_pipeline(
         command += ["--model", str(model)]
 
     print(f"  [run]   {' '.join(command)}")
-    # cwd=REPO_ROOT so both environments import the same working tree: the
-    # libraries are the variable, the GenoTools source is not.
-    result = subprocess.run(command, cwd=REPO_ROOT)
+    # `python -m genotools` imports whatever tree `cwd` names; callers decide
+    # whether the source or the libraries are the variable.
+    result = subprocess.run(command, cwd=cwd)
 
     # A non-zero exit is not a reason to abandon the comparison. GenoTools
     # exits 1 when any step failed, and a step failing is itself something the

--- a/tests/unit/test_ancestry/conftest.py
+++ b/tests/unit/test_ancestry/conftest.py
@@ -70,3 +70,66 @@ def geno21_22_pfile(tmp_path_factory) -> Path:
     for ext in (".pgen", ".pvar", ".psam"):
         shutil.copy2(src.with_suffix(ext), dst.with_suffix(ext))
     return dst
+
+
+def _write_vcf(path: Path, records: list, n_samples: int) -> None:
+    """Minimal VCF writer. `records` are (pos, snp_id, ref, alt, genotypes)."""
+    samples = [f"S{i:03d}" for i in range(n_samples)]
+    lines = [
+        "##fileformat=VCFv4.2",
+        "##contig=<ID=1>",
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        "#" + "\t".join(["CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT"] + samples),
+    ]
+    for pos, snp_id, ref, alt, gts in records:
+        lines.append("\t".join(["1", str(pos), snp_id, ref, alt, ".", ".", ".", "GT"] + gts))
+    path.write_text("\n".join(lines) + "\n")
+
+
+@pytest.fixture(scope="session")
+def dup_position_bfiles(tmp_path_factory) -> tuple:
+    """Two bfiles sharing positions, where the *first* carries 1:1000 under two
+    probe IDs with very different call rates.
+
+    `probe_hi` (50% missing) is deliberately placed ahead of `probe_lo` (5%
+    missing) in the .bim, so first-row-wins dedup selects the badly-called
+    probe and a missingness-aware tie-break selects the good one. Without the
+    ordering the test could pass for the wrong reason.
+    """
+    n = 20
+    hi = ["./." if i < 10 else "0/1" for i in range(n)]          # 50% missing
+    lo = ["./." if i < 1 else "0/1" for i in range(n)]           # 5% missing
+    het = ["0/1"] * n
+    shared = [(2000, "shared_a", "A", "G", het), (3000, "shared_b", "C", "A", het)]
+
+    d = tmp_path_factory.mktemp("dup_pos")
+    _write_vcf(d / "one.vcf", [(1000, "probe_hi", "A", "G", hi),
+                               (1000, "probe_lo", "A", "G", lo)] + shared, n)
+    _write_vcf(d / "two.vcf", [(1000, "ref_probe", "A", "G", het)] + shared, n)
+
+    out = []
+    for name in ("one", "two"):
+        prefix = d / name
+        run_command(
+            f"{get_plink2()} --vcf {prefix}.vcf --make-bed --double-id --out {prefix}",
+            tool_name="plink2",
+        )
+        out.append(prefix)
+    return tuple(out)
+
+
+@pytest.fixture(scope="session")
+def palindrome_free_bfile(synth_ref_bfile: Path, tmp_path_factory) -> Path:
+    """`synth_ref_bfile` with its palindromic (A/T, C/G) sites removed, so the
+    new and legacy get_common_snps must agree exactly on it."""
+    bim = pd.read_csv(f"{synth_ref_bfile}.bim", sep="\t", header=None)
+    keep = bim.loc[~(bim[4] + bim[5]).isin({"AT", "TA", "CG", "GC"}), 1]
+    d = tmp_path_factory.mktemp("no_palindrome")
+    keep_file = d / "keep.snplist"
+    keep.to_csv(keep_file, header=False, index=False)
+    out = d / "ref_nopal"
+    run_command(
+        f"{get_plink2()} --bfile {synth_ref_bfile} --extract {keep_file} --make-bed --out {out}",
+        tool_name="plink2",
+    )
+    return out

--- a/tests/unit/test_ancestry/test_preprocessing.py
+++ b/tests/unit/test_ancestry/test_preprocessing.py
@@ -10,24 +10,76 @@ def _read_bim_snps(prefix: str) -> set:
     return set(bim[1])
 
 
-def test_get_common_snps_matches_legacy(synth_ref_bfile, tmp_path):
-    """New port yields the same extracted SNP set + common_snps file as legacy."""
+PALINDROMIC = {"AT", "TA", "CG", "GC"}
+
+
+def _palindromic_snps(prefix: str) -> set:
+    bim = pd.read_csv(f"{prefix}.bim", sep=r"\s+", header=None)
+    return set(bim.loc[(bim[4] + bim[5]).isin(PALINDROMIC), 1])
+
+
+def test_get_common_snps_matches_legacy_on_unambiguous_input(palindrome_free_bfile, tmp_path):
+    """On input with nothing ambiguous to decide, the port is still exactly the
+    legacy function — which is what the old version of this test was really
+    checking, minus the palindromes that masked the difference."""
     from genotools.ancestry.preprocessing import get_common_snps as new_fn
     from genotools.utils import get_common_snps as legacy_fn
 
-    # Use the same bfile as both inputs (guarantees a nonempty common set)
-    g1, g2 = str(synth_ref_bfile), str(synth_ref_bfile)
+    g = str(palindrome_free_bfile)
+    assert not _palindromic_snps(g), "fixture should have no palindromic sites"
 
-    legacy_out = tmp_path / "legacy_common"
-    new_out = tmp_path / "new_common"
-
-    legacy_res = legacy_fn(g1, g2, str(legacy_out))
-    new_res = new_fn(g1, g2, str(new_out))
+    legacy_out, new_out = tmp_path / "legacy_common", tmp_path / "new_common"
+    legacy_res = legacy_fn(g, g, str(legacy_out))
+    new_res = new_fn(g, g, str(new_out))
 
     assert set(new_res.keys()) == set(legacy_res.keys())
     assert _read_bim_snps(str(new_out)) == _read_bim_snps(str(legacy_out))
     assert (Path(f"{new_out}.common_snps").read_text()
             == Path(f"{legacy_out}.common_snps").read_text())
+
+
+def test_get_common_snps_excludes_palindromic(synth_ref_bfile, tmp_path):
+    """Palindromic sites are dropped, and legacy is shown to have kept them.
+
+    Their alleles survive strand complement unchanged, so nothing downstream
+    can tell which strand they came from -- get_raw_files' allele-switch test
+    can never fire for one. The legacy assertion is what makes this a
+    regression test rather than a restatement of the implementation.
+    """
+    from genotools.ancestry.preprocessing import get_common_snps as new_fn
+    from genotools.utils import get_common_snps as legacy_fn
+
+    g = str(synth_ref_bfile)
+    palindromic = _palindromic_snps(g)
+    assert palindromic, "fixture must contain palindromic sites to be meaningful"
+
+    new_res = new_fn(g, g, str(tmp_path / "new_common"))
+    kept = set(pd.read_csv(new_res["common_snps"], header=None)[0])
+    assert not (kept & palindromic), "palindromic sites reached the common set"
+
+    legacy_res = legacy_fn(g, g, str(tmp_path / "legacy_common"))
+    legacy_kept = set(pd.read_csv(legacy_res["common_snps"], header=None)[0])
+    assert legacy_kept & palindromic, "legacy should have kept them (test is degenerate)"
+    assert legacy_kept - kept == palindromic, "only palindromic sites should differ"
+
+
+def test_get_common_snps_breaks_position_ties_by_missingness(dup_position_bfiles, tmp_path):
+    """When one position offers several probes, the best-called one wins.
+
+    The fixture puts the 50%-missing probe ahead of the 5%-missing one, so
+    first-row-wins dedup would take `probe_hi`.
+    """
+    from genotools.ancestry.preprocessing import get_common_snps
+
+    one, two = dup_position_bfiles
+    res = get_common_snps(str(one), str(two), str(tmp_path / "out"))
+    kept = set(pd.read_csv(res["common_snps"], header=None)[0])
+
+    assert "probe_lo" in kept, "the better-called probe should have been chosen"
+    assert "probe_hi" not in kept, "the 50%-missing probe should have lost"
+    # one row per position, not one per probe
+    bim = pd.read_csv(f"{tmp_path / 'out'}.bim", sep=r"\s+", header=None)
+    assert not bim.duplicated(subset=[0, 3]).any(), "a position survived twice"
 
 
 def _sorted_df(df):


### PR DESCRIPTION
## Summary

Resolves `REFACTOR.md` item 13 — two fixes in `ancestry/preprocessing.py::get_common_snps`. The filed headline turned out to be unreachable; the aside next to it was the live defect.

**Palindromic sites are now excluded — a guard, not a live fix.** Complementing an A/T or C/G pair returns the same pair, so the match cannot tell which strand the site came from, and `get_raw_files`' allele-switch test ("differs from the reference allele *and* from its complement") can never fire for one — it was accepted at whatever orientation it arrived in. Panels built per `docs/prep_reference_panel.md` exclude them at build time, and the GP2 panel has **0 of 209,517**, so none can survive the intersection. Provably a no-op here, which is what makes it safe to land; a real correctness fix for panels built otherwise.

**Position ties are now broken by call rate — this was the live defect.** `drop_duplicates(subset=["chr","pos"])` kept whichever row the merge emitted first. It matters because `get_common_snps` is called **twice with its arguments reversed**: the second call extracts from the *cohort*, so the written ID is a cohort variant, and cohorts carry the same site under several probe IDs (`rs301801`, `IlmnSeq_rs301801`, `seq_rs301801` — 98,509 duplicate positions in the 10k subset).

**1,078 of 43,173 common SNPs (2.50%)** were decided by row order, and the candidates were not redundant copies: only **4** were bit-identical, missingness differed by up to **6.9%** and genotypes by up to **49.9%** (`4:115883489`). Deterministic per input file, but arbitrary, and sensitive to input variant order. The best-called probe now wins, exact ties keeping the earlier row.

**Existing models are not invalidated.** The missingness pass is skipped unless a position's candidates actually name different variants, so the reference-panel-side call stays byte-identical: a saved model's common-SNP list, classifier and accuracy are untouched.

**Measured cost: 1 call in 10,000.** Via `tests/scripts/compare_snp_matching.py` (new — sibling of round 16's comparator, varying the source rather than the libraries), on the 10k GP2 subset reusing the saved parity model:

```
[FAIL] ancestry labels: 1/10,000 differ — old FIN -> new EUR
[FAIL] ancestry counts: EUR 6927->6928, FIN 12->11
[PASS] test accuracy: identical (0.985037)
[PASS] confusion matrix: identical (10x10)
[PASS] QC metrics: all 55 pruned_counts identical
[PASS] pruned samples: identical IDs across 3 step(s), 412 total
[PASS] related samples: identical 52 pairs
[PASS] step pass/fail: identical across 11 ancestry group(s)
```

456 probes and 105,318 feature-matrix cells changed, for one moved call. The identical accuracy and confusion matrix confirm the model is untouched and the effect is entirely on prediction.

## Test plan

- `tests/unit` **695 passed**; `tests/regression` **77 passed**
- **`test_get_common_snps_matches_legacy` pinned the bug** — it asserted byte-identity against the legacy function but passed the same bfile as both inputs, so it never exercised ambiguous ordering and any fix would fail it by construction. Replaced by three: legacy parity on unambiguous input, palindrome exclusion (asserting legacy *kept* them, so it cannot pass vacuously), and tie-breaking on a fixture whose 50%-missing probe is deliberately ordered ahead of its 5%-missing one.
- **Revert-checked** both production changes: neutering `_drop_palindromic` fails the second test; restoring the old `drop_duplicates` fails the third, selecting the 50%-missing probe.
- **Goldens unchanged, structurally** — both ancestry fixtures (`ref21_22`, `geno21_22`) have zero palindromes and zero duplicate positions, so neither half can reach them. No regeneration needed; they also would never have caught this bug.
- Verified plink2's `--missing` report no longer clobbers an existing `.log` (writes to a `_missing` prefix; the variant-prune log is byte-unchanged).

Reproduce the end-to-end number:

```bash
git worktree add /tmp/baseline 6b18a75   # this branch's merge-base
python tests/scripts/compare_snp_matching.py \
    --python .venv/bin/python --baseline-repo /tmp/baseline \
    --geno ~/parity_data/GP2_r12_subset10k \
    --ref-panel ~/.genotools/ref/ref_panel/ref_panel_gp2_prune_rm_underperform_pos_update \
    --ref-labels ~/.genotools/ref/ref_panel/ref_panel_ancestry_updated.txt \
    --model ~/parity_data/models/new_ancestry_ancestry_model \
    --work /tmp/snp-compare --mode reuse-model --skip-genotypes
```