### PR TITLE
Feat/ancestry diagnostics

### DIFF
--- a/MIGRATION_2.0.md
+++ b/MIGRATION_2.0.md
@@ -135,6 +135,12 @@ that `--het sd` is the spelling now. See
 `--het-ancestry`, `--quiet`, `--debug`, `--no-warn`, `--no-prune-duplicated`.
 `--het` accepts a new `sd [N]` form.
 
+Ancestry prediction adds `--no-admixture-detection`,
+`--ancestry-missing-fill`, `--ancestry-max-missing-snps`, `--ancestry-plots`
+and `--ancestry-self-test`. See
+[Absent model SNPs are no longer filled with dosage 2](#absent-model-snps-are-no-longer-filled-with-dosage-2)
+and `docs/cli_args.md`.
+
 ---
 
 ## Behavior changes
@@ -360,6 +366,46 @@ common-SNP list, its fitted classifier and its accuracy are all unaffected. You
 do not need to retrain, and predictions from an existing model shift only by
 the amount above.
 
+### Absent model SNPs are no longer filled with dosage 2
+
+**This can change ancestry calls a lot, but only for a cohort that was already
+being predicted badly.**
+
+When predicting with a saved model, the cohort's feature matrix has to have
+exactly the model's SNPs in the model's order, so any SNP the cohort does not
+carry has to be invented. 1.x — and 2.0 up to this point — filled every such
+SNP with dosage **2** for every sample. Dosage 2 is not a neutral value: it is
+one end of the range, applied identically to everybody, so a cohort missing a
+large share of the model's SNP list acquires a large *shared* offset in PC
+space, lands somewhere no reference sample sits, and can end up nearer the
+global centroid than to any ancestry centroid — which is the rule that labels a
+sample `CAH`. A high-accuracy model predicting `CAH` for an entire cohort is
+this, not a model failure.
+
+The fill is now a missing value, which `PCAReducer`'s reference-fitted imputer
+replaces with the panel's own mean for that SNP. That is already how a
+genuinely missing call at a SNP the cohort *does* carry is treated, so the
+change also makes the matrix internally consistent. A filled SNP now
+contributes nothing to the projection instead of pulling it.
+
+Three things follow:
+
+- **A cohort that matched the model's SNPs well barely moves.** The filled
+  columns were a small part of the matrix, and they now sit at the panel mean
+  instead of at 2.
+- **A cohort that matched badly may move a great deal** — that is the fix, not
+  a regression. The old labels for such a cohort were describing the fill.
+- **Above 50% filled, prediction is refused** rather than reported, naming the
+  counts and the likely cause. Raise `--ancestry-max-missing-snps` to predict
+  anyway; every run logs the overlap and writes the filled IDs to
+  `{out}_filled_snps.txt` either way.
+
+`--ancestry-missing-fill constant` restores the old behaviour exactly, int
+dosages included, for reproducing an older run.
+
+**Existing models are not invalidated** — the model is untouched; this is
+entirely about the matrix handed to it at prediction time.
+
 ### GWAS p-values shift slightly
 
 PCA now prunes high-LD and MHC regions that 1.x left in, so association
@@ -383,6 +429,7 @@ Most of the report is unchanged. The differences:
 | `pruned_samples[].label` | unchanged — still carries the sample's ancestry group |
 | `total_umap`, `ref_umap`, `new_samples_umap` | **columns renamed** `"0".."24"` → `"UMAP1".."UMAP25"` |
 | `common_snps` | **new** — count of variants shared between input and reference panel |
+| `ancestry_diagnostics` | **new** — what the prediction path measured about itself: `snp_overlap` (how much of the model's SNP list the cohort carried, and how much was filled), `allele_frequency` (panel/cohort concordance over matched sites, with a swap-signature count), `pc_drift` (per-PC cohort displacement in reference SDs), `admixture` (the `CAH` count with the classifier's labels from before the override), `self_test` (with `--ancestry-self-test`), `plots`, and `warnings` |
 | `projected_pcs` | same columns and values; column *order* differs (`label` moved earlier) |
 
 The UMAP rename is the one breaking change here. If you read those columns by

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1291,6 +1291,162 @@ goldens would not have caught the bug, and still would not.
 
 ---
 
+### Round 18 (instruments for the prediction path, and the fill behind an all-CAH run)
+
+Prompted by a report from outside this repo: a team training an ancestry model
+on long-read sequencing got high test accuracy and then `CAH` for **every**
+sample in their cohort. No file in the run said why, so the round is mostly
+about making the prediction path answer questions about itself.
+
+**Where the asymmetry is.** Training accuracy is measured on reference samples
+built by the *training* branch of `get_raw_files`; a cohort goes through the
+*inference* branch, which has to align itself to a saved model's SNP list. Only
+the inference branch can fail at alignment, and nothing downstream of it could
+see that it had:
+
+```
+absent model SNP -> filled with dosage 2 for every sample
+                 -> identical large offset for every sample after ref-fitted scaling
+                 -> cohort collapses to one point off the reference manifold
+                 -> nearest centroid is the global one
+                 -> CAH, for everybody, from a model with 0.98 test accuracy
+```
+
+`missing_cols += [pd.Series(np.repeat(2, ...))]` (1.x, carried into 2.0) was
+the first link and it was **silent** — no count, no warning, no report field.
+Dosage 2 is not a neutral filler: it is one end of the range, applied
+identically to every sample, which is precisely what produces a shared offset
+rather than noise.
+
+**The fill is now `NaN`,** which `PCAReducer.transform`'s imputer — fitted on
+the reference panel — replaces with that SNP's panel mean. This is not a new
+convention: `plink2 --recode A` already writes `NA` for a genuinely missing
+call at a SNP the cohort *does* carry, and those NaNs already reached the same
+imputer. The old code was inconsistent with the matrix it was filling in.
+`--ancestry-missing-fill constant` restores dosage 2 exactly, int dtypes
+included, and is pinned by the legacy golden.
+
+**Eight instruments, in the order a failing run should be read.** Each answers
+one question, all are on by default, and all land in the log and in the JSON
+report's new `ancestry_diagnostics` section:
+
+| Instrument | Question it settles |
+|---|---|
+| `SnpOverlapReport` | How much of the model's SNP list did the cohort actually carry? More than 5% filled warns; more than 50% **refuses** rather than predicting from fill (`--ancestry-max-missing-snps`), and the filled IDs go to `{out}_filled_snps.txt` |
+| `bim_compatibility` | When a match comes back near-empty, do the two files even share a coordinate space? Names `chr1`-vs-`1` and hg19-vs-hg38 outright; zero overlap now raises instead of failing inside `plink2 --extract` |
+| `allele_frequency_concordance` | Do matched sites agree with the panel on frequency, or is a swap-signature population sitting near `1 - ref_freq`? |
+| `pc_drift` | Where did the cohort land, in reference SD? A centroid 40 SD out, or a spread ratio near zero, is a feature-matrix problem, not ancestry |
+| `admixture_summary` | What did the classifier say *before* the `CAH` override replaced it? |
+| `--no-admixture-detection` | The same question by experiment |
+| `self_test` | Can the model still recover the reference panel's own labels through the prediction path? |
+| `--ancestry-plots` | The two pictures worth having once the numbers have narrowed it |
+
+The override was the other silent step: `_predict_admixed` overwrote the
+classifier's label and discarded it, so an all-`CAH` run was indistinguishable
+from a broken classifier. It now also returns a per-sample decision frame —
+both labels, every centroid distance, and `margin_to_all`, which restates the
+rule as one signed number (negative is `CAH`) — written to `{out}_decisions.txt`.
+A spread of pre-override labels under a uniform `CAH` result localizes the
+fault to the override or the projection in one line of the log.
+
+`self_test` is the measurement that splits the two hypotheses the reporting
+team could not split. Its accuracy is optimistic by construction — most of
+those samples were fitted on — so the load-bearing number is the panel's own
+`CAH` rate: the panel *defines* the ancestry centroids, so a panel that comes
+back largely `CAH` indicts the override or the projection no matter what the
+cohort looks like, and a panel that predicts itself correctly leaves only the
+cohort's preprocessing to blame.
+
+**A trap found on the way in.** `run_umap` selected its features by *dropping*
+`FID`/`IID`/`label`, so anything else in `_projected_new_pca.txt` became a UMAP
+feature — silently, since UMAP accepts any width. Writing per-sample distances
+into that file, the obvious first design, would have moved every point in the
+embedding. Diagnostics went to their own file instead, and `run_umap` now
+selects `PC*` by name with a fallback for frames that name their components
+otherwise.
+
+**Both prediction modes, or neither.** `_run_training_mode` and
+`_run_inference_mode` each call `get_raw_files` and `predict` with their own
+argument lists — the `--amr-het` shape, where a setting honoured on one path and
+forgotten on the other works right up until the run that matters. Every wiring
+test is parameterized over both modes, and the revert-check confirms the
+parameterization is what catches it: dropping the fill settings from the
+inference branch fails only `[inference]`, hardcoding `detect_admixed=True` in
+the training branch fails only `[training]`.
+
+Diagnostic artifacts are written to the **final** output prefix rather than
+beside the intermediates, because a run without `--full-output` deletes the
+directory the intermediates live in — and the evidence is worth more than the
+matrix it came from.
+
+**What the fill change costs, measured.** `tests/scripts/compare_missing_fill.py`
+is the third single-variable comparator after rounds 16 and 17, and the first
+that needs neither a second venv nor a second checkout: both strategies are
+reachable from one tree, so it holds the model, the reference PCA and the
+libraries constant in a single process and varies only the value written into
+the columns the cohort could not supply.
+
+On the 10k GP2 subset with the saved parity model:
+
+```
+  cohort matched 43173/43173 model SNPs (100.00%); 0 filled
+  fill: constant -> ref-mean   0 of 10,000 calls moved (0.000%)
+```
+
+The exposure is **zero** — this cohort carries the model's entire SNP list — so
+the change is provably a no-op here and cannot move a call. That is the same
+shape of argument as round 17's palindrome exclusion: it lands without
+revalidation because the data in use is not exposed to it, and the cohort that
+*is* exposed is exactly the one whose old labels were describing fill.
+
+**The same run calibrates the thresholds, which is worth more than the parity
+result.** A healthy real cohort against this panel looks like:
+
+| Instrument | Healthy value here | Warns at |
+|---|---|---|
+| SNP overlap | 43,173 / 43,173 (100.00%) | < 95% filled-in, refuses > 50% |
+| Allele-frequency concordance | r = 0.9516, 2 of 43,173 discordant, **0** swap signatures | r < 0.7, > 1% swap |
+| PC drift (PC1-PC10) | shift 0.01-0.92 SD, spread ratio 0.25-0.93 | > 5 SD, ratio outside 0.1-10 |
+| CAH rate | 135 of 10,000 (**1.35%**) | > 50% |
+| Self-test (`--ancestry-self-test`) | 4,008 panel samples, balanced accuracy **0.9471** (0.9565 before the override), **0.92%** CAH | accuracy < 0.5, or CAH > 50% |
+
+Every instrument sits an order of magnitude inside its threshold on real data,
+which is the evidence that none of them will cry wolf on an ordinary run. It is
+one cohort against one panel, so it is a calibration point rather than a
+calibration — recorded as remaining-work item 28.
+
+**The whole path was then run through the CLI once**, on the same cohort and
+model, without `--full-output`:
+
+```
+genotools --pfile GP2_r12_subset10k --ancestry --model <parity model> \
+          --ref-panel <panel> --ref-labels <labels> \
+          --ancestry-plots --ancestry-self-test
+```
+
+Everything landed: the overlap, drift table, self-test and override summary in
+the log; `ancestry_diagnostics` in the report; `{out}_decisions.txt` (10,000
+rows, 20 columns) and both PNGs at the **final** prefix, outliving the temp
+directory. No diagnostic fired a warning, which is the correct result for this
+cohort.
+
+The override summary is the line worth showing, because it is the one that was
+previously impossible to obtain:
+
+```
+Admixture detection: 135/10000 labeled CAH; classifier labels before the
+override: {'EUR': 6932, 'EAS': 769, 'AFR': 608, 'AJ': 399, 'AMR': 380,
+'CAS': 313, 'MDE': 303, 'AAC': 161, 'SAS': 122, 'FIN': 13}
+```
+
+On a healthy run it is unremarkable — `AMR` 380 → 344, `CAS` 313 → 271,
+`AAC` 161 → 113. On the run that prompted the round it would have read
+`{'EUR': ..., 'AFR': ..., 'EAS': ...}` under an all-`CAH` result, which
+localizes the fault in one line.
+
+
+---
+
 ## Remaining work (tracked, not yet done)
 
 Priority order for making the refactor mergeable to `main`:
@@ -1425,3 +1581,33 @@ Priority order for making the refactor mergeable to `main`:
     the reason golden reports needed normalizing at all (round 14). Recording
     the stable `{out}_{step}` prefixes instead would be more useful, but it is
     a report contract change.
+27. **Training mode has no overlap report, and a width mismatch crashes it.**
+    Round 18 instrumented the inference branch of `get_raw_files`, where the
+    cohort is aligned to a saved model's SNP list. The training branch does not
+    reindex the cohort matrix to the reference's columns at all — it assumes the
+    two `get_common_snps` calls produced the same width and does
+    `raw_geno.columns = col_names`, which raises pandas' bare "Length mismatch"
+    if they did not. Not observed on real data, and the second call can only
+    lose variants relative to the first, so it is reachable in principle rather
+    than in practice. Reporting the shortfall the way the inference branch now
+    does would be strictly better than the traceback.
+28. **The diagnostic thresholds are reasoned, not calibrated.** 5 reference SD
+    of PC shift, a 0.1-10x spread ratio, 50% CAH, r < 0.7 on allele frequency,
+    1% swap signature (`ancestry/diagnostics.py`) were each derived from the
+    mechanism they detect, not from a distribution of real runs. They are only
+    warnings — except the 50%-filled refusal, which is the one with teeth — but
+    a false positive on a legitimately unusual cohort costs trust in all of
+    them. Worth recalibrating once a handful of real cohorts have been through
+    the instrumented path.
+29. **The self-test measures a floor, not accuracy.** `--ancestry-self-test`
+    predicts the whole reference panel, most of which the model was fitted on,
+    so its balanced accuracy is optimistic by construction and only its
+    *failure* is informative. The honest version would push the model's own
+    held-out test split through `predict`, which means recording those sample
+    IDs onto the model at `fit` time — a model-format change, so deferred.
+30. **`ancestry_diagnostics` has no golden.** The regression goldens cover no
+    ancestry run at all (`tests/scripts/generate_golden.py` has no ancestry
+    generator), so the new report section's shape is pinned only by unit tests
+    against a hand-built result dict. The same gap is why round 18 needed no
+    golden regeneration; it is also why a change to that section's shape would
+    not be caught.

--- a/TESTING.md
+++ b/TESTING.md
@@ -243,6 +243,36 @@ per-group pipeline structurally cannot see, and borderline first-degree pairs ca
 be pushed over 0.354 by running KING on a mixed-ancestry cohort. Compare old
 against new, not against the release.
 
+### Single-variable comparators
+
+Three scripts isolate one variable each and delegate the movement table to
+`compare_ancestry_run.py`, so a number means the same thing in all of them:
+
+| Script | Holds constant | Varies |
+|---|---|---|
+| `compare_umap_versions.py` | the source tree | the installed libraries (round 16) |
+| `compare_snp_matching.py` | the libraries | the source tree, via `cwd` (round 17) |
+| `compare_missing_fill.py` | both — one process, one loaded model | the missing-SNP fill strategy (round 18) |
+
+The third needs neither a second venv nor a second checkout, because both fill
+strategies are reachable from one tree through `--ancestry-missing-fill`. It is
+also the fastest first thing to run against a cohort whose prediction looks
+wrong: the header it prints is how much of the model's SNP list that cohort
+actually carried, which decides whether anything else is worth investigating.
+
+```bash
+.venv/bin/python tests/scripts/compare_missing_fill.py \
+    --geno ~/parity_data/GP2_r12_subset10k \
+    --ref-panel ~/.genotools/ref/ref_panel/ref_panel_gp2_prune_rm_underperform_pos_update \
+    --ref-labels ~/.genotools/ref/ref_panel/ref_panel_ancestry_updated.txt \
+    --model ~/parity_data/models/new_ancestry_ancestry_model \
+    --work /tmp/missing-fill-compare
+```
+
+Run it with `python -u`: its findings go to stdout while the pipeline's own
+logging goes to stderr, so a redirect without `-u` buffers the findings behind
+every log line.
+
 ---
 
 ## 6. Decision B: GWAS/PCA region exclusion

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -353,6 +353,81 @@ should be tightened.
     are recorded in the pruned-samples output with the step
     `insufficient_ancestry_sample_n`.
 
+#### Prediction-path diagnostics
+
+Training accuracy is measured on reference samples that went through the
+*training* preprocessing branch. A cohort goes through the *inference* branch,
+which aligns it to the model's SNP list — and can fail there in ways training
+never sees. The classic symptom is a model with high test accuracy predicting a
+single label (often `CAH`) for an entire cohort, because the cohort matched
+almost none of the model's SNPs and the rest were invented.
+
+Every ancestry run now measures that path and reports it in the log and in the
+JSON report's `ancestry_diagnostics` section: how much of the model's SNP list
+the cohort carried, whether matched sites agree with the panel on allele
+frequency, where the cohort landed in reference PC space, and what the `CAH`
+override did to the classifier's labels. The flags below tune or extend it.
+Each one requires `--ancestry`; passing one without it is an error rather than a
+silent no-op.
+
+- **`--ancestry-missing-fill`**
+  - *Type*: `str` (`ref-mean` or `constant`)
+  - *Default*: `ref-mean`
+  - *Description*: How to fill a model SNP the cohort does not carry.
+    `ref-mean` writes a missing value, which the reference-fitted imputer fills
+    with the panel's own mean for that SNP, so the filled SNP contributes
+    nothing to the projection. `constant` writes dosage 2 — one end of the
+    range, applied identically to every sample — which is what 1.x and 2.0
+    before this did, and is the mechanism behind whole cohorts collapsing onto
+    one label. Kept only for reproducing an older run.
+
+- **`--ancestry-max-missing-snps`**
+  - *Type*: `float` (fraction in `[0, 1]`)
+  - *Default*: `0.5`
+  - *Description*: Refuse to predict when more than this share of the model's
+    SNPs is absent from the cohort. Above roughly half, a predicted label
+    describes the fill rather than the sample. The error names the counts and
+    the usual causes (chromosome naming, genome build); raise the limit to
+    predict anyway. Below the limit, exceeding 5% logs a warning.
+
+- **`--no-admixture-detection`**
+  - *Type*: `flag`
+  - *Default*: `False` (detection on)
+  - *Description*: Report the classifier's own labels instead of relabeling as
+    `CAH` the samples that sit nearer the global centroid than any ancestry
+    centroid. The first thing to try on an all-`CAH` result: it separates a
+    broken classifier from a broken override. The per-sample
+    `{out}_decisions.txt` file records both labels either way.
+
+- **`--ancestry-plots`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Write two diagnostic PNGs: `{out}_pca_diagnostic.png`, the
+    reference panel coloured by label with the cohort overlaid across the three
+    leading PC pairs, and `{out}_centroid_distance.png`, the margin behind each
+    `CAH` decision against the line where the decision flips.
+
+- **`--ancestry-self-test`**
+  - *Type*: `flag`
+  - *Default*: `False`
+  - *Description*: Predict the reference panel's *own* ancestries through the
+    prediction path, as a positive control. Accuracy is optimistic by
+    construction (most of these samples were fitted on), so the load-bearing
+    number is the panel's `CAH` rate: the panel defines the ancestry centroids,
+    so a panel that comes back largely `CAH` indicts the override or the
+    projection, not the cohort. A panel that predicts itself correctly here
+    leaves only the cohort's own preprocessing to blame.
+
+**Files an ancestry run writes for debugging** (alongside the report, at the
+final output prefix — they survive a run without `--full-output`):
+
+| File | Contents |
+|---|---|
+| `{out}_decisions.txt` | Per sample: the classifier's label, the label after the `CAH` override, the nearest centroid, and one distance column per centroid |
+| `{out}_filled_snps.txt` | IDs of the model SNPs the cohort did not carry |
+| `{out}_pca_diagnostic.png` | With `--ancestry-plots` |
+| `{out}_centroid_distance.png` | With `--ancestry-plots` |
+
 ---
 
 ### GWAS and PCA Arguments
@@ -412,4 +487,10 @@ genotools --pfile data/mydata --out results/output --ancestry \
 genotools --pfile data/mydata --out results/output \
           --callrate 0.05 --geno 0.01 --hwe 1e-6 \
           --pca 20 --gwas --quiet
+
+# Debugging a prediction that came back one label for every sample
+genotools --pfile data/mydata --out results/debug --ancestry \
+          --model models/my_model --ref-panel refs/panel \
+          --ref-labels refs/labels.txt \
+          --ancestry-self-test --ancestry-plots --no-admixture-detection
 ```

--- a/genotools/ancestry/__init__.py
+++ b/genotools/ancestry/__init__.py
@@ -73,7 +73,21 @@ from genotools.ancestry.config import (
     TrainingConfig,
     InferenceMode,
     DEFAULT_ANCESTRY_LABELS,
+    MISSING_FILL_STRATEGIES,
+    LEGACY_FILL_VALUE,
 )
+
+# Diagnostics for the prediction path
+from genotools.ancestry.diagnostics import (
+    AncestryDiagnostics,
+    SnpOverlapReport,
+    BimCompatibility,
+    admixture_summary,
+    allele_frequency_concordance,
+    bim_compatibility,
+    pc_drift,
+)
+from genotools.ancestry.plots import plot_ancestry_diagnostics
 
 # Result classes
 from genotools.ancestry.results import (
@@ -115,6 +129,17 @@ __all__ = [
     "TrainingConfig",
     "InferenceMode",
     "DEFAULT_ANCESTRY_LABELS",
+    "MISSING_FILL_STRATEGIES",
+    "LEGACY_FILL_VALUE",
+    # Diagnostics
+    "AncestryDiagnostics",
+    "SnpOverlapReport",
+    "BimCompatibility",
+    "admixture_summary",
+    "allele_frequency_concordance",
+    "bim_compatibility",
+    "pc_drift",
+    "plot_ancestry_diagnostics",
     # Results
     "AncestryPredictions",
     "AncestryResult",

--- a/genotools/ancestry/config.py
+++ b/genotools/ancestry/config.py
@@ -41,6 +41,25 @@ from typing import Optional, Tuple
 from genotools.core.config import BaseConfig, ThresholdConfig
 
 
+#: How `get_raw_files` fills a model SNP the cohort does not carry.
+#:
+#: ``ref-mean`` (the default) writes NaN, which `PCAReducer.transform` then
+#: fills with the *reference panel's* mean for that SNP -- the same treatment
+#: the matrix already gives a genuinely missing call at a SNP the cohort does
+#: carry, since `plink2 --recode A` writes those as NA. A filled SNP therefore
+#: contributes nothing to the projection instead of pulling it.
+#:
+#: ``constant`` writes dosage 2, which is what 1.x and 2.0 up to this round
+#: did. Dosage 2 is not neutral: it is one end of the range, applied
+#: identically to every sample, so a cohort missing much of the model's SNP
+#: list gets a large shared offset in PC space and lands somewhere no reference
+#: sample sits. Kept as an escape hatch for reproducing an older run.
+MISSING_FILL_STRATEGIES = ("ref-mean", "constant")
+
+#: The dosage the ``constant`` strategy fills with (1.x's behaviour).
+LEGACY_FILL_VALUE = 2
+
+
 class InferenceMode(Enum):
     """Ancestry inference execution modes.
 

--- a/genotools/ancestry/diagnostics.py
+++ b/genotools/ancestry/diagnostics.py
@@ -1,0 +1,699 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Instruments for the ancestry *prediction* path.
+
+Training accuracy is measured on reference samples that went through the
+training branch of `get_raw_files`; a cohort goes through the inference branch,
+which aligns itself to a saved model's SNP list and can fail there in ways
+training never sees. The failure that motivated this module is a model with
+0.98 test accuracy predicting a single label -- `CAH` -- for every sample in a
+cohort, because the cohort matched almost none of the model's SNPs and the
+absent ones were filled with a constant. Every sample then carried the same
+large offset, projected to one point off the reference manifold, and landed
+nearer the global centroid than any ancestry centroid, which is exactly the
+`CAH` rule.
+
+Each function here answers one question about that path, and the answers
+compose into the pipeline's report:
+
+- `SnpOverlapReport` -- how much of the model's SNP list the cohort actually
+  carried, and how much was filled in
+- `bim_compatibility` -- when a match comes back near-empty, whether the two
+  files even describe the same coordinate space
+- `allele_frequency_concordance` -- whether matched sites agree on allele
+  frequency, or look strand/allele-swapped
+- `pc_drift` -- where the cohort landed in PC space relative to the reference
+  it is being compared against
+- `admixture_summary` -- what the classifier said before the `CAH` override
+  replaced it, and by what margin
+
+They are deliberately pure functions over frames so they can be tested against
+hand-built input, per the `select_het_outliers` pattern.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+from genotools.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+#: Fraction of a model's SNPs that may be absent from a cohort before the run
+#: warns. Small overlap losses are normal (a cohort legitimately drops variants
+#: at `--geno 0.1`); this is the level at which the projection starts to be
+#: driven by fill rather than by data.
+WARN_FILL_FRACTION = 0.05
+
+#: Fraction above which prediction is refused outright. At half the model's
+#: SNPs filled, a predicted label describes the fill, not the sample. Override
+#: with `--ancestry-max-missing-snps`.
+DEFAULT_MAX_FILL_FRACTION = 0.5
+
+#: A match this small means the two files probably do not share a coordinate
+#: space (chromosome naming, genome build) rather than merely disagreeing on
+#: content. Expressed against the smaller of the two variant sets.
+LOW_OVERLAP_FRACTION = 0.05
+
+#: Cohort centroid displacement, in reference PC standard deviations, that is
+#: too large to be ancestry. Roughly: no real population sits 5 SD off the
+#: reference panel's own spread on an early PC.
+WARN_PC_SHIFT_SD = 5.0
+
+#: Cohort-to-reference PC spread ratios outside this range. A ratio near zero
+#: means the cohort collapsed to a point (the constant-fill signature); a large
+#: one means the projection is dominated by something other than ancestry.
+WARN_PC_SD_RATIO = (0.1, 10.0)
+
+#: Per-SNP allele-frequency difference (on the 0-1 scale) counted as
+#: discordant between panel and cohort.
+DISCORDANT_FREQ_DELTA = 0.2
+
+#: How close to `1 - ref_freq` a discordant SNP must sit to be called an
+#: allele-swap signature rather than ordinary population difference.
+FLIP_SIGNATURE_TOLERANCE = 0.05
+
+#: Fraction of samples labeled CAH that is high enough to suspect the override
+#: rather than the cohort. A real cohort has admixed samples; it does not
+#: consist of them.
+WARN_CAH_FRACTION = 0.5
+
+
+def _f(value: Any) -> Optional[float]:
+    """Plain float for JSON, or None for anything not finite."""
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if np.isfinite(out) else None
+
+
+# ---------------------------------------------------------------------------
+# 1. How much of the model's SNP list did the cohort actually carry?
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SnpOverlapReport:
+    """What the cohort contributed to a model's feature matrix, and what was
+    filled in for it.
+
+    The inference branch of `get_raw_files` must hand the model a matrix with
+    exactly the model's SNPs, in order. Any SNP the cohort does not carry has
+    to be invented, and this records how much of the matrix was invented -- the
+    number that separates "the model is wrong about this cohort" from "the
+    model was never shown this cohort".
+
+    Attributes:
+        n_model_snps: SNPs the model expects (the width of its feature matrix).
+        n_matched: Of those, how many came from the cohort.
+        fill_strategy: How the remainder were filled. See
+            `preprocessing.MISSING_FILL_STRATEGIES`.
+        filled_snps: IDs of the filled SNPs, for writing alongside the run.
+    """
+
+    n_model_snps: int
+    n_matched: int
+    fill_strategy: str
+    filled_snps: Tuple[str, ...] = ()
+
+    @property
+    def n_filled(self) -> int:
+        """SNPs the cohort did not carry."""
+        return self.n_model_snps - self.n_matched
+
+    @property
+    def fraction_filled(self) -> float:
+        """Share of the feature matrix that is fill rather than data."""
+        if self.n_model_snps <= 0:
+            return 0.0
+        return self.n_filled / self.n_model_snps
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Counts for the JSON report. The ID list goes to its own file."""
+        return {
+            "n_model_snps": int(self.n_model_snps),
+            "n_matched": int(self.n_matched),
+            "n_filled": int(self.n_filled),
+            "fraction_filled": _f(self.fraction_filled),
+            "fill_strategy": self.fill_strategy,
+        }
+
+    def format_summary(self) -> str:
+        """One line for the log."""
+        return (
+            f"cohort matched {self.n_matched}/{self.n_model_snps} model SNPs "
+            f"({100 * (1 - self.fraction_filled):.2f}%); "
+            f"{self.n_filled} filled with '{self.fill_strategy}' "
+            f"({100 * self.fraction_filled:.2f}% of the feature matrix)"
+        )
+
+
+def snp_overlap_warnings(
+    report: SnpOverlapReport,
+    warn_fraction: float = WARN_FILL_FRACTION,
+) -> List[str]:
+    """Human-readable concerns about a `SnpOverlapReport`, worst first."""
+    warnings: List[str] = []
+    if report.n_model_snps <= 0:
+        return ["the model reports no SNPs, so nothing could be matched"]
+    if report.n_matched == 0:
+        warnings.append(
+            "the cohort matched NONE of the model's SNPs: every feature is "
+            "fill, so predictions describe the fill and not the samples. Check "
+            "chromosome naming and genome build against the reference panel."
+        )
+    elif report.fraction_filled >= warn_fraction:
+        warnings.append(
+            f"{100 * report.fraction_filled:.2f}% of the model's SNPs were "
+            f"absent from the cohort and filled with "
+            f"'{report.fill_strategy}'. Predictions are correspondingly "
+            f"driven by fill rather than by genotypes."
+        )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# 2. Do the two files even describe the same coordinate space?
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BimCompatibility:
+    """Whether two `.bim` files are talking about the same genome.
+
+    Produced when a variant match comes back small or empty, where the useful
+    answer is almost never "these cohorts differ" and almost always one of a
+    handful of clerical mismatches: `chr1` against `1`, hg19 against hg38, or a
+    file that is not the one intended.
+
+    Attributes:
+        n_variants: Variant counts, `(file1, file2)`.
+        shared_chroms: Chromosome names present in both.
+        only_in_1: Chromosome names unique to the first file (truncated).
+        only_in_2: Chromosome names unique to the second file (truncated).
+        position_ranges: Per shared chromosome, `(min1, max1, min2, max2)`.
+        hints: Ordered, plain-language explanations of what looks wrong.
+    """
+
+    n_variants: Tuple[int, int]
+    shared_chroms: Tuple[str, ...]
+    only_in_1: Tuple[str, ...]
+    only_in_2: Tuple[str, ...]
+    position_ranges: Dict[str, Tuple[int, int, int, int]] = field(
+        default_factory=dict
+    )
+    hints: Tuple[str, ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serializable form for the report."""
+        return {
+            "n_variants": [int(n) for n in self.n_variants],
+            "shared_chroms": list(self.shared_chroms),
+            "only_in_1": list(self.only_in_1),
+            "only_in_2": list(self.only_in_2),
+            "hints": list(self.hints),
+        }
+
+    def format_report(self) -> str:
+        """Multi-line text for a log or an exception message."""
+        lines = [
+            f"  variants:          {self.n_variants[0]} vs {self.n_variants[1]}",
+            f"  shared chroms:     {', '.join(self.shared_chroms) or '(none)'}",
+        ]
+        if self.only_in_1:
+            lines.append(f"  only in first:     {', '.join(self.only_in_1)}")
+        if self.only_in_2:
+            lines.append(f"  only in second:    {', '.join(self.only_in_2)}")
+        for chrom, (lo1, hi1, lo2, hi2) in sorted(self.position_ranges.items()):
+            lines.append(
+                f"  chr {chrom} positions: {lo1}-{hi1} vs {lo2}-{hi2}"
+            )
+        for hint in self.hints:
+            lines.append(f"  hint:              {hint}")
+        return "\n".join(lines)
+
+
+def _strip_chr(values: Sequence[str]) -> set:
+    return {str(v)[3:] if str(v).lower().startswith("chr") else str(v) for v in values}
+
+
+def bim_compatibility(
+    bim1: pd.DataFrame,
+    bim2: pd.DataFrame,
+    max_chroms_listed: int = 8,
+    max_ranges: int = 3,
+) -> BimCompatibility:
+    """Compare the coordinate spaces of two `.bim`-shaped frames.
+
+    Args:
+        bim1: Frame with `chr` and `pos` columns.
+        bim2: Frame with `chr` and `pos` columns.
+        max_chroms_listed: Cap on chromosome names reported per side.
+        max_ranges: Cap on per-chromosome position ranges reported.
+
+    Returns:
+        A `BimCompatibility` whose `hints` name the likely mismatch.
+    """
+    chroms1 = {str(c) for c in bim1["chr"].unique()}
+    chroms2 = {str(c) for c in bim2["chr"].unique()}
+    shared = sorted(chroms1 & chroms2)
+
+    hints: List[str] = []
+    if not shared:
+        if _strip_chr(chroms1) & _strip_chr(chroms2):
+            hints.append(
+                "chromosome naming differs ('chr1' vs '1'): the two files "
+                "share no chromosome name, but do once a 'chr' prefix is "
+                "stripped. Rename one side's contigs before matching."
+            )
+        else:
+            hints.append(
+                "no chromosome name is present in both files -- check that "
+                "both paths point at the intended data."
+            )
+
+    ranges: Dict[str, Tuple[int, int, int, int]] = {}
+    for chrom in shared[:max_ranges]:
+        p1 = bim1.loc[bim1["chr"].astype(str) == chrom, "pos"]
+        p2 = bim2.loc[bim2["chr"].astype(str) == chrom, "pos"]
+        if len(p1) and len(p2):
+            ranges[chrom] = (int(p1.min()), int(p1.max()), int(p2.min()), int(p2.max()))
+
+    if shared:
+        shared_positions = 0
+        for chrom in shared:
+            pos1 = set(bim1.loc[bim1["chr"].astype(str) == chrom, "pos"])
+            pos2 = set(bim2.loc[bim2["chr"].astype(str) == chrom, "pos"])
+            shared_positions += len(pos1 & pos2)
+        if shared_positions == 0:
+            hints.append(
+                "the files share chromosomes but not a single position, which "
+                "is what a genome-build mismatch looks like (hg19 vs hg38). "
+                "Lift one side over before matching."
+            )
+
+    return BimCompatibility(
+        n_variants=(len(bim1), len(bim2)),
+        shared_chroms=tuple(shared[:max_chroms_listed]),
+        only_in_1=tuple(sorted(chroms1 - chroms2)[:max_chroms_listed]),
+        only_in_2=tuple(sorted(chroms2 - chroms1)[:max_chroms_listed]),
+        position_ranges=ranges,
+        hints=tuple(hints),
+    )
+
+
+def is_low_overlap(
+    n_common: int,
+    n_variants: Tuple[int, int],
+    floor_fraction: float = LOW_OVERLAP_FRACTION,
+) -> bool:
+    """Whether a match is small enough to be a coordinate-space problem.
+
+    Measured against the *smaller* input: matching a 43k panel into a 1.9M
+    cohort legitimately keeps 43k, so a fraction of the larger side would call
+    every healthy run suspicious.
+    """
+    smaller = min(n for n in n_variants if n > 0) if any(n_variants) else 0
+    if smaller <= 0:
+        return True
+    return (n_common / smaller) < floor_fraction
+
+
+# ---------------------------------------------------------------------------
+# 3. Do matched sites agree on allele frequency?
+# ---------------------------------------------------------------------------
+
+
+def allele_frequency_concordance(
+    ref_dosages: pd.DataFrame,
+    geno_dosages: pd.DataFrame,
+    discordant_delta: float = DISCORDANT_FREQ_DELTA,
+    flip_tolerance: float = FLIP_SIGNATURE_TOLERANCE,
+) -> Dict[str, Any]:
+    """Compare per-SNP allele frequency between reference panel and cohort.
+
+    Both matrices count the same allele at the same sites by the time they
+    reach the model, so their frequencies should agree to within population
+    difference. They will not if the allele-switch step mis-oriented a site, and
+    a mis-oriented site has a signature worth naming: its cohort frequency sits
+    near `1 - ref_freq` rather than near `ref_freq`. That distinguishes a
+    strand/allele bug from a genuinely different population, which the
+    correlation alone does not.
+
+    Args:
+        ref_dosages: Reference matrix, samples x SNPs, values 0/1/2 (NaN ok).
+        geno_dosages: Cohort matrix over the same SNP columns.
+        discordant_delta: Frequency difference counted as discordant.
+        flip_tolerance: Closeness to `1 - ref_freq` counted as a swap.
+
+    Returns:
+        Dict with `n_snps`, `correlation`, `mean_abs_delta`, `n_discordant`,
+        `n_flip_signature` and their fractions. Empty overlap yields zeros and
+        a None correlation rather than an exception -- this is a diagnostic and
+        must never be the thing that fails a run.
+    """
+    # A cohort can carry the same site under several probe IDs; if two
+    # survived into the matrix, the second is not a second opinion worth
+    # averaging, and a duplicated label would break the alignment below.
+    geno_dosages = geno_dosages.loc[:, ~geno_dosages.columns.duplicated()]
+    ref_dosages = ref_dosages.loc[:, ~ref_dosages.columns.duplicated()]
+
+    shared = [c for c in ref_dosages.columns if c in set(geno_dosages.columns)]
+    if not shared:
+        return {
+            "n_snps": 0,
+            "correlation": None,
+            "mean_abs_delta": None,
+            "n_discordant": 0,
+            "fraction_discordant": None,
+            "n_flip_signature": 0,
+            "fraction_flip_signature": None,
+        }
+
+    ref_freq = ref_dosages[shared].mean(axis=0, skipna=True) / 2.0
+    geno_freq = geno_dosages[shared].mean(axis=0, skipna=True) / 2.0
+    usable = ref_freq.notna() & geno_freq.notna()
+    ref_freq, geno_freq = ref_freq[usable], geno_freq[usable]
+
+    n_snps = int(len(ref_freq))
+    if n_snps == 0:
+        correlation = None
+    elif ref_freq.std() == 0 or geno_freq.std() == 0:
+        # A constant column has no correlation to report; saying so beats
+        # emitting the NaN that pandas would.
+        correlation = None
+    else:
+        correlation = _f(ref_freq.corr(geno_freq))
+
+    delta = (geno_freq - ref_freq).abs()
+    discordant = delta > discordant_delta
+    flipped = discordant & ((geno_freq - (1.0 - ref_freq)).abs() <= flip_tolerance)
+
+    return {
+        "n_snps": n_snps,
+        "correlation": correlation,
+        "mean_abs_delta": _f(delta.mean()) if n_snps else None,
+        "n_discordant": int(discordant.sum()),
+        "fraction_discordant": _f(discordant.mean()) if n_snps else None,
+        "n_flip_signature": int(flipped.sum()),
+        "fraction_flip_signature": _f(flipped.mean()) if n_snps else None,
+    }
+
+
+def allele_frequency_warnings(
+    concordance: Dict[str, Any],
+    min_correlation: float = 0.7,
+    max_flip_fraction: float = 0.01,
+) -> List[str]:
+    """Concerns about an `allele_frequency_concordance` result."""
+    warnings: List[str] = []
+    if not concordance.get("n_snps"):
+        return warnings
+    corr = concordance.get("correlation")
+    if corr is not None and corr < min_correlation:
+        warnings.append(
+            f"panel/cohort allele frequencies correlate at only r={corr:.3f} "
+            f"across {concordance['n_snps']} matched SNPs; the match itself is "
+            f"suspect (wrong variant identity, or wrong file)."
+        )
+    flip_fraction = concordance.get("fraction_flip_signature")
+    if flip_fraction is not None and flip_fraction > max_flip_fraction:
+        warnings.append(
+            f"{100 * flip_fraction:.2f}% of matched SNPs have a cohort "
+            f"frequency near 1 - panel frequency, the signature of a "
+            f"reference-allele or strand swap rather than of population "
+            f"difference."
+        )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# 4. Where did the cohort land in PC space?
+# ---------------------------------------------------------------------------
+
+
+def pc_columns(frame: pd.DataFrame, n_pcs: Optional[int] = None) -> List[str]:
+    """PC column names in numeric order, optionally capped at `n_pcs`.
+
+    Selected by name rather than by dropping known ID columns: a frame carrying
+    an extra diagnostic column must not have it silently treated as a PC.
+    """
+    cols = [c for c in frame.columns if str(c).startswith("PC")]
+
+    def _index(name: str) -> int:
+        try:
+            return int(str(name)[2:])
+        except ValueError:
+            return 1 << 30
+
+    cols.sort(key=_index)
+    return cols[:n_pcs] if n_pcs else cols
+
+
+def pc_drift(
+    train_pca: pd.DataFrame,
+    projected: pd.DataFrame,
+    n_pcs: int = 10,
+) -> pd.DataFrame:
+    """Per-PC comparison of where the reference sits and where the cohort landed.
+
+    The reference PCA defines the space; the cohort is projected into it. Two
+    numbers say whether that projection is believable. `shift_sd` is how far the
+    cohort's centre sits from the reference's, in reference standard deviations
+    -- ancestry moves a cohort a fraction of an SD to a few SD, not tens.
+    `sd_ratio` is how much spread the cohort has relative to the reference; near
+    zero means the cohort collapsed to a point, which is what a constant fill
+    across most of the feature matrix produces.
+
+    Args:
+        train_pca: Reference PCA frame with PC columns.
+        projected: Cohort PCA frame with the same PC columns.
+        n_pcs: How many leading PCs to report.
+
+    Returns:
+        Frame with one row per PC: `pc`, `train_mean`, `train_sd`,
+        `cohort_mean`, `cohort_sd`, `shift_sd`, `sd_ratio`.
+    """
+    cols = [c for c in pc_columns(train_pca, n_pcs) if c in projected.columns]
+    rows = []
+    for col in cols:
+        t = pd.to_numeric(train_pca[col], errors="coerce")
+        c = pd.to_numeric(projected[col], errors="coerce")
+        t_sd = float(t.std())
+        rows.append(
+            {
+                "pc": col,
+                "train_mean": _f(t.mean()),
+                "train_sd": _f(t_sd),
+                "cohort_mean": _f(c.mean()),
+                "cohort_sd": _f(c.std()),
+                "shift_sd": _f((c.mean() - t.mean()) / t_sd) if t_sd else None,
+                "sd_ratio": _f(c.std() / t_sd) if t_sd else None,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def format_pc_drift(drift: pd.DataFrame) -> str:
+    """Fixed-width text table of a `pc_drift` frame, for the log."""
+    if drift.empty:
+        return "  (no PCs in common between reference and cohort)"
+    header = (
+        f"  {'PC':<5} {'ref mean':>12} {'ref sd':>10} "
+        f"{'cohort mean':>12} {'cohort sd':>10} {'shift (sd)':>11} {'sd ratio':>9}"
+    )
+    lines = [header, "  " + "-" * (len(header) - 2)]
+    for row in drift.itertuples(index=False):
+        def _fmt(value: Any, width: int, places: int = 3) -> str:
+            return f"{'n/a':>{width}}" if value is None else f"{value:>{width}.{places}f}"
+
+        lines.append(
+            f"  {row.pc:<5} {_fmt(row.train_mean, 12)} {_fmt(row.train_sd, 10)} "
+            f"{_fmt(row.cohort_mean, 12)} {_fmt(row.cohort_sd, 10)} "
+            f"{_fmt(row.shift_sd, 11, 2)} {_fmt(row.sd_ratio, 9, 2)}"
+        )
+    return "\n".join(lines)
+
+
+def pc_drift_warnings(
+    drift: pd.DataFrame,
+    max_shift_sd: float = WARN_PC_SHIFT_SD,
+    sd_ratio_range: Tuple[float, float] = WARN_PC_SD_RATIO,
+) -> List[str]:
+    """Concerns about a `pc_drift` frame, one line per offending PC."""
+    warnings: List[str] = []
+    low, high = sd_ratio_range
+    for row in drift.itertuples(index=False):
+        if row.shift_sd is not None and abs(row.shift_sd) > max_shift_sd:
+            warnings.append(
+                f"{row.pc}: the cohort centre sits {row.shift_sd:.1f} reference "
+                f"SD from the reference centre -- too far to be ancestry. The "
+                f"feature matrix handed to the projection is the thing to check."
+            )
+        if row.sd_ratio is None:
+            continue
+        if row.sd_ratio < low:
+            warnings.append(
+                f"{row.pc}: the cohort has {row.sd_ratio:.3f}x the reference's "
+                f"spread -- it has collapsed to a point, which is what a mostly "
+                f"filled feature matrix produces."
+            )
+        elif row.sd_ratio > high:
+            warnings.append(
+                f"{row.pc}: the cohort has {row.sd_ratio:.1f}x the reference's "
+                f"spread, so something other than ancestry dominates the "
+                f"projection."
+            )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# 5. What did the classifier say before the CAH override?
+# ---------------------------------------------------------------------------
+
+
+def admixture_summary(decisions: pd.DataFrame) -> Dict[str, Any]:
+    """Summarize the CAH override from a per-sample decision frame.
+
+    The override is the last thing to touch a label and it discards what the
+    classifier said, so an all-CAH run looks identical to a broken classifier
+    from the outside. Keeping both labels separates them: a sensible spread of
+    `label_pre_admixture` under an all-CAH `label` localizes the fault to the
+    override (or to the projection feeding it), not to the model.
+
+    Args:
+        decisions: Frame with `label_pre_admixture`, `label`, and the
+            `margin_to_all` written by `AncestryModel._predict_admixed`.
+
+    Returns:
+        Dict with the CAH count and fraction, the pre-override label counts,
+        the pre-to-post crosstab, and margin quantiles.
+    """
+    n_total = int(len(decisions))
+    if n_total == 0:
+        return {"n_samples": 0, "n_cah": 0, "fraction_cah": None}
+
+    final = decisions["label"].astype(str)
+    n_cah = int((final == "CAH").sum())
+
+    summary: Dict[str, Any] = {
+        "n_samples": n_total,
+        "n_cah": n_cah,
+        "fraction_cah": _f(n_cah / n_total),
+        "final_counts": {str(k): int(v) for k, v in final.value_counts().items()},
+    }
+
+    if "label_pre_admixture" in decisions.columns:
+        pre = decisions["label_pre_admixture"].astype(str)
+        summary["pre_admixture_counts"] = {
+            str(k): int(v) for k, v in pre.value_counts().items()
+        }
+        summary["overridden_from"] = {
+            str(k): int(v) for k, v in pre[final == "CAH"].value_counts().items()
+        }
+        summary["n_distinct_pre_admixture"] = int(pre.nunique())
+
+    if "margin_to_all" in decisions.columns:
+        margin = pd.to_numeric(decisions["margin_to_all"], errors="coerce").dropna()
+        if len(margin):
+            summary["margin_to_all_quantiles"] = {
+                q: _f(margin.quantile(v))
+                for q, v in (("p05", 0.05), ("p50", 0.5), ("p95", 0.95))
+            }
+    return summary
+
+
+def admixture_warnings(
+    summary: Dict[str, Any],
+    max_cah_fraction: float = WARN_CAH_FRACTION,
+) -> List[str]:
+    """Concerns about an `admixture_summary` result."""
+    warnings: List[str] = []
+    fraction = summary.get("fraction_cah")
+    if fraction is None or fraction <= max_cah_fraction:
+        return warnings
+
+    detail = ""
+    n_pre = summary.get("n_distinct_pre_admixture")
+    if n_pre and n_pre > 1:
+        detail = (
+            f" The classifier itself assigned {n_pre} distinct labels before "
+            f"the override, so the classifier is not the thing that failed -- "
+            f"check the projection and the SNP overlap above."
+        )
+    warnings.append(
+        f"{100 * fraction:.1f}% of samples were labeled CAH by admixture "
+        f"detection.{detail} Re-run with --no-admixture-detection to see the "
+        f"classifier's own labels."
+    )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Aggregate
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AncestryDiagnostics:
+    """Everything the instruments found, as one thing to hand to the report.
+
+    Assembled across two layers -- preprocessing owns the SNP overlap and the
+    allele frequencies, the model owns the PC drift and the override -- so it is
+    mutable and filled in as a run proceeds.
+    """
+
+    snp_overlap: Optional[SnpOverlapReport] = None
+    filled_snps_path: Optional[str] = None
+    allele_frequency: Optional[Dict[str, Any]] = None
+    pc_drift: Optional[pd.DataFrame] = None
+    admixture: Optional[Dict[str, Any]] = None
+    self_test: Optional[Dict[str, Any]] = None
+    plots: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def add_warnings(self, warnings: Sequence[str]) -> None:
+        """Record concerns, and log each one as a warning."""
+        for warning in warnings:
+            if warning not in self.warnings:
+                self.warnings.append(warning)
+                logger.warning(warning)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serializable form for the JSON report's `ancestry_diagnostics`."""
+        out: Dict[str, Any] = {}
+        if self.snp_overlap is not None:
+            out["snp_overlap"] = self.snp_overlap.to_dict()
+        if self.filled_snps_path:
+            out["filled_snps_path"] = self.filled_snps_path
+        if self.allele_frequency is not None:
+            out["allele_frequency"] = self.allele_frequency
+        if self.pc_drift is not None and not self.pc_drift.empty:
+            out["pc_drift"] = self.pc_drift.to_dict(orient="list")
+        if self.admixture is not None:
+            out["admixture"] = self.admixture
+        if self.self_test is not None:
+            out["self_test"] = self.self_test
+        if self.plots:
+            out["plots"] = list(self.plots)
+        out["warnings"] = list(self.warnings)
+        return out

--- a/genotools/ancestry/model.py
+++ b/genotools/ancestry/model.py
@@ -61,6 +61,8 @@ from genotools.ancestry.config import (
     InferenceMode,
     PCAConfig,
 )
+from genotools.ancestry import diagnostics as diagnostics_mod
+from genotools.ancestry.diagnostics import AncestryDiagnostics
 from genotools.ancestry.reducers.pca import PCAReducer
 from genotools.ancestry.reducers.umap_reducer import UMAPReducer
 from genotools.ancestry.results import (
@@ -388,18 +390,29 @@ class AncestryModel:
         self,
         projected: pd.DataFrame,
         train_pca: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """Identify samples with complex admixture history.
 
         Samples closest to the global centroid rather than any specific
         ancestry centroid are classified as CAH (Complex Admixture History).
+
+        This is the last thing to touch a label and it *discards* what the
+        classifier said, so the second return value keeps the working: both
+        labels, every centroid distance, and the margin the decision turned on.
+        Without it an all-CAH run is indistinguishable from a broken
+        classifier, which is the case that prompted this.
 
         Args:
             projected: DataFrame with projected samples (PCs + predicted label).
             train_pca: DataFrame with training PCA data and labels.
 
         Returns:
-            Updated projected DataFrame with CAH labels.
+            Tuple of `(labeled, decisions)`. `labeled` is the projected frame
+            with CAH labels applied -- unchanged from before this round.
+            `decisions` is one row per sample: `FID`, `IID`,
+            `label_pre_admixture`, `label`, `nearest_centroid`,
+            `dist_to_all`, `nearest_ancestry`, `dist_to_nearest_ancestry`,
+            `margin_to_all`, and a `dist_<centroid>` column per centroid.
         """
         # Copy training data for admixture calculation
         train_pca_admix = train_pca.copy()
@@ -468,7 +481,28 @@ class AncestryModel:
             projected_ids["label"],
         )
 
-        return result
+        # The same decision, with its inputs kept. `margin_to_all` restates the
+        # CAH rule as a single signed number: negative means the global
+        # centroid won, so negative is CAH. A cohort clustered just left of
+        # zero is a threshold question; one far to the left is a projection
+        # question.
+        ancestry_cols = [c for c in distance_cols if c != "ALL"]
+        decisions = projected_ids[["FID", "IID"]].reset_index(drop=True).copy()
+        decisions["label_pre_admixture"] = projected_ids["label"].values
+        decisions["label"] = result["label"].values
+        decisions["nearest_centroid"] = projected_pcs["min_distance_ancestry"].values
+        decisions["dist_to_all"] = projected_pcs["ALL"].values
+        if ancestry_cols:
+            ancestry_dist = projected_pcs[ancestry_cols]
+            decisions["nearest_ancestry"] = ancestry_dist.idxmin(axis=1).values
+            decisions["dist_to_nearest_ancestry"] = ancestry_dist.min(axis=1).values
+            decisions["margin_to_all"] = (
+                decisions["dist_to_all"] - decisions["dist_to_nearest_ancestry"]
+            )
+        for centroid in distance_cols:
+            decisions[f"dist_{centroid}"] = projected_pcs[centroid].values
+
+        return result, decisions
 
     def fit(
         self,
@@ -542,6 +576,9 @@ class AncestryModel:
         geno_ids: pd.DataFrame,
         out_path: Optional[Path] = None,
         detect_admixed: bool = True,
+        diagnostics: Optional[AncestryDiagnostics] = None,
+        diagnostics_prefix: Optional[str] = None,
+        collect_diagnostics: bool = True,
     ) -> AncestryPredictions:
         """Predict ancestry for new samples.
 
@@ -550,9 +587,19 @@ class AncestryModel:
             geno_ids: DataFrame with FID, IID columns.
             out_path: Optional path for saving outputs.
             detect_admixed: Whether to detect admixed samples. Default True.
+            diagnostics: Collector to record PC drift and the admixture
+                decision into. Created if not supplied.
+            diagnostics_prefix: Prefix for the per-sample decision file.
+                Defaults to `out_path`; the runner passes the final output
+                prefix so the file survives a partial-output run.
+            collect_diagnostics: Whether to measure and report at all. False
+                for the reference-panel self-test, which calls this method
+                about data whose drift against itself means nothing.
 
         Returns:
-            AncestryPredictions with predicted ancestries.
+            AncestryPredictions with predicted ancestries, and -- when
+            diagnostics are collected -- the per-sample admixture decisions and
+            the findings.
 
         Raises:
             AncestryError: If model not fitted or prediction fails.
@@ -587,11 +634,15 @@ class AncestryModel:
         projected["label"] = y_pred
 
         # Detect admixed samples if requested
+        decisions: Optional[pd.DataFrame] = None
         if detect_admixed and self._train_pca is not None:
-            projected = self._predict_admixed(projected, self._train_pca)
+            projected, decisions = self._predict_admixed(projected, self._train_pca)
             y_pred = projected["label"].values
 
-        # Save outputs if path provided
+        # Save outputs if path provided. `_projected_new_pca.txt` keeps exactly
+        # the columns it always had: run_umap treats every column it does not
+        # recognise as a feature, so a diagnostic column added here would
+        # silently enter the embedding. The diagnostics get their own file.
         output_path = None
         if out_path:
             output_path = Path(f"{out_path}_umap_linearsvc_predicted_labels.txt")
@@ -608,10 +659,166 @@ class AncestryModel:
 
         logger.info(f"Predicted ancestry counts: {pd.Series(y_pred).value_counts().to_dict()}")
 
+        if collect_diagnostics:
+            diagnostics = diagnostics if diagnostics is not None else AncestryDiagnostics()
+            self._report_prediction_diagnostics(
+                diagnostics=diagnostics,
+                projected=projected,
+                decisions=decisions,
+                prefix=str(diagnostics_prefix or out_path) if (diagnostics_prefix or out_path) else None,
+            )
+
         return AncestryPredictions(
             predictions=predictions_df,
             output_path=output_path,
+            decisions=decisions,
+            diagnostics=diagnostics if collect_diagnostics else None,
         )
+
+    def _report_prediction_diagnostics(
+        self,
+        diagnostics: AncestryDiagnostics,
+        projected: pd.DataFrame,
+        decisions: Optional[pd.DataFrame],
+        prefix: Optional[str],
+    ) -> None:
+        """Measure where the cohort landed, and what the CAH rule did to it.
+
+        Both questions are answered against the reference the cohort is being
+        compared to, so both need `_train_pca` -- a model saved without it can
+        still predict, and then simply has less to say.
+        """
+        if self._train_pca is not None:
+            drift = diagnostics_mod.pc_drift(self._train_pca, projected)
+            diagnostics.pc_drift = drift
+            logger.info(
+                "Cohort position in reference PC space:\n"
+                + diagnostics_mod.format_pc_drift(drift)
+            )
+            diagnostics.add_warnings(diagnostics_mod.pc_drift_warnings(drift))
+
+        if decisions is None or decisions.empty:
+            return
+
+        summary = diagnostics_mod.admixture_summary(decisions)
+        diagnostics.admixture = summary
+        logger.info(
+            f"Admixture detection: {summary['n_cah']}/{summary['n_samples']} "
+            f"labeled CAH; classifier labels before the override: "
+            f"{summary.get('pre_admixture_counts')}"
+        )
+        diagnostics.add_warnings(diagnostics_mod.admixture_warnings(summary))
+
+        if prefix:
+            decisions_path = f"{prefix}_decisions.txt"
+            decisions.to_csv(decisions_path, sep="\t", index=False)
+            logger.info(f"Per-sample ancestry decisions written to: {decisions_path}")
+
+    def self_test(
+        self,
+        labeled_ref_data: pd.DataFrame,
+        detect_admixed: bool = True,
+    ) -> Dict[str, Any]:
+        """Positive control: predict the reference panel's own ancestries.
+
+        Training accuracy is measured inside `fit`, on features built by the
+        training branch of `get_raw_files`. This instead pushes the reference
+        panel through `predict` -- the same PCA projection, classifier and CAH
+        override a cohort goes through -- and checks the labels against the
+        panel's own. It is the one measurement that separates "the model is
+        broken" from "the cohort never reached the model": a panel that
+        predicts itself correctly here leaves only the cohort's own
+        preprocessing to blame.
+
+        Accuracy is optimistic by construction -- most of these samples were
+        fitted on -- so it is a floor, not an estimate. The `cah_fraction` is
+        the load-bearing number: the reference panel defines the ancestry
+        centroids, so almost none of it should fall nearer the global centroid
+        than to any of them. A panel that comes back largely CAH indicts the
+        override, whatever the cohort looks like.
+
+        Args:
+            labeled_ref_data: Reference matrix from `get_raw_files`
+                (`FID`, `IID`, model SNPs, `label`).
+            detect_admixed: Whether to apply the CAH override, so the test can
+                measure it.
+
+        Returns:
+            Dict with sample count, balanced accuracy before and after the
+            override, the CAH fraction overall and per true label, and the
+            most common confusions.
+        """
+        from sklearn.metrics import balanced_accuracy_score
+
+        labeled = labeled_ref_data[labeled_ref_data["label"].notna()]
+        if labeled.empty:
+            return {"n_samples": 0, "error": "no labeled reference samples"}
+
+        truth = labeled["label"].astype(str).reset_index(drop=True)
+        ids = labeled[["FID", "IID"]].reset_index(drop=True)
+        features = labeled.drop(columns=["label"]).reset_index(drop=True)
+
+        predictions = self.predict(
+            features,
+            ids,
+            out_path=None,
+            detect_admixed=detect_admixed,
+            collect_diagnostics=False,
+        )
+        final = predictions.predictions["predicted_ancestry"].astype(str).reset_index(drop=True)
+        if predictions.decisions is not None:
+            pre = predictions.decisions["label_pre_admixture"].astype(str).reset_index(drop=True)
+        else:
+            pre = final
+
+        is_cah = final == "CAH"
+        confusions = (
+            pd.DataFrame({"truth": truth, "predicted": final})
+            .loc[truth != final]
+            .value_counts()
+            .head(5)
+        )
+
+        result: Dict[str, Any] = {
+            "n_samples": int(len(truth)),
+            "n_labels": int(truth.nunique()),
+            "balanced_accuracy_pre_admixture": float(
+                balanced_accuracy_score(truth, pre)
+            ),
+            "balanced_accuracy": float(balanced_accuracy_score(truth, final)),
+            "n_cah": int(is_cah.sum()),
+            "cah_fraction": float(is_cah.mean()),
+            "cah_fraction_by_label": {
+                str(label): float(is_cah[truth == label].mean())
+                for label in sorted(truth.unique())
+            },
+            "top_confusions": {
+                f"{t}->{pred}": int(count)
+                for (t, pred), count in confusions.items()
+            },
+        }
+        logger.info(
+            f"Reference-panel self-test on {result['n_samples']} samples: "
+            f"balanced accuracy {result['balanced_accuracy']:.4f} "
+            f"({result['balanced_accuracy_pre_admixture']:.4f} before the CAH "
+            f"override), CAH {100 * result['cah_fraction']:.2f}%"
+        )
+        if result["cah_fraction"] > diagnostics_mod.WARN_CAH_FRACTION:
+            logger.warning(
+                f"The reference panel itself comes back "
+                f"{100 * result['cah_fraction']:.1f}% CAH. The panel defines "
+                f"the ancestry centroids, so this is the admixture detection "
+                f"or the projection failing, not the cohort."
+            )
+        elif result["balanced_accuracy"] < 0.5:
+            logger.warning(
+                f"The reference panel predicts itself at only "
+                f"{result['balanced_accuracy']:.3f} balanced accuracy through "
+                f"the prediction path, despite being what the model was fitted "
+                f"on. The fault is in the model or its saved state, not in the "
+                f"cohort."
+            )
+        return result
 
     def save(self, path: Path) -> Path:
         """Save fitted model to a directory.

--- a/genotools/ancestry/plots.py
+++ b/genotools/ancestry/plots.py
@@ -1,0 +1,239 @@
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Diagnostic plots for an ancestry run.
+
+The numbers in `diagnostics.py` fire on their own and land in the log and the
+report; these pictures are for the case where they have already told you
+*something* is wrong and you want to see *what*. A cohort projected onto its
+reference panel shows in one glance what a table of standard deviations only
+implies: whether it lands inside the reference cloud, beside it, or collapsed
+into a single point somewhere off the edge.
+
+Opt-in via `--ancestry-plots`, because these are binary artifacts and every
+other output of a run is text.
+"""
+
+from pathlib import Path
+from typing import List, Optional
+
+import pandas as pd
+
+from genotools.core.logging import get_logger
+from genotools.ancestry.diagnostics import pc_columns
+
+logger = get_logger(__name__)
+
+def _cohort_style(n_samples: int) -> dict:
+    """Marker styling for the cohort overlay, thinned by cohort size.
+
+    The overlay's job is to show *where* the cohort sits relative to the
+    reference, which it stops doing once it paints over it: 10,000 points at a
+    fixed alpha turn every dense region into one black blob and hide the
+    coloured panel underneath. Alpha and size fall with n so a large cohort
+    reads as shading over a visible reference rather than as a silhouette.
+    """
+    alpha = min(0.35, max(0.04, 1500 / max(n_samples, 1)))
+    return dict(
+        color="black",
+        marker="x",
+        s=12 if n_samples <= 2000 else 6,
+        alpha=alpha,
+        linewidths=0.5,
+    )
+
+
+def _pyplot():
+    """Import pyplot against a non-interactive backend, or return None.
+
+    Matplotlib is a hard dependency, but a run must not die because a plotting
+    backend is unhappy on some cluster node -- the plots are the least load-
+    bearing output of the pipeline.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+
+        return plt
+    except Exception as exc:  # pragma: no cover - environment-specific
+        logger.warning(f"Diagnostic plots skipped: matplotlib unavailable ({exc})")
+        return None
+
+
+def plot_pca_projection(
+    train_pca: pd.DataFrame,
+    projected: pd.DataFrame,
+    out_path: Path,
+    pc_pairs: Optional[List[tuple]] = None,
+) -> Optional[Path]:
+    """Reference PCA coloured by ancestry, with the cohort overlaid.
+
+    Args:
+        train_pca: Reference PCA frame with PC columns and a `label` column.
+        projected: Cohort PCA frame with the same PC columns.
+        out_path: PNG path to write.
+        pc_pairs: `(x, y)` PC index pairs. Default is the three leading pairs,
+            which is where ancestry structure lives.
+
+    Returns:
+        The path written, or None if nothing could be plotted.
+    """
+    plt = _pyplot()
+    if plt is None:
+        return None
+
+    available = [c for c in pc_columns(train_pca) if c in projected.columns]
+    if len(available) < 2:
+        logger.warning("Diagnostic plots skipped: fewer than 2 shared PCs")
+        return None
+
+    pc_pairs = pc_pairs or [(1, 2), (2, 3), (3, 4)]
+    pairs = [
+        (f"PC{x}", f"PC{y}")
+        for x, y in pc_pairs
+        if f"PC{x}" in available and f"PC{y}" in available
+    ]
+    if not pairs:
+        pairs = [(available[0], available[1])]
+
+    fig, axes = plt.subplots(1, len(pairs), figsize=(5.2 * len(pairs), 4.8))
+    axes = [axes] if len(pairs) == 1 else list(axes)
+
+    labels = (
+        sorted(train_pca["label"].astype(str).unique())
+        if "label" in train_pca.columns
+        else []
+    )
+    colors = plt.get_cmap("tab20")
+
+    for ax, (xcol, ycol) in zip(axes, pairs):
+        if labels:
+            for i, label in enumerate(labels):
+                subset = train_pca[train_pca["label"].astype(str) == label]
+                ax.scatter(
+                    subset[xcol], subset[ycol],
+                    s=6, alpha=0.5, color=colors(i % 20), label=label,
+                )
+        else:
+            ax.scatter(train_pca[xcol], train_pca[ycol], s=6, alpha=0.5, color="lightgray")
+        ax.scatter(
+            projected[xcol], projected[ycol], label="cohort",
+            **_cohort_style(len(projected)),
+        )
+        ax.set_xlabel(xcol)
+        ax.set_ylabel(ycol)
+
+    axes[0].set_title("reference panel (colour) vs projected cohort (black x)", loc="left")
+    handles, legend_labels = axes[0].get_legend_handles_labels()
+    fig.legend(
+        handles, legend_labels, loc="center left", bbox_to_anchor=(1.0, 0.5),
+        frameon=False, fontsize="small",
+    )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def plot_centroid_distances(
+    decisions: pd.DataFrame,
+    out_path: Path,
+) -> Optional[Path]:
+    """How close each sample came to being called CAH.
+
+    `margin_to_all` is the distance to the global centroid minus the distance
+    to the nearest ancestry centroid, so the CAH rule is exactly "margin below
+    zero". Plotting the distribution against that line shows whether an all-CAH
+    result was a near-miss (the cohort sitting on the boundary) or a rout (the
+    whole cohort far to the left of it, which means the projection, not the
+    threshold).
+
+    Args:
+        decisions: Per-sample frame from `AncestryModel._predict_admixed`.
+        out_path: PNG path to write.
+
+    Returns:
+        The path written, or None if there was nothing to plot.
+    """
+    plt = _pyplot()
+    if plt is None or "margin_to_all" not in decisions.columns:
+        return None
+
+    margin = pd.to_numeric(decisions["margin_to_all"], errors="coerce").dropna()
+    if margin.empty:
+        return None
+
+    fig, (ax_margin, ax_counts) = plt.subplots(1, 2, figsize=(11, 4.2))
+
+    ax_margin.hist(margin, bins=60, color="steelblue", alpha=0.85)
+    ax_margin.axvline(0.0, color="crimson", linestyle="--", linewidth=1.2)
+    ax_margin.set_xlabel("distance to ALL centroid - distance to nearest ancestry")
+    ax_margin.set_ylabel("samples")
+    n_cah = int((margin < 0).sum())
+    ax_margin.set_title(
+        f"left of the red line is CAH: {n_cah}/{len(margin)} samples "
+        f"({100 * n_cah / len(margin):.1f}%)",
+        loc="left", fontsize="medium",
+    )
+
+    counts = decisions["label"].astype(str).value_counts()
+    ax_counts.barh(list(counts.index)[::-1], list(counts.values)[::-1], color="slategray")
+    ax_counts.set_xlabel("samples")
+    ax_counts.set_title("final labels", loc="left", fontsize="medium")
+
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+    return out_path
+
+
+def plot_ancestry_diagnostics(
+    train_pca: Optional[pd.DataFrame],
+    projected: Optional[pd.DataFrame],
+    out_prefix: str,
+    decisions: Optional[pd.DataFrame] = None,
+) -> List[str]:
+    """Write every diagnostic plot available for a run.
+
+    Args:
+        train_pca: Reference PCA frame, or None if the run has none.
+        projected: Cohort PCA frame, or None.
+        out_prefix: Path prefix; each plot appends its own suffix.
+        decisions: Per-sample admixture decisions, if detection ran.
+
+    Returns:
+        Paths written, as strings, for the report.
+    """
+    written: List[str] = []
+
+    if train_pca is not None and projected is not None:
+        path = plot_pca_projection(
+            train_pca, projected, Path(f"{out_prefix}_pca_diagnostic.png")
+        )
+        if path is not None:
+            written.append(str(path))
+
+    if decisions is not None and not decisions.empty:
+        path = plot_centroid_distances(
+            decisions, Path(f"{out_prefix}_centroid_distance.png")
+        )
+        if path is not None:
+            written.append(str(path))
+
+    if written:
+        logger.info(f"Diagnostic plots written: {', '.join(written)}")
+    return written

--- a/genotools/ancestry/preprocessing.py
+++ b/genotools/ancestry/preprocessing.py
@@ -1,17 +1,38 @@
 """Ancestry PLINK preprocessing (legacy-free port of the Ancestry helpers).
 
 Ports of legacy Ancestry.get_raw_files / clean_up and utils.get_common_snps,
-using core.executors. `get_raw_files` output is identical to the legacy version
-(proven by differential tests). `get_common_snps` deliberately diverges: it
-excludes palindromic sites and breaks position ties by missingness, both of
-which the legacy version got wrong. See the helpers below.
+using core.executors. `get_raw_files` deliberately diverges from the legacy
+version in one place -- how it fills SNPs the cohort does not carry, see
+`MISSING_FILL_STRATEGIES` -- and is otherwise identical to it (proven by
+differential tests). `get_common_snps` diverges too: it excludes palindromic
+sites and breaks position ties by missingness, both of which the legacy version
+got wrong. See the helpers below.
+
+This is also where the ancestry run's diagnostics start: the two questions this
+module can answer that no later stage can -- how much of the model's SNP list
+the cohort actually carried, and whether the matched sites agree on allele
+frequency -- are recorded into an `AncestryDiagnostics` here and carried
+through to the report.
 """
 
 import os
+from typing import Optional
 
 import numpy as np
 import pandas as pd
 
+from genotools.ancestry.config import LEGACY_FILL_VALUE, MISSING_FILL_STRATEGIES
+from genotools.ancestry.diagnostics import (
+    AncestryDiagnostics,
+    DEFAULT_MAX_FILL_FRACTION,
+    SnpOverlapReport,
+    allele_frequency_concordance,
+    allele_frequency_warnings,
+    bim_compatibility,
+    is_low_overlap,
+    snp_overlap_warnings,
+)
+from genotools.core.exceptions import AncestryError
 from genotools.core.executors import run_command, get_plink, get_plink2
 from genotools.core.logging import get_logger
 
@@ -96,6 +117,42 @@ def _select_one_per_position(common_snps: pd.DataFrame, geno_path1: str) -> pd.D
     )
 
 
+def _check_overlap(
+    common_snps: pd.DataFrame,
+    bim1: pd.DataFrame,
+    bim2: pd.DataFrame,
+    geno_path1: str,
+    geno_path2: str,
+) -> None:
+    """Fail loudly when two files barely match, and say why they might not.
+
+    A near-empty match is almost never two cohorts genuinely differing. It is
+    `chr1` against `1`, hg19 against hg38, or a path pointing at the wrong
+    file -- and none of those are visible downstream, where the symptom is
+    instead a feature matrix made mostly of fill and a cohort that predicts one
+    label. `bim_compatibility` names the mismatch; this decides whether to warn
+    or to stop.
+
+    Zero overlap raises: `plink2 --extract` on an empty list fails anyway, with
+    a message about a file rather than about the genome.
+    """
+    n_common = len(common_snps)
+    n_variants = (len(bim1), len(bim2))
+    if not is_low_overlap(n_common, n_variants):
+        return
+
+    compat = bim_compatibility(bim1, bim2)
+    if n_common == 0:
+        raise AncestryError(
+            f"No common variants between {geno_path1} and {geno_path2}.\n"
+            f"{compat.format_report()}"
+        )
+    logger.warning(
+        f"Only {n_common} variant(s) are common to {geno_path1} and "
+        f"{geno_path2}:\n{compat.format_report()}"
+    )
+
+
 def get_common_snps(geno_path1: str, geno_path2: str, out_name: str) -> dict:
     """Extract SNPs common to two bfiles from geno_path1. Returns output paths."""
     logger.info("Getting Common SNPs")
@@ -139,6 +196,7 @@ def get_common_snps(geno_path1: str, geno_path2: str, out_name: str) -> dict:
 
     common_snps = pd.concat([common_snps, common_snps1, common_snps2], axis=0)
     common_snps = _select_one_per_position(common_snps, geno_path1)
+    _check_overlap(common_snps, bim1, bim2, geno_path1, geno_path2)
 
     common_snps_file = f"{out_name}.common_snps"
     common_snps["rsid_y"].to_csv(f"{common_snps_file}", sep="\t", header=False, index=False)
@@ -168,15 +226,57 @@ def get_raw_files(
     out_path: str,
     train: bool,
     common_snps_file: str | None = None,
+    fill_strategy: str = "ref-mean",
+    max_missing_fraction: float = DEFAULT_MAX_FILL_FRACTION,
+    diagnostics: Optional[AncestryDiagnostics] = None,
+    diagnostics_prefix: Optional[str] = None,
 ) -> dict:
     """Process reference + genotype data into labeled raw feature matrices.
 
-    Faithful port of legacy Ancestry.get_raw_files (train + model-inference
-    branches; containerized branch intentionally omitted). In inference mode,
-    pass the model's common-SNP list path via `common_snps_file`.
+    Port of legacy Ancestry.get_raw_files (train + model-inference branches;
+    containerized branch intentionally omitted). In inference mode, pass the
+    model's common-SNP list path via `common_snps_file`.
+
+    Args:
+        geno_path: Cohort pfile prefix.
+        ref_panel: Reference panel bfile prefix.
+        ref_labels: TSV of `FID IID label` for the reference panel.
+        out_path: Output prefix for intermediate files.
+        train: Whether to derive the common-SNP list (True) or take it from a
+            saved model (False).
+        common_snps_file: The model's common-SNP list. Required when
+            `train` is False.
+        fill_strategy: How to fill a model SNP the cohort does not carry. One
+            of `MISSING_FILL_STRATEGIES`.
+        max_missing_fraction: Refuse to build the matrix when more than this
+            share of the model's SNPs had to be filled. A label predicted from
+            mostly-filled features describes the fill.
+        diagnostics: Collector to record the SNP overlap and allele-frequency
+            findings into. One is created if not supplied, and returned either
+            way.
+        diagnostics_prefix: Prefix for diagnostic artifacts the user keeps.
+            Defaults to `out_path`, which for a partial-output run is a
+            temporary directory -- the runner passes the final output prefix so
+            the evidence outlives the run that produced it.
+
+    Returns:
+        Dict with `raw_ref`, `raw_geno`, `out_paths` and `diagnostics`.
+
+    Raises:
+        AncestryError: If `fill_strategy` is unknown, or if the cohort matched
+            too little of the model's SNP list to predict from.
+        FileNotFoundError: If an expected PLINK output is missing.
     """
+    if fill_strategy not in MISSING_FILL_STRATEGIES:
+        raise AncestryError(
+            f"Unknown fill strategy {fill_strategy!r}; expected one of "
+            f"{', '.join(MISSING_FILL_STRATEGIES)}"
+        )
+
     plink2 = get_plink2()
     out_paths = {}
+    diagnostics = diagnostics if diagnostics is not None else AncestryDiagnostics()
+    diagnostics_prefix = diagnostics_prefix or out_path
 
     # variant prune geno before getting common snps
     geno_prune_path = f"{out_path}_variant_pruned"
@@ -269,14 +369,73 @@ def get_raw_files(
     geno_snps = raw_geno.drop(columns=["FID", "IID", "PAT", "MAT", "SEX", "PHENOTYPE"])
     geno_snps.columns = geno_snps.columns.str.extract("(.*)_")[0]
 
-    # adding missing snps when not training
-    missing_cols = []
+    # Do the panel and the cohort agree about the sites they matched? Asked
+    # before any fill, so the answer is about real genotypes only. Both
+    # matrices count the same allele by this point, so disagreement here is a
+    # matching or orientation fault, not population difference.
+    concordance = allele_frequency_concordance(ref_snps, geno_snps)
+    diagnostics.allele_frequency = concordance
+    correlation = concordance["correlation"]
+    logger.info(
+        f"Panel/cohort allele-frequency concordance over "
+        f"{concordance['n_snps']} matched SNP(s): "
+        f"r={'n/a' if correlation is None else f'{correlation:.4f}'}, "
+        f"{concordance['n_discordant']} discordant, "
+        f"{concordance['n_flip_signature']} with a swap signature"
+    )
+    diagnostics.add_warnings(allele_frequency_warnings(concordance))
+
+    # Adding missing snps when not training. The model's feature matrix has a
+    # fixed width and order, so a SNP the cohort does not carry has to be
+    # invented -- and how much of the matrix was invented is the number that
+    # separates "the model is wrong about this cohort" from "the model was
+    # never shown this cohort". Recorded, warned about, and above a threshold
+    # refused, because none of it is visible in a predicted label.
     if not train:
-        for col in ref_snps.columns:
-            if col not in geno_snps.columns:
-                missing_cols += [pd.Series(np.repeat(2, geno_snps.shape[0]), name=col)]
-        if len(missing_cols) > 0:
-            missing_cols = pd.concat(missing_cols, axis=1)
+        absent = [col for col in ref_snps.columns if col not in set(geno_snps.columns)]
+        overlap = SnpOverlapReport(
+            n_model_snps=len(ref_snps.columns),
+            n_matched=len(ref_snps.columns) - len(absent),
+            fill_strategy=fill_strategy,
+            filled_snps=tuple(absent),
+        )
+        diagnostics.snp_overlap = overlap
+        logger.info(f"Model SNP overlap: {overlap.format_summary()}")
+
+        if absent:
+            filled_path = f"{diagnostics_prefix}_filled_snps.txt"
+            with open(filled_path, "w") as handle:
+                for snp in absent:
+                    handle.write(f"{snp}\n")
+            diagnostics.filled_snps_path = filled_path
+            logger.info(f"Filled SNP IDs written to: {filled_path}")
+
+        diagnostics.add_warnings(snp_overlap_warnings(overlap))
+        if overlap.fraction_filled > max_missing_fraction:
+            raise AncestryError(
+                f"The cohort carries only {overlap.n_matched} of the model's "
+                f"{overlap.n_model_snps} SNPs, so "
+                f"{100 * overlap.fraction_filled:.2f}% of the feature matrix "
+                f"would be fill -- above the "
+                f"{100 * max_missing_fraction:.0f}% limit. A label predicted "
+                f"from that describes the fill, not the sample. Check that the "
+                f"cohort and the reference panel share a genome build and "
+                f"chromosome naming; the matched and filled SNPs are listed "
+                f"beside this run. Raise --ancestry-max-missing-snps to "
+                f"predict anyway."
+            )
+
+        if absent:
+            # ``constant`` reproduces 1.x exactly, int dosages included;
+            # ``ref-mean`` writes NaN for PCAReducer's reference-fitted imputer
+            # to fill. See MISSING_FILL_STRATEGIES.
+            if fill_strategy == "constant":
+                fill = np.repeat(LEGACY_FILL_VALUE, geno_snps.shape[0])
+            else:
+                fill = np.full(geno_snps.shape[0], np.nan)
+            missing_cols = pd.DataFrame(
+                {col: fill for col in absent}, index=geno_snps.index
+            )
             geno_snps = pd.concat([geno_snps, missing_cols], axis=1)
         geno_snps = geno_snps[ref_snps.columns]
 
@@ -293,4 +452,5 @@ def get_raw_files(
         "raw_ref": labeled_ref_raw,
         "raw_geno": raw_geno,
         "out_paths": out_paths,
+        "diagnostics": diagnostics,
     }

--- a/genotools/ancestry/reducers/umap_reducer.py
+++ b/genotools/ancestry/reducers/umap_reducer.py
@@ -205,6 +205,13 @@ class UMAPReducer:
         return cls(config=config)
 
 
+def _pc_names(frame: pd.DataFrame) -> list:
+    """PC columns of `frame` in numeric order, or empty if it names none."""
+    from genotools.ancestry.diagnostics import pc_columns
+
+    return pc_columns(frame)
+
+
 def run_umap(
     ref_pca: pd.DataFrame,
     new_pca: pd.DataFrame,
@@ -234,14 +241,27 @@ def run_umap(
             - new_umap: DataFrame with new samples UMAP + labels + dataset='predicted'
             - total_umap: DataFrame with combined ref + new UMAP
     """
+    # Select the PCs by name rather than by dropping the columns we know
+    # about. Dropping treats anything unrecognised as a feature, so a single
+    # extra column written into `_projected_new_pca.txt` -- a distance, a
+    # second label, anything a later diagnostic wants to record -- would enter
+    # the embedding silently and move every point. Falls back to the old
+    # behaviour for a frame that names its components something else.
+    ref_features = _pc_names(ref_pca) or [
+        c for c in ref_pca.columns if c not in ("FID", "IID", "label")
+    ]
+    new_features = _pc_names(new_pca) or [
+        c for c in new_pca.columns if c not in ("FID", "IID", "label")
+    ]
+
     # Get reference data without IDs and labels
     ref_labels = ref_pca["label"].values
     ref_ids = ref_pca[["FID", "IID"]]
-    X_ref = ref_pca.drop(columns=["FID", "IID", "label"]).values
+    X_ref = ref_pca[ref_features].values
 
     # Get new sample data without IDs
     new_ids = new_pca[["FID", "IID"]]
-    X_new = new_pca.drop(columns=["FID", "IID", "label"], errors="ignore").values
+    X_new = new_pca[new_features].values
 
     # Create reducer
     if params is not None:

--- a/genotools/ancestry/results.py
+++ b/genotools/ancestry/results.py
@@ -36,6 +36,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from genotools.ancestry.diagnostics import AncestryDiagnostics
+
 
 @dataclass
 class AncestryPredictions:
@@ -56,11 +58,19 @@ class AncestryPredictions:
         probabilities: Optional DataFrame with per-class prediction
             probabilities. Columns are ancestry labels, rows are samples.
         output_path: Path where predictions were saved, if any.
+        decisions: Optional per-sample admixture-detection working: the label
+            the classifier assigned, the label after the CAH override, and the
+            centroid distances the override turned on. None when detection did
+            not run. See `AncestryModel._predict_admixed`.
+        diagnostics: Optional `AncestryDiagnostics` for the run. Kept off the
+            predictions frame because it is per-run, not per-sample.
     """
 
     predictions: pd.DataFrame
     probabilities: Optional[pd.DataFrame] = None
     output_path: Optional[Path] = None
+    decisions: Optional[pd.DataFrame] = None
+    diagnostics: Optional["AncestryDiagnostics"] = None
 
     def __post_init__(self) -> None:
         """Validate predictions DataFrame."""

--- a/genotools/cli/output.py
+++ b/genotools/cli/output.py
@@ -94,6 +94,10 @@ class PipelineOutput:
         input_samples: DataFrame of input samples.
         ancestry_counts: Ancestry prediction counts.
         ancestry_labels: Per-sample ancestry labels.
+        ancestry_diagnostics: What the prediction path measured about itself -
+            SNP overlap with the model, allele-frequency concordance, where the
+            cohort landed in reference PC space, and what the CAH override did.
+            See ancestry/diagnostics.py.
         confusion_matrix: Ancestry model confusion matrix.
         test_accuracy: Ancestry model test accuracy.
         ref_pcs: Reference PCA coordinates.
@@ -113,6 +117,7 @@ class PipelineOutput:
     input_samples: Optional[pd.DataFrame] = None
     ancestry_counts: Optional[pd.DataFrame] = None
     ancestry_labels: Optional[pd.DataFrame] = None
+    ancestry_diagnostics: Optional[Dict[str, Any]] = None
     confusion_matrix: Optional[pd.DataFrame] = None
     test_accuracy: Optional[float] = None
     common_snps: Optional[List[str]] = None
@@ -216,8 +221,11 @@ class PipelineOutput:
             if "predict_data" in data and "ids" in data["predict_data"]:
                 self.ancestry_labels = pd.DataFrame(data["predict_data"]["ids"])
 
-            # Confusion matrix
-            if "confusion_matrix" in data and "label_encoder" in data:
+            # Confusion matrix. Checked for a value rather than a key: the
+            # runner sets both to None when a loaded model carries no training
+            # metrics, and a None encoder here would crash report assembly
+            # after the run had already done all its work.
+            if data.get("confusion_matrix") is not None and data.get("label_encoder") is not None:
                 le = data["label_encoder"]
                 cm = pd.DataFrame(data["confusion_matrix"])
                 labels = le.inverse_transform([i for i in range(len(cm))])
@@ -244,6 +252,14 @@ class PipelineOutput:
         # Common SNPs
         if "data" in ancestry_result and "common_snps" in ancestry_result["data"]:
             self.common_snps = ancestry_result["data"]["common_snps"]
+
+        # Diagnostics. Accepts either the collector or its dict form, so a
+        # caller assembling this dict by hand does not have to know which.
+        diagnostics = ancestry_result.get("diagnostics")
+        if diagnostics is not None:
+            self.ancestry_diagnostics = (
+                diagnostics.to_dict() if hasattr(diagnostics, "to_dict") else diagnostics
+            )
 
     def _process_qc_results(
         self,
@@ -457,6 +473,8 @@ class PipelineOutput:
             result["test_accuracy"] = self.test_accuracy
         if self.common_snps is not None:
             result["common_snps"] = self.common_snps
+        if self.ancestry_diagnostics:
+            result["ancestry_diagnostics"] = self.ancestry_diagnostics
 
         # PCA/UMAP data
         if self.ref_pcs is not None:

--- a/genotools/cli/parser.py
+++ b/genotools/cli/parser.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Sequence
 
+from ..ancestry.config import MISSING_FILL_STRATEGIES
+from ..ancestry.diagnostics import DEFAULT_MAX_FILL_FRACTION
 from ..qc.config import (
     CallrateConfig,
     SexConfig,
@@ -298,6 +300,19 @@ _UNSUPPORTED_INFERENCE_FLAGS: Dict[str, Tuple[str, str]] = {
 }
 
 
+#: Diagnostic settings that only mean something when prediction actually runs,
+#: mapped to ``(flag, default)``. Passing one without ``--ancestry`` is an
+#: error rather than a no-op, for the reason ``--amr-het`` exists: a setting
+#: that is quietly ignored is worse than one that is refused.
+_ANCESTRY_DIAGNOSTIC_FLAGS: Dict[str, Tuple[str, object]] = {
+    "detect_admixed": ("--no-admixture-detection", True),
+    "missing_fill": ("--ancestry-missing-fill", "ref-mean"),
+    "max_missing_snps": ("--ancestry-max-missing-snps", DEFAULT_MAX_FILL_FRACTION),
+    "write_plots": ("--ancestry-plots", False),
+    "self_test": ("--ancestry-self-test", False),
+}
+
+
 @dataclass
 class AncestryArgs:
     """Ancestry prediction arguments."""
@@ -308,6 +323,16 @@ class AncestryArgs:
     model_path: Optional[Path] = None
     subset_ancestry: Optional[List[str]] = None
     min_samples: int = 0
+
+    # Prediction-path controls and diagnostics (see ancestry/diagnostics.py).
+    # detect_admixed exists to be turned *off*: the CAH override replaces the
+    # classifier's label, so seeing what the classifier said is the fastest way
+    # to tell a broken classifier from a broken override.
+    detect_admixed: bool = True
+    missing_fill: str = "ref-mean"
+    max_missing_snps: float = DEFAULT_MAX_FILL_FRACTION
+    write_plots: bool = False
+    self_test: bool = False
 
     # Remote-execution flags. Accepted by the parser so that a 1.x command line
     # gets a targeted error instead of argparse's bare "unrecognized arguments",
@@ -321,6 +346,25 @@ class AncestryArgs:
         for flag, (attr, detail) in _UNSUPPORTED_INFERENCE_FLAGS.items():
             if getattr(self, attr):
                 raise ValueError(f"{flag} is not supported in GenoTools 2.0. {detail}")
+
+        if self.missing_fill not in MISSING_FILL_STRATEGIES:
+            raise ValueError(
+                f"--ancestry-missing-fill must be one of "
+                f"{', '.join(MISSING_FILL_STRATEGIES)}, got {self.missing_fill!r}"
+            )
+        if not 0.0 <= self.max_missing_snps <= 1.0:
+            raise ValueError(
+                f"--ancestry-max-missing-snps must be a fraction in [0, 1], "
+                f"got {self.max_missing_snps}"
+            )
+
+    def diagnostic_flags_set(self) -> List[str]:
+        """Diagnostic flags whose value differs from the default."""
+        return [
+            flag
+            for attr, (flag, default) in _ANCESTRY_DIAGNOSTIC_FLAGS.items()
+            if getattr(self, attr) != default
+        ]
 
 
 @dataclass
@@ -380,6 +424,17 @@ class PipelineArgs:
                 f"ancestry prediction has no ancestry labels to match. To set "
                 f"bounds for the whole input, use --het instead."
             )
+
+        # Same rule for the prediction-path settings: without --ancestry there
+        # is no prediction to configure or measure, and accepting the flag
+        # would mean silently doing nothing with it.
+        if not self.ancestry.run_ancestry:
+            stray = self.ancestry.diagnostic_flags_set()
+            if stray:
+                raise ValueError(
+                    f"{', '.join(stray)} requires --ancestry: there is no "
+                    f"ancestry prediction to configure in a run without it."
+                )
 
     @property
     def geno_path(self) -> Path:
@@ -840,6 +895,41 @@ Examples:
         default=0,
         metavar="N",
         help="Minimum samples per ancestry for downstream analysis (default: 0)",
+    )
+    ancestry_group.add_argument(
+        "--no-admixture-detection",
+        action="store_true",
+        help="Report the classifier's own labels instead of relabeling "
+             "samples nearest the global centroid as CAH",
+    )
+    ancestry_group.add_argument(
+        "--ancestry-missing-fill",
+        type=str,
+        default="ref-mean",
+        choices=list(MISSING_FILL_STRATEGIES),
+        help="How to fill a model SNP the cohort does not carry: 'ref-mean' "
+             "(neutral, the default) or 'constant' (dosage 2, as 1.x did)",
+    )
+    ancestry_group.add_argument(
+        "--ancestry-max-missing-snps",
+        type=float,
+        default=DEFAULT_MAX_FILL_FRACTION,
+        metavar="FRAC",
+        help=f"Refuse to predict when more than this fraction of the model's "
+             f"SNPs are absent from the cohort "
+             f"(default: {DEFAULT_MAX_FILL_FRACTION})",
+    )
+    ancestry_group.add_argument(
+        "--ancestry-plots",
+        action="store_true",
+        help="Write diagnostic PNGs: the cohort projected onto the reference "
+             "panel, and the margin behind each CAH decision",
+    )
+    ancestry_group.add_argument(
+        "--ancestry-self-test",
+        action="store_true",
+        help="Predict the reference panel's own ancestries through the "
+             "prediction path, as a positive control on the model",
     )
 
     # GWAS group
@@ -1387,6 +1477,11 @@ def parse_args(args: Optional[Sequence[str]] = None) -> PipelineArgs:
         model_path=ns.model,
         subset_ancestry=ns.subset_ancestry,
         min_samples=ns.min_samples,
+        detect_admixed=not ns.no_admixture_detection,
+        missing_fill=ns.ancestry_missing_fill,
+        max_missing_snps=ns.ancestry_max_missing_snps,
+        write_plots=ns.ancestry_plots,
+        self_test=ns.ancestry_self_test,
         use_container=ns.container,
         use_singularity=ns.singularity,
         use_cloud=ns.cloud,

--- a/genotools/cli/runner.py
+++ b/genotools/cli/runner.py
@@ -55,6 +55,7 @@ from ..core.validation import (
 from ..qc.results import STEP_REPORT, unrun_result
 
 if TYPE_CHECKING:  # QC config is imported lazily in _initialize_modules
+    from ..ancestry.diagnostics import AncestryDiagnostics
     from ..qc.config import HetConfig
 
 logger = get_logger(__name__)
@@ -332,7 +333,7 @@ class PipelineRunner:
         )
 
         # Import Ancestry module
-        from ..ancestry import AncestryModel, AncestryConfig
+        from ..ancestry import AncestryModel, AncestryConfig, AncestryDiagnostics
 
         # Store module references
         self._new_modules = {
@@ -349,6 +350,7 @@ class PipelineRunner:
             "run_gwas_association": run_gwas_association,
             "GenotypeData": GenotypeData,
             "AncestryModel": AncestryModel,
+            "AncestryDiagnostics": AncestryDiagnostics,
         }
 
         # Store config classes
@@ -759,22 +761,49 @@ class PipelineRunner:
         model_path = self.args.ancestry.model_path
         is_inference = model_path is not None
 
+        # One collector for the whole run: preprocessing fills in the SNP
+        # overlap and the allele frequencies, prediction fills in the PC drift
+        # and the admixture decision, and the report gets all of it. Its
+        # artifacts are written to `out_path` rather than `actual_out`, so the
+        # evidence survives a run that discards its temp directory.
+        diagnostics = self._new_modules["AncestryDiagnostics"]()
+
         if is_inference:
             model, predictions, ref_pca, raw = self._run_inference_mode(
-                AncestryModel, model_path, actual_out
+                AncestryModel, model_path, actual_out, diagnostics, out_path
             )
         else:
             model, predictions, ref_pca, raw = self._run_training_mode(
-                AncestryModel, actual_out, out_path
+                AncestryModel, actual_out, out_path, diagnostics
             )
 
         # --- Common post-processing (both modes) ---
 
-        # UMAP visualization
-        from ..ancestry.reducers.umap_reducer import run_umap
+        # Positive control. High training accuracy says the model learned the
+        # panel; this says the *prediction path* can still recover it. When it
+        # passes and a cohort still comes back one label, the cohort's own
+        # preprocessing is the only thing left.
+        if self.args.ancestry.self_test:
+            diagnostics.self_test = model.self_test(
+                raw["raw_ref"],
+                detect_admixed=self.args.ancestry.detect_admixed,
+            )
 
         projected_pca_path = f"{actual_out}_projected_new_pca.txt"
         projected_pca = pd.read_csv(projected_pca_path, sep="\t")
+
+        if self.args.ancestry.write_plots:
+            from ..ancestry.plots import plot_ancestry_diagnostics
+
+            diagnostics.plots = plot_ancestry_diagnostics(
+                train_pca=model._train_pca,
+                projected=projected_pca,
+                out_prefix=out_path,
+                decisions=predictions.decisions,
+            )
+
+        # UMAP visualization
+        from ..ancestry.reducers.umap_reducer import run_umap
 
         umap_result: Optional[Dict[str, Any]] = None
         if ref_pca is not None:
@@ -848,6 +877,7 @@ class PipelineRunner:
             "data": data_dict,
             "metrics": metrics_dict,
             "output": outfiles_dict,
+            "diagnostics": diagnostics.to_dict(),
         }
 
         # Cleanup intermediate files
@@ -870,6 +900,7 @@ class PipelineRunner:
         AncestryModel: type,
         actual_out: str,
         out_path: str,
+        diagnostics: "AncestryDiagnostics",
     ) -> tuple:
         """Train a new AncestryModel from reference panel.
 
@@ -877,6 +908,7 @@ class PipelineRunner:
             AncestryModel: The AncestryModel class.
             actual_out: Output path prefix (may be temp dir).
             out_path: Final output path (for saving model).
+            diagnostics: Run-wide diagnostics collector.
 
         Returns:
             Tuple of (model, predictions, ref_pca, raw).
@@ -890,6 +922,10 @@ class PipelineRunner:
             ref_labels=str(self.args.ancestry.ref_labels),
             out_path=actual_out,
             train=True,
+            fill_strategy=self.args.ancestry.missing_fill,
+            max_missing_fraction=self.args.ancestry.max_missing_snps,
+            diagnostics=diagnostics,
+            diagnostics_prefix=out_path,
         )
         raw_ref = raw["raw_ref"]
         raw_geno = raw["raw_geno"]
@@ -922,7 +958,9 @@ class PipelineRunner:
             geno_data,
             geno_ids,
             out_path=Path(actual_out),
-            detect_admixed=True,
+            detect_admixed=self.args.ancestry.detect_admixed,
+            diagnostics=diagnostics,
+            diagnostics_prefix=out_path,
         )
 
         # Load ref PCA written by fit()
@@ -936,6 +974,8 @@ class PipelineRunner:
         AncestryModel: type,
         model_path: Path,
         actual_out: str,
+        diagnostics: "AncestryDiagnostics",
+        out_path: str,
     ) -> tuple:
         """Load a pre-trained AncestryModel and predict.
 
@@ -944,6 +984,8 @@ class PipelineRunner:
             model_path: Path to a model directory, or a single .pkl written
                 by GenoTools 2.0.
             actual_out: Output path prefix.
+            diagnostics: Run-wide diagnostics collector.
+            out_path: Final output prefix, for artifacts the user keeps.
 
         Returns:
             Tuple of (model, predictions, ref_pca, raw).
@@ -976,6 +1018,10 @@ class PipelineRunner:
             out_path=actual_out,
             train=False,
             common_snps_file=common_snps_file,
+            fill_strategy=self.args.ancestry.missing_fill,
+            max_missing_fraction=self.args.ancestry.max_missing_snps,
+            diagnostics=diagnostics,
+            diagnostics_prefix=out_path,
         )
         raw_geno = raw["raw_geno"]
         geno_data = raw_geno.drop(columns=["label"])
@@ -986,7 +1032,9 @@ class PipelineRunner:
             geno_data,
             geno_ids,
             out_path=Path(actual_out),
-            detect_admixed=True,
+            detect_admixed=self.args.ancestry.detect_admixed,
+            diagnostics=diagnostics,
+            diagnostics_prefix=out_path,
         )
 
         # Use training PCA as ref PCA for UMAP visualization

--- a/tests/scripts/compare_missing_fill.py
+++ b/tests/scripts/compare_missing_fill.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+# Copyright 2023 The GenoTools Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Quantify what changing the missing-SNP fill does to ancestry calls.
+
+Third in the series after ``compare_umap_versions.py`` (vary the libraries) and
+``compare_snp_matching.py`` (vary the source tree). This one needs neither: both
+fill strategies are reachable from one tree through
+``--ancestry-missing-fill``, so it holds *everything* constant -- one process,
+one loaded model, one reference PCA -- and varies only the value written into
+the columns the cohort could not supply. Every moved call is therefore
+attributable to the fill and to nothing else.
+
+It also doubles as the first thing to run against a cohort whose prediction
+looks wrong. The header it prints -- how much of the model's SNP list the
+cohort carried -- is the number that decides whether there is anything else
+worth investigating:
+
+    matched 43,173 / 43,173 (100.00%)   the fill cannot matter; look elsewhere
+    matched   412 / 43,173 (  0.95%)    nothing else matters until this is fixed
+
+Usage
+-----
+    python tests/scripts/compare_missing_fill.py \\
+        --geno ~/parity_data/GP2_r12_subset10k \\
+        --ref-panel ~/.genotools/ref/ref_panel/ref_panel_gp2_prune_rm_underperform_pos_update \\
+        --ref-labels ~/.genotools/ref/ref_panel/ref_panel_ancestry_updated.txt \\
+        --model ~/parity_data/models/new_ancestry_ancestry_model \\
+        --work /tmp/missing-fill-compare
+
+Requires a pre-trained model: the point is to hold the model fixed. Run from the
+repo root, which puts the working tree first on ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+STRATEGIES = ("constant", "ref-mean")
+
+
+def _predict(
+    strategy: str, args: argparse.Namespace, model: Any
+) -> Dict[str, Any]:
+    """Build the feature matrix under one fill strategy and predict from it."""
+    from genotools.ancestry.diagnostics import AncestryDiagnostics, format_pc_drift
+    from genotools.ancestry.preprocessing import get_raw_files
+
+    work = args.work / strategy
+    work.mkdir(parents=True, exist_ok=True)
+
+    snps_file = work / "model.common_snps"
+    snps_file.write_text("\n".join(model.common_snps) + "\n")
+
+    diagnostics = AncestryDiagnostics()
+    raw = get_raw_files(
+        geno_path=str(args.geno),
+        ref_panel=str(args.ref_panel),
+        ref_labels=str(args.ref_labels),
+        out_path=str(work / "out"),
+        train=False,
+        common_snps_file=str(snps_file),
+        fill_strategy=strategy,
+        # The comparison is the point; a refusal here would prevent it. The
+        # overlap is printed either way, which is what a refusal is for.
+        max_missing_fraction=1.0,
+        diagnostics=diagnostics,
+    )
+    geno = raw["raw_geno"]
+    predictions = model.predict(
+        geno.drop(columns=["label"]),
+        geno[["FID", "IID"]],
+        out_path=work / "predict",
+        diagnostics=diagnostics,
+        diagnostics_prefix=str(work / "predict"),
+    )
+
+    print(f"\n--- fill = {strategy} " + "-" * (56 - len(strategy)))
+    print(f"  {diagnostics.snp_overlap.format_summary()}")
+    print(format_pc_drift(diagnostics.pc_drift))
+    counts = predictions.predictions["predicted_ancestry"].value_counts()
+    print(f"  labels: {counts.to_dict()}")
+    if diagnostics.admixture:
+        print(
+            f"  CAH: {diagnostics.admixture['n_cah']} of "
+            f"{diagnostics.admixture['n_samples']}"
+        )
+    return {
+        "diagnostics": diagnostics,
+        "labels": predictions.predictions.set_index("IID")["predicted_ancestry"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--geno", required=True, type=Path, help="Cohort pfile prefix")
+    parser.add_argument("--ref-panel", required=True, type=Path)
+    parser.add_argument("--ref-labels", required=True, type=Path)
+    parser.add_argument("--model", required=True, type=Path,
+                        help="Pre-trained model directory (held constant across arms)")
+    parser.add_argument("--work", required=True, type=Path,
+                        help="Directory for both arms' intermediates")
+    args = parser.parse_args()
+    args.geno = args.geno.expanduser()
+    args.ref_panel = args.ref_panel.expanduser()
+    args.ref_labels = args.ref_labels.expanduser()
+    args.model = args.model.expanduser()
+    args.work = args.work.expanduser()
+
+    from genotools.ancestry import AncestryModel
+    from genotools.core.logging import setup_logging
+
+    setup_logging(level="INFO")
+    model = AncestryModel.load(args.model)
+    print(f"model: {args.model} ({len(model.common_snps)} common SNPs)")
+    print(f"cohort: {args.geno}")
+
+    arms = {strategy: _predict(strategy, args, model) for strategy in STRATEGIES}
+
+    baseline, candidate = (arms[s]["labels"] for s in STRATEGIES)
+    shared = baseline.index.intersection(candidate.index)
+    baseline, candidate = baseline.loc[shared], candidate.loc[shared]
+    moved = baseline != candidate
+
+    print("\n=== fill: constant -> ref-mean " + "=" * 45)
+    print(f"  {int(moved.sum())} of {len(shared)} calls moved "
+          f"({100 * moved.mean():.3f}%)")
+    if moved.any():
+        transitions = (
+            pd.DataFrame({"old": baseline[moved], "new": candidate[moved]})
+            .value_counts()
+            .sort_values(ascending=False)
+        )
+        for (old, new), count in transitions.items():
+            print(f"    {old:>6} -> {new:<6} {count}")
+
+    overlaps = {s: arms[s]["diagnostics"].snp_overlap.n_filled for s in STRATEGIES}
+    assert len(set(overlaps.values())) == 1, (
+        f"the arms disagree about how many SNPs were filled ({overlaps}), so "
+        f"they are not comparing the same match"
+    )
+    if overlaps["ref-mean"] == 0:
+        print("\n  Nothing was filled, so this cohort cannot be affected by the")
+        print("  change. That is the expected result for a cohort that carries")
+        print("  the model's SNP list in full.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(REPO_ROOT))
+    raise SystemExit(main())

--- a/tests/unit/test_ancestry/test_diagnostics.py
+++ b/tests/unit/test_ancestry/test_diagnostics.py
@@ -1,0 +1,334 @@
+"""Unit tests for the ancestry prediction diagnostics.
+
+Every function here is pure over frames, so these run against hand-built input
+rather than a PLINK pipeline -- the `select_het_outliers` pattern. The cases are
+the real failure shapes: a cohort that matched nothing, `chr1` against `1`,
+hg19 against hg38, an allele-swapped match, a cohort collapsed to a point, and
+an all-CAH override sitting on top of a classifier that worked.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from genotools.ancestry.diagnostics import (
+    AncestryDiagnostics,
+    SnpOverlapReport,
+    admixture_summary,
+    admixture_warnings,
+    allele_frequency_concordance,
+    allele_frequency_warnings,
+    bim_compatibility,
+    format_pc_drift,
+    is_low_overlap,
+    pc_columns,
+    pc_drift,
+    pc_drift_warnings,
+    snp_overlap_warnings,
+)
+
+
+# --- SNP overlap -----------------------------------------------------------
+
+
+def test_overlap_report_counts_and_fraction():
+    report = SnpOverlapReport(
+        n_model_snps=1000, n_matched=750, fill_strategy="ref-mean",
+        filled_snps=tuple(f"rs{i}" for i in range(250)),
+    )
+    assert report.n_filled == 250
+    assert report.fraction_filled == pytest.approx(0.25)
+    assert report.to_dict()["n_filled"] == 250
+    # The ID list is a file, not a report field.
+    assert "filled_snps" not in report.to_dict()
+    assert "750/1000" in report.format_summary()
+
+
+def test_overlap_report_survives_an_empty_model():
+    report = SnpOverlapReport(n_model_snps=0, n_matched=0, fill_strategy="ref-mean")
+    assert report.fraction_filled == 0.0
+    assert "no SNPs" in snp_overlap_warnings(report)[0]
+
+
+def test_small_overlap_loss_is_not_worth_a_warning():
+    report = SnpOverlapReport(n_model_snps=1000, n_matched=990, fill_strategy="ref-mean")
+    assert snp_overlap_warnings(report) == []
+
+
+def test_overlap_loss_above_the_threshold_warns():
+    report = SnpOverlapReport(n_model_snps=1000, n_matched=800, fill_strategy="ref-mean")
+    (warning,) = snp_overlap_warnings(report)
+    assert "20.00%" in warning
+
+
+def test_matching_nothing_says_so_and_names_the_usual_causes():
+    """The long-read failure: a cohort sharing no coordinate space at all."""
+    report = SnpOverlapReport(n_model_snps=1000, n_matched=0, fill_strategy="ref-mean")
+    (warning,) = snp_overlap_warnings(report)
+    assert "NONE" in warning
+    assert "genome build" in warning
+
+
+# --- bim compatibility ------------------------------------------------------
+
+
+def _bim(chroms, positions):
+    return pd.DataFrame({"chr": [str(c) for c in chroms], "pos": list(positions)})
+
+
+def test_matched_files_get_no_hints():
+    bim = _bim(["1", "1", "2"], [100, 200, 300])
+    compat = bim_compatibility(bim, bim)
+    assert compat.hints == ()
+    assert compat.shared_chroms == ("1", "2")
+
+
+def test_chr_prefix_mismatch_is_named():
+    compat = bim_compatibility(
+        _bim(["1", "2"], [100, 200]), _bim(["chr1", "chr2"], [100, 200])
+    )
+    assert compat.shared_chroms == ()
+    assert "chr1' vs '1" in compat.hints[0]
+    assert "1" in compat.only_in_1 and "chr1" in compat.only_in_2
+
+
+def test_disjoint_positions_on_shared_chromosomes_suggests_a_build_mismatch():
+    compat = bim_compatibility(
+        _bim(["1", "1"], [10_000, 20_000]),
+        _bim(["1", "1"], [910_000, 920_000]),
+    )
+    assert compat.shared_chroms == ("1",)
+    assert "hg19 vs hg38" in compat.hints[0]
+    assert compat.position_ranges["1"] == (10_000, 20_000, 910_000, 920_000)
+
+
+def test_unrelated_files_say_nothing_is_shared():
+    compat = bim_compatibility(_bim(["1"], [100]), _bim(["X"], [100]))
+    assert "no chromosome name is present in both" in compat.hints[0]
+
+
+def test_report_text_lists_both_sides():
+    text = bim_compatibility(
+        _bim(["1"], [100]), _bim(["chr1"], [100])
+    ).format_report()
+    assert "variants:" in text and "hint:" in text
+
+
+# --- overlap floor ----------------------------------------------------------
+
+
+def test_a_panel_matched_into_a_much_larger_cohort_is_not_low_overlap():
+    """The real shape: 43k of a 209k panel found in a 1.9M cohort."""
+    assert not is_low_overlap(43_173, (209_517, 1_900_000))
+
+
+def test_a_near_empty_match_is_low_overlap():
+    assert is_low_overlap(12, (209_517, 1_900_000))
+
+
+def test_zero_variants_counts_as_low_overlap():
+    assert is_low_overlap(0, (0, 0))
+
+
+# --- allele frequency -------------------------------------------------------
+
+
+def _dosages(**columns):
+    return pd.DataFrame(columns)
+
+
+def test_identical_matrices_agree_perfectly():
+    ref = _dosages(rs1=[0, 1, 2, 1], rs2=[2, 2, 1, 0], rs3=[0, 0, 1, 1])
+    result = allele_frequency_concordance(ref, ref.copy())
+    assert result["n_snps"] == 3
+    assert result["correlation"] == pytest.approx(1.0)
+    assert result["n_discordant"] == 0
+    assert result["n_flip_signature"] == 0
+
+
+def test_a_swapped_allele_is_recognised_as_a_swap_not_a_difference():
+    """`2 - dosage` is the signature: frequency near `1 - ref_freq`."""
+    ref = _dosages(rs1=[0, 0, 0, 1], rs2=[2, 2, 2, 1], rs3=[0, 1, 2, 1])
+    cohort = ref.copy()
+    cohort["rs1"] = 2 - cohort["rs1"]
+    result = allele_frequency_concordance(ref, cohort)
+    assert result["n_discordant"] == 1
+    assert result["n_flip_signature"] == 1
+    (warning,) = allele_frequency_warnings(result, min_correlation=0.0)
+    assert "swap" in warning
+
+
+def test_population_difference_is_discordant_without_a_swap_signature():
+    ref = _dosages(rs1=[0, 0, 0, 0], rs2=[0, 1, 2, 1], rs3=[2, 1, 0, 1])
+    cohort = _dosages(rs1=[1, 1, 1, 1], rs2=[0, 1, 2, 1], rs3=[2, 1, 0, 1])
+    result = allele_frequency_concordance(ref, cohort)
+    assert result["n_discordant"] == 1
+    assert result["n_flip_signature"] == 0
+
+
+def test_no_shared_snps_reports_zeros_rather_than_raising():
+    result = allele_frequency_concordance(
+        _dosages(rs1=[0, 1]), _dosages(rs9=[0, 1])
+    )
+    assert result == {
+        "n_snps": 0,
+        "correlation": None,
+        "mean_abs_delta": None,
+        "n_discordant": 0,
+        "fraction_discordant": None,
+        "n_flip_signature": 0,
+        "fraction_flip_signature": None,
+    }
+
+
+def test_duplicate_cohort_probes_do_not_break_alignment():
+    """A cohort can carry one site under several probe IDs."""
+    ref = _dosages(rs1=[0, 1, 2], rs2=[2, 1, 0])
+    cohort = pd.DataFrame(
+        np.array([[0, 1, 2], [1, 1, 1], [2, 1, 0]]).T, columns=["rs1", "rs1", "rs2"]
+    )
+    result = allele_frequency_concordance(ref, cohort)
+    assert result["n_snps"] == 2
+
+
+def test_a_constant_column_yields_no_correlation_rather_than_nan():
+    ref = _dosages(rs1=[1, 1], rs2=[1, 1])
+    assert allele_frequency_concordance(ref, ref.copy())["correlation"] is None
+
+
+def test_a_weak_correlation_warns_about_the_match_itself():
+    result = {"n_snps": 500, "correlation": 0.1, "fraction_flip_signature": 0.0}
+    (warning,) = allele_frequency_warnings(result)
+    assert "r=0.100" in warning
+
+
+# --- PC drift ---------------------------------------------------------------
+
+
+def test_pc_columns_sort_numerically_and_ignore_everything_else():
+    frame = pd.DataFrame(
+        columns=["FID", "IID", "PC10", "PC2", "PC1", "label", "dist_to_all"]
+    )
+    assert pc_columns(frame) == ["PC1", "PC2", "PC10"]
+    assert pc_columns(frame, 2) == ["PC1", "PC2"]
+
+
+def _train_frame(n=200, seed=0):
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({"PC1": rng.normal(0, 1, n), "PC2": rng.normal(0, 2, n)})
+
+
+def test_a_cohort_inside_the_reference_cloud_drifts_little():
+    train = _train_frame()
+    drift = pc_drift(train, _train_frame(seed=1))
+    assert list(drift["pc"]) == ["PC1", "PC2"]
+    assert abs(drift.loc[0, "shift_sd"]) < 0.5
+    assert drift.loc[0, "sd_ratio"] == pytest.approx(1.0, abs=0.2)
+    assert pc_drift_warnings(drift) == []
+
+
+def test_a_displaced_cohort_is_measured_in_reference_sds():
+    train = _train_frame()
+    cohort = _train_frame(seed=1)
+    cohort["PC1"] += 40
+    drift = pc_drift(train, cohort)
+    assert drift.loc[0, "shift_sd"] == pytest.approx(40, rel=0.1)
+    (warning,) = pc_drift_warnings(drift)
+    assert "too far to be ancestry" in warning
+
+
+def test_a_cohort_collapsed_to_a_point_is_the_constant_fill_signature():
+    train = _train_frame()
+    cohort = pd.DataFrame({"PC1": [3.0] * 50, "PC2": [1.0] * 50})
+    drift = pc_drift(train, cohort)
+    assert drift.loc[0, "sd_ratio"] == pytest.approx(0.0)
+    assert any("collapsed to a point" in w for w in pc_drift_warnings(drift))
+
+
+def test_pc_drift_only_reports_pcs_present_on_both_sides():
+    train = _train_frame()
+    drift = pc_drift(train, pd.DataFrame({"PC1": [0.0, 1.0]}))
+    assert list(drift["pc"]) == ["PC1"]
+
+
+def test_formatting_handles_a_missing_value():
+    drift = pd.DataFrame([{
+        "pc": "PC1", "train_mean": 0.0, "train_sd": 0.0,
+        "cohort_mean": 1.0, "cohort_sd": 1.0, "shift_sd": None, "sd_ratio": None,
+    }])
+    text = format_pc_drift(drift)
+    assert "n/a" in text
+    assert "no PCs in common" in format_pc_drift(pd.DataFrame())
+
+
+# --- admixture override -----------------------------------------------------
+
+
+def _decisions(pre, final, margin):
+    return pd.DataFrame({
+        "FID": range(len(pre)), "IID": range(len(pre)),
+        "label_pre_admixture": pre, "label": final, "margin_to_all": margin,
+    })
+
+
+def test_summary_keeps_what_the_classifier_said():
+    decisions = _decisions(
+        pre=["EUR", "AFR", "EAS", "EUR"],
+        final=["CAH", "CAH", "CAH", "CAH"],
+        margin=[-2.0, -3.0, -1.0, -4.0],
+    )
+    summary = admixture_summary(decisions)
+    assert summary["fraction_cah"] == 1.0
+    assert summary["n_distinct_pre_admixture"] == 3
+    assert summary["overridden_from"] == {"EUR": 2, "AFR": 1, "EAS": 1}
+    assert summary["margin_to_all_quantiles"]["p50"] < 0
+
+
+def test_an_all_cah_run_with_a_working_classifier_points_away_from_the_model():
+    """The whole reason both labels are kept."""
+    summary = admixture_summary(
+        _decisions(["EUR", "AFR", "EAS"], ["CAH"] * 3, [-1.0, -1.0, -1.0])
+    )
+    (warning,) = admixture_warnings(summary)
+    assert "3 distinct labels" in warning
+    assert "not the thing that failed" in warning
+    assert "--no-admixture-detection" in warning
+
+
+def test_a_normal_admixture_rate_is_not_warned_about():
+    summary = admixture_summary(
+        _decisions(["EUR"] * 10, ["EUR"] * 9 + ["CAH"], [1.0] * 9 + [-1.0])
+    )
+    assert summary["fraction_cah"] == pytest.approx(0.1)
+    assert admixture_warnings(summary) == []
+
+
+def test_summary_of_nothing_is_empty_not_an_error():
+    assert admixture_summary(pd.DataFrame())["n_samples"] == 0
+
+
+# --- the collector ----------------------------------------------------------
+
+
+def test_collector_deduplicates_warnings_and_serializes():
+    diagnostics = AncestryDiagnostics(
+        snp_overlap=SnpOverlapReport(100, 90, "ref-mean"),
+        allele_frequency={"n_snps": 90},
+        pc_drift=pd.DataFrame([{"pc": "PC1", "shift_sd": 0.1}]),
+        admixture={"n_cah": 0},
+        self_test={"balanced_accuracy": 0.9},
+        plots=["/tmp/x.png"],
+    )
+    diagnostics.add_warnings(["same", "same", "other"])
+    assert diagnostics.warnings == ["same", "other"]
+
+    out = diagnostics.to_dict()
+    assert out["snp_overlap"]["n_matched"] == 90
+    assert out["pc_drift"]["pc"] == ["PC1"]
+    assert out["self_test"]["balanced_accuracy"] == 0.9
+    assert out["plots"] == ["/tmp/x.png"]
+    assert out["warnings"] == ["same", "other"]
+
+
+def test_an_empty_collector_serializes_to_just_its_warnings():
+    assert AncestryDiagnostics().to_dict() == {"warnings": []}

--- a/tests/unit/test_ancestry/test_model_diagnostics.py
+++ b/tests/unit/test_ancestry/test_model_diagnostics.py
@@ -1,0 +1,254 @@
+"""Prediction-path diagnostics at the model layer.
+
+The projection and the classifier are stubbed so the PC coordinates are inputs
+to the test rather than an outcome of a fit: what is under test is what the CAH
+override does with a position, what it records about the decision, and what the
+self-test makes of the reference panel. Fitting a real model would take minutes
+and would measure UMAP, not this.
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.preprocessing import LabelEncoder
+
+from genotools.ancestry.model import AncestryModel
+
+# Three well-separated reference groups. Their global centroid sits near
+# (0, 10/3, 0) -- nowhere near any of them, which is what makes CAH reachable.
+CENTROIDS = {"EUR": (10.0, 0.0, 0.0), "AFR": (-10.0, 0.0, 0.0), "EAS": (0.0, 10.0, 0.0)}
+GLOBAL_CENTROID = (0.0, 10.0 / 3.0, 0.0)
+
+
+class _StubPCAReducer:
+    """Treats the first three feature columns as PC1-PC3."""
+
+    def transform(self, X, return_dataframe=False):
+        pcs = pd.DataFrame(np.asarray(X, dtype=float)[:, :3], columns=["PC1", "PC2", "PC3"])
+        return pcs if return_dataframe else pcs.values
+
+
+class _StubPipeline:
+    """Returns encoded labels chosen by the test."""
+
+    def __init__(self, encoded):
+        self.encoded = np.asarray(encoded)
+
+    def predict(self, X):
+        return self.encoded[: len(X)]
+
+
+def _train_pca(per_group=40, spread=0.2, seed=0):
+    rng = np.random.default_rng(seed)
+    frames = []
+    for label, centre in CENTROIDS.items():
+        offsets = rng.normal(0, spread, (per_group, 3))
+        frame = pd.DataFrame(offsets + np.array(centre), columns=["PC1", "PC2", "PC3"])
+        frame.insert(0, "IID", [f"{label}_{i}" for i in range(per_group)])
+        frame.insert(0, "FID", [f"{label}_{i}" for i in range(per_group)])
+        frame["label"] = label
+        frames.append(frame)
+    return pd.concat(frames, ignore_index=True)
+
+
+def _model(predicted_labels, train_pca=None):
+    encoder = LabelEncoder().fit(sorted(CENTROIDS))
+    model = AncestryModel()
+    model.pca_reducer = _StubPCAReducer()
+    model.pipeline = _StubPipeline(encoder.transform(predicted_labels))
+    model.label_encoder = encoder
+    model._train_pca = train_pca if train_pca is not None else _train_pca()
+    model._is_fitted = True
+    return model
+
+
+def _cohort(positions):
+    frame = pd.DataFrame(positions, columns=["snp1", "snp2", "snp3"])
+    frame.insert(0, "IID", [f"S{i}" for i in range(len(frame))])
+    frame.insert(0, "FID", [f"S{i}" for i in range(len(frame))])
+    return frame
+
+
+def _predict(model, cohort, **kwargs):
+    return model.predict(cohort, cohort[["FID", "IID"]], **kwargs)
+
+
+# --- the override, and its working --------------------------------------------
+
+
+def test_a_cohort_sitting_on_an_ancestry_centroid_keeps_its_label():
+    cohort = _cohort([CENTROIDS["EUR"]] * 5)
+    result = _predict(_model(["EUR"] * 5), cohort, collect_diagnostics=False)
+    assert list(result.predictions["predicted_ancestry"]) == ["EUR"] * 5
+    assert (result.decisions["margin_to_all"] > 0).all()
+    assert (result.decisions["label_pre_admixture"] == "EUR").all()
+    assert (result.decisions["nearest_centroid"] == "EUR").all()
+
+
+def test_a_cohort_at_the_global_centroid_becomes_cah_but_keeps_the_classifier_label():
+    """The all-CAH failure, and the evidence that separates its two causes."""
+    cohort = _cohort([GLOBAL_CENTROID] * 6)
+    result = _predict(
+        _model(["EUR", "AFR", "EAS", "EUR", "AFR", "EAS"]), cohort,
+        collect_diagnostics=False,
+    )
+    assert set(result.predictions["predicted_ancestry"]) == {"CAH"}
+    assert set(result.decisions["label_pre_admixture"]) == {"EUR", "AFR", "EAS"}
+    assert (result.decisions["margin_to_all"] < 0).all()
+    assert (result.decisions["nearest_centroid"] == "ALL").all()
+
+
+def test_the_decision_frame_carries_a_distance_per_centroid():
+    cohort = _cohort([CENTROIDS["AFR"]] * 2)
+    result = _predict(_model(["AFR"] * 2), cohort, collect_diagnostics=False)
+    decisions = result.decisions
+    for centroid in ["ALL", *CENTROIDS]:
+        assert f"dist_{centroid}" in decisions.columns
+    assert decisions.loc[0, "dist_AFR"] < decisions.loc[0, "dist_EUR"]
+    assert decisions.loc[0, "nearest_ancestry"] == "AFR"
+    assert decisions.loc[0, "dist_to_nearest_ancestry"] == pytest.approx(
+        decisions.loc[0, "dist_AFR"]
+    )
+
+
+def test_margin_is_exactly_the_rule_the_override_applies():
+    """`margin_to_all < 0` and `label == CAH` must never disagree."""
+    positions = [CENTROIDS["EUR"], GLOBAL_CENTROID, CENTROIDS["EAS"], GLOBAL_CENTROID]
+    cohort = _cohort(positions)
+    result = _predict(_model(["EUR", "EUR", "EAS", "EAS"]), cohort, collect_diagnostics=False)
+    decisions = result.decisions
+    assert list(decisions["margin_to_all"] < 0) == list(decisions["label"] == "CAH")
+
+
+def test_detection_can_be_turned_off_to_see_the_classifier():
+    cohort = _cohort([GLOBAL_CENTROID] * 3)
+    result = _predict(
+        _model(["EUR", "AFR", "EAS"]), cohort,
+        detect_admixed=False, collect_diagnostics=False,
+    )
+    assert list(result.predictions["predicted_ancestry"]) == ["EUR", "AFR", "EAS"]
+    assert result.decisions is None
+
+
+# --- what predict() reports ---------------------------------------------------
+
+
+def test_predict_reports_drift_the_override_and_writes_the_decisions(tmp_path, caplog):
+    cohort = _cohort([GLOBAL_CENTROID] * 4)
+    with caplog.at_level(logging.INFO, logger="genotools"):
+        result = _predict(
+            _model(["EUR", "AFR", "EAS", "EUR"]), cohort,
+            diagnostics_prefix=str(tmp_path / "cohort"),
+        )
+
+    diagnostics = result.diagnostics
+    assert list(diagnostics.pc_drift["pc"]) == ["PC1", "PC2", "PC3"]
+    assert diagnostics.admixture["fraction_cah"] == 1.0
+    assert diagnostics.admixture["n_distinct_pre_admixture"] == 3
+    assert any("labeled CAH" in w for w in diagnostics.warnings)
+
+    written = pd.read_csv(tmp_path / "cohort_decisions.txt", sep="\t")
+    assert len(written) == 4
+    assert {"label_pre_admixture", "label", "margin_to_all"} <= set(written.columns)
+
+
+def test_a_collapsed_cohort_is_reported_as_such(tmp_path):
+    """Every sample at one point: the constant-fill signature, in PC space."""
+    cohort = _cohort([GLOBAL_CENTROID] * 20)
+    result = _predict(_model(["EUR"] * 20), cohort, diagnostics_prefix=str(tmp_path / "c"))
+    assert any("collapsed to a point" in w for w in result.diagnostics.warnings)
+
+
+def test_diagnostics_can_be_declined_entirely():
+    cohort = _cohort([CENTROIDS["EUR"]] * 2)
+    result = _predict(_model(["EUR"] * 2), cohort, collect_diagnostics=False)
+    assert result.diagnostics is None
+
+
+# --- the reference-panel self-test -------------------------------------------
+
+
+def _labeled_ref(train_pca):
+    """The panel as `get_raw_files` hands it over: IDs, features, label."""
+    ref = train_pca[["FID", "IID"]].copy()
+    ref[["snp1", "snp2", "snp3"]] = train_pca[["PC1", "PC2", "PC3"]].values
+    ref["label"] = train_pca["label"].values
+    return ref
+
+
+def test_self_test_recovers_a_working_model():
+    train_pca = _train_pca()
+    ref = _labeled_ref(train_pca)
+    model = _model(list(train_pca["label"]), train_pca=train_pca)
+
+    result = model.self_test(ref)
+    assert result["n_samples"] == len(ref)
+    assert result["balanced_accuracy"] == pytest.approx(1.0)
+    assert result["cah_fraction"] == 0.0
+    assert result["top_confusions"] == {}
+
+
+def test_self_test_indicts_the_override_when_the_panel_comes_back_cah(caplog):
+    """The panel defines the centroids, so a CAH panel is not the cohort's fault."""
+    train_pca = _train_pca()
+    ref = _labeled_ref(train_pca)
+    # Every reference sample projected onto the global centroid.
+    ref[["snp1", "snp2", "snp3"]] = np.tile(GLOBAL_CENTROID, (len(ref), 1))
+    model = _model(list(train_pca["label"]), train_pca=train_pca)
+
+    with caplog.at_level(logging.WARNING, logger="genotools"):
+        result = model.self_test(ref)
+
+    assert result["cah_fraction"] == 1.0
+    assert result["balanced_accuracy"] == 0.0
+    # The classifier was right all along; only the override moved.
+    assert result["balanced_accuracy_pre_admixture"] == pytest.approx(1.0)
+    assert "not the cohort" in caplog.text
+
+
+def test_self_test_separates_a_broken_classifier_from_a_broken_override(caplog):
+    train_pca = _train_pca()
+    ref = _labeled_ref(train_pca)
+    # Classifier says EUR for everything; positions are still correct, so the
+    # override leaves the labels alone and the accuracy collapse is the model's.
+    model = _model(["EUR"] * len(ref), train_pca=train_pca)
+
+    with caplog.at_level(logging.WARNING, logger="genotools"):
+        result = model.self_test(ref)
+
+    assert result["cah_fraction"] == 0.0
+    assert result["balanced_accuracy"] == pytest.approx(1 / 3)
+    assert "not in the cohort" in caplog.text
+    assert result["top_confusions"]
+
+
+def test_self_test_ignores_unlabeled_reference_samples():
+    train_pca = _train_pca()
+    ref = _labeled_ref(train_pca)
+    ref.loc[: len(ref) // 2, "label"] = np.nan
+    model = _model(list(train_pca["label"]), train_pca=train_pca)
+
+    result = model.self_test(ref)
+    assert result["n_samples"] == int(ref["label"].notna().sum())
+
+
+def test_self_test_on_an_unlabeled_panel_says_so_rather_than_dividing_by_zero():
+    train_pca = _train_pca()
+    ref = _labeled_ref(train_pca)
+    ref["label"] = np.nan
+    result = _model(list(train_pca["label"]), train_pca=train_pca).self_test(ref)
+    assert result == {"n_samples": 0, "error": "no labeled reference samples"}
+
+
+def test_self_test_reports_the_cah_rate_per_true_label():
+    train_pca = _train_pca()
+    ref = _labeled_ref(train_pca)
+    eas = ref["label"] == "EAS"
+    ref.loc[eas, ["snp1", "snp2", "snp3"]] = np.tile(GLOBAL_CENTROID, (int(eas.sum()), 1))
+    model = _model(list(train_pca["label"]), train_pca=train_pca)
+
+    by_label = model.self_test(ref)["cah_fraction_by_label"]
+    assert by_label["EAS"] == 1.0
+    assert by_label["EUR"] == 0.0

--- a/tests/unit/test_ancestry/test_plots.py
+++ b/tests/unit/test_ancestry/test_plots.py
@@ -1,0 +1,104 @@
+"""Tests for the ancestry diagnostic plots.
+
+Plots are the least load-bearing output of a run, so what matters here is that
+they are written when asked for, degrade rather than raise when there is
+nothing to draw, and never take a run down with them.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from genotools.ancestry.plots import (
+    plot_ancestry_diagnostics,
+    plot_centroid_distances,
+    plot_pca_projection,
+)
+
+
+def _train_pca(n: int = 60) -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    return pd.DataFrame({
+        "FID": [f"R{i}" for i in range(n)],
+        "IID": [f"R{i}" for i in range(n)],
+        "PC1": rng.normal(0, 1, n),
+        "PC2": rng.normal(0, 1, n),
+        "PC3": rng.normal(0, 1, n),
+        "PC4": rng.normal(0, 1, n),
+        "label": ["EUR" if i % 2 else "AFR" for i in range(n)],
+    })
+
+
+def _projected(n: int = 10) -> pd.DataFrame:
+    rng = np.random.default_rng(1)
+    return pd.DataFrame({
+        "FID": [f"S{i}" for i in range(n)],
+        "IID": [f"S{i}" for i in range(n)],
+        "PC1": rng.normal(5, 0.1, n),
+        "PC2": rng.normal(0, 0.1, n),
+        "PC3": rng.normal(0, 0.1, n),
+        "PC4": rng.normal(0, 0.1, n),
+        "label": ["CAH"] * n,
+    })
+
+
+def _decisions(n: int = 10) -> pd.DataFrame:
+    return pd.DataFrame({
+        "FID": [f"S{i}" for i in range(n)],
+        "IID": [f"S{i}" for i in range(n)],
+        "label_pre_admixture": ["EUR"] * n,
+        "label": ["CAH"] * n,
+        "margin_to_all": np.linspace(-2, 1, n),
+    })
+
+
+def test_both_plots_are_written(tmp_path: Path) -> None:
+    written = plot_ancestry_diagnostics(
+        _train_pca(), _projected(), str(tmp_path / "run"), _decisions()
+    )
+    assert [Path(p).name for p in written] == [
+        "run_pca_diagnostic.png",
+        "run_centroid_distance.png",
+    ]
+    assert all(Path(p).stat().st_size > 0 for p in written)
+
+
+def test_the_pca_panel_survives_a_cohort_with_only_two_pcs(tmp_path: Path) -> None:
+    train = _train_pca()[["FID", "IID", "PC1", "PC2", "label"]]
+    projected = _projected()[["FID", "IID", "PC1", "PC2"]]
+    path = plot_pca_projection(train, projected, tmp_path / "two.png")
+    assert path is not None and path.exists()
+
+
+def test_a_single_shared_pc_is_not_plotted(tmp_path: Path) -> None:
+    train = _train_pca()[["FID", "IID", "PC1", "label"]]
+    projected = _projected()[["FID", "IID", "PC1"]]
+    assert plot_pca_projection(train, projected, tmp_path / "one.png") is None
+
+
+def test_an_unlabeled_reference_still_plots(tmp_path: Path) -> None:
+    train = _train_pca().drop(columns=["label"])
+    path = plot_pca_projection(train, _projected(), tmp_path / "nolabel.png")
+    assert path is not None and path.exists()
+
+
+def test_decisions_without_a_margin_produce_no_distance_plot(tmp_path: Path) -> None:
+    decisions = _decisions().drop(columns=["margin_to_all"])
+    assert plot_centroid_distances(decisions, tmp_path / "none.png") is None
+
+
+def test_nothing_to_plot_is_an_empty_list_not_an_error(tmp_path: Path) -> None:
+    assert plot_ancestry_diagnostics(None, None, str(tmp_path / "run"), None) == []
+
+
+def test_the_cohort_overlay_thins_as_the_cohort_grows() -> None:
+    """A 10k-sample overlay at a fixed alpha hides the reference underneath it,
+    which is the one thing the panel exists to show."""
+    from genotools.ancestry.plots import _cohort_style
+
+    small, large = _cohort_style(200), _cohort_style(10_000)
+    assert small["alpha"] > large["alpha"]
+    assert small["s"] > large["s"]
+    assert _cohort_style(10_000_000)["alpha"] >= 0.04
+    assert _cohort_style(1)["alpha"] <= 0.35

--- a/tests/unit/test_ancestry/test_preprocessing.py
+++ b/tests/unit/test_ancestry/test_preprocessing.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from .conftest import GOLDEN
 
@@ -101,39 +102,167 @@ def test_get_raw_files_train_golden(ref21_22_bfile, ref21_22_labels, geno21_22_p
         _sorted_df(res["raw_geno"]), pd.read_parquet(GOLDEN / "raw_geno_train.parquet"))
 
 
-def test_get_raw_files_inference_golden(ref21_22_bfile, ref21_22_labels, geno21_22_pfile, tmp_path):
-    """Inference-mode raw_geno matches golden; the np.repeat spy proves the
-    missing-column fill loop ran (chr22 excluded from the inference geno)."""
+@pytest.fixture(scope="module")
+def inference_inputs(ref21_22_bfile, ref21_22_labels, geno21_22_pfile, tmp_path_factory):
+    """A model SNP list plus a cohort missing chr22, so the fill path must run.
+
+    Module-scoped: the two PLINK stages behind it are the slow part of these
+    tests, and every fill-strategy test wants the same inputs.
+    """
     import shutil
-    from unittest.mock import patch
-    import genotools.ancestry.preprocessing as prep
     from genotools.ancestry.preprocessing import get_raw_files
     from genotools.core.executors import run_command, get_plink2
 
+    d = tmp_path_factory.mktemp("inference_inputs")
+
     # common_snps from a train run on the full (chr21+22) reduced geno
-    prep_dir = tmp_path / "prep"; prep_dir.mkdir()
+    prep_dir = d / "prep"; prep_dir.mkdir()
     train_res = get_raw_files(
         geno_path=str(geno21_22_pfile), ref_panel=str(ref21_22_bfile),
         ref_labels=str(ref21_22_labels), out_path=str(prep_dir / "out"), train=True)
-    common_snps_src = train_res["out_paths"]["common_snps"]
+    common_snps = d / "model.common_snps"
+    shutil.copy2(train_res["out_paths"]["common_snps"], common_snps)
 
     # inference geno MISSING chr22 -> ref chr22 common SNPs must be filled
-    subset_geno = tmp_path / "subset_geno"
+    subset_geno = d / "subset_geno"
     run_command(
         f"{get_plink2()} --pfile {geno21_22_pfile} --not-chr 22 "
         f"--make-pgen psam-cols=fid,parents,sex,pheno1,phenos --out {subset_geno}",
         tool_name="plink2")
+    return subset_geno, common_snps
 
-    nd = tmp_path / "new"; nd.mkdir()
-    shutil.copy2(common_snps_src, nd / "model.common_snps")
-    with patch.object(prep.np, "repeat", wraps=prep.np.repeat) as spy:
-        res = get_raw_files(
-            geno_path=str(subset_geno), ref_panel=str(ref21_22_bfile),
-            ref_labels=str(ref21_22_labels), out_path=str(nd / "out"), train=False,
-            common_snps_file=str(nd / "model.common_snps"))
-    assert spy.called, "missing-column fill loop was not exercised (degenerate test)"
-    pd.testing.assert_frame_equal(
-        _sorted_df(res["raw_geno"]), pd.read_parquet(GOLDEN / "raw_geno_inference.parquet"))
+
+def _run_inference(inputs, ref_bfile, ref_labels, out_dir, **kwargs):
+    from genotools.ancestry.preprocessing import get_raw_files
+
+    subset_geno, common_snps = inputs
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return get_raw_files(
+        geno_path=str(subset_geno), ref_panel=str(ref_bfile),
+        ref_labels=str(ref_labels), out_path=str(out_dir / "out"), train=False,
+        common_snps_file=str(common_snps), **kwargs)
+
+
+def _filled_columns(golden: pd.DataFrame) -> list:
+    """Columns the legacy golden filled with a constant 2 for every sample."""
+    numeric = golden.drop(columns=["FID", "IID", "label"])
+    return list(numeric.columns[(numeric == 2).all(axis=0)])
+
+
+def test_get_raw_files_inference_constant_fill_matches_golden(
+    inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path
+):
+    """`constant` reproduces the legacy fill exactly, int dtypes included.
+
+    The golden was captured against 1.x's `np.repeat(2, ...)`, so this is the
+    escape hatch's parity test. The overlap assertions keep it honest: without
+    them it could pass on a cohort that needed no fill at all.
+    """
+    res = _run_inference(
+        inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path / "constant",
+        fill_strategy="constant",
+    )
+    golden = pd.read_parquet(GOLDEN / "raw_geno_inference.parquet")
+    overlap = res["diagnostics"].snp_overlap
+    assert overlap.n_filled == len(_filled_columns(golden)) > 0
+    assert overlap.n_matched + overlap.n_filled == overlap.n_model_snps
+    pd.testing.assert_frame_equal(_sorted_df(res["raw_geno"]), golden)
+
+
+def test_get_raw_files_inference_defaults_to_ref_mean_fill(
+    inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path
+):
+    """The default leaves absent SNPs NaN for the reference-fitted imputer.
+
+    Dosage 2 is one end of the range applied identically to every sample, so a
+    cohort missing much of the model's SNP list gets a large shared offset in PC
+    space -- the mechanism behind an all-CAH prediction. NaN instead reaches
+    `PCAReducer.transform`'s imputer, which fills the reference panel's own mean
+    and so contributes nothing to the projection. Columns the cohort *did*
+    carry must be untouched by the change.
+    """
+    res = _run_inference(
+        inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path / "refmean",
+    )
+    raw = _sorted_df(res["raw_geno"])
+    golden = pd.read_parquet(GOLDEN / "raw_geno_inference.parquet")
+    filled = _filled_columns(golden)
+    assert filled, "fixture no longer exercises the fill path"
+
+    assert raw[filled].isna().all().all(), "absent SNPs should be NaN, not a dosage"
+    carried = [c for c in golden.columns if c not in set(filled)]
+    pd.testing.assert_frame_equal(raw[carried], golden[carried])
+
+    overlap = res["diagnostics"].snp_overlap
+    assert overlap.fill_strategy == "ref-mean"
+    assert overlap.n_filled == len(filled)
+    assert set(overlap.filled_snps) == set(filled)
+
+
+def test_get_raw_files_writes_filled_snp_ids(
+    inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path
+):
+    """The filled IDs are written where a user can read them."""
+    keep = tmp_path / "keep"; keep.mkdir()
+    res = _run_inference(
+        inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path / "run",
+        diagnostics_prefix=str(keep / "cohort"),
+    )
+    path = Path(res["diagnostics"].filled_snps_path)
+    assert path == keep / "cohort_filled_snps.txt"
+    written = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    assert written == list(res["diagnostics"].snp_overlap.filled_snps)
+
+
+def test_get_raw_files_refuses_a_mostly_filled_matrix(
+    inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path
+):
+    """Above the limit, prediction is refused rather than reported.
+
+    A label predicted from a feature matrix that is mostly fill describes the
+    fill. The message has to name the numbers and the override, because the
+    alternative -- what shipped before this round -- was a confident label.
+    """
+    from genotools.core.exceptions import AncestryError
+
+    with pytest.raises(AncestryError) as excinfo:
+        _run_inference(
+            inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path / "strict",
+            max_missing_fraction=0.01,
+        )
+    message = str(excinfo.value)
+    assert "of the model's" in message
+    assert "--ancestry-max-missing-snps" in message
+
+
+def test_get_raw_files_rejects_an_unknown_fill_strategy(
+    inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path
+):
+    from genotools.core.exceptions import AncestryError
+
+    with pytest.raises(AncestryError, match="Unknown fill strategy"):
+        _run_inference(
+            inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path / "bogus",
+            fill_strategy="zero",
+        )
+
+
+def test_get_raw_files_reports_allele_frequency_concordance(
+    inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path
+):
+    """Matched sites are compared to the panel before anything is filled.
+
+    Same data on both sides of the match, so agreement should be near-perfect;
+    the point is that the number exists and covers the matched SNPs only.
+    """
+    res = _run_inference(
+        inference_inputs, ref21_22_bfile, ref21_22_labels, tmp_path / "af",
+    )
+    concordance = res["diagnostics"].allele_frequency
+    overlap = res["diagnostics"].snp_overlap
+    assert concordance["n_snps"] == overlap.n_matched
+    assert concordance["correlation"] > 0.99
+    assert concordance["n_flip_signature"] == 0
 
 
 def test_clean_up_files_removes_extensions(tmp_path):

--- a/tests/unit/test_ancestry/test_reducers.py
+++ b/tests/unit/test_ancestry/test_reducers.py
@@ -333,3 +333,76 @@ class TestUMAPReducer:
         reducer = UMAPReducer()
         with pytest.raises(AncestryError, match="requires at least"):
             reducer.fit(data)
+
+
+class _RecordingReducer:
+    """Stands in for UMAPReducer, recording the feature width it is handed."""
+
+    widths: list = []
+
+    def fit(self, X: np.ndarray) -> "_RecordingReducer":
+        self.widths.append(("fit", X.shape[1]))
+        return self
+
+    def transform(self, X: np.ndarray, return_dataframe: bool = False):
+        self.widths.append(("transform", X.shape[1]))
+        frame = pd.DataFrame(np.asarray(X)[:, :2], columns=["UMAP1", "UMAP2"])
+        return frame if return_dataframe else frame.values
+
+    @classmethod
+    def from_params(cls, params: Any) -> "_RecordingReducer":
+        return cls()
+
+
+def _pca_frame(n: int = 6, label: str = "EUR") -> pd.DataFrame:
+    frame = pd.DataFrame({
+        "FID": [f"S{i}" for i in range(n)],
+        "IID": [f"S{i}" for i in range(n)],
+        "PC1": np.linspace(0, 1, n),
+        "PC2": np.linspace(1, 0, n),
+        "PC3": np.linspace(0, 2, n),
+        "label": [label] * n,
+    })
+    return frame
+
+
+def test_run_umap_embeds_the_pcs_and_nothing_else(monkeypatch):
+    """An extra column in the projected frame must not enter the embedding.
+
+    `run_umap` used to select features by dropping FID/IID/label, so anything
+    else written into `_projected_new_pca.txt` became a feature and moved every
+    point -- silently, since UMAP accepts any width. Diagnostics write per-sample
+    distances now, which is exactly the column that would have leaked in.
+    """
+    from genotools.ancestry.reducers import umap_reducer
+
+    _RecordingReducer.widths = []
+    monkeypatch.setattr(umap_reducer, "UMAPReducer", _RecordingReducer)
+
+    new_pca = _pca_frame()
+    new_pca["dist_to_all"] = 42.0
+    new_pca["label_pre_admixture"] = "AFR"
+
+    result = umap_reducer.run_umap(
+        ref_pca=_pca_frame(),
+        new_pca=new_pca,
+        new_labels=new_pca["label"],
+    )
+
+    assert {width for _, width in _RecordingReducer.widths} == {3}
+    assert list(result["new_umap"].columns) == ["UMAP1", "UMAP2", "label", "dataset"]
+
+
+def test_run_umap_falls_back_when_components_are_not_named_pc(monkeypatch):
+    """A frame naming its components something else still embeds them all."""
+    from genotools.ancestry.reducers import umap_reducer
+
+    _RecordingReducer.widths = []
+    monkeypatch.setattr(umap_reducer, "UMAPReducer", _RecordingReducer)
+
+    frame = pd.DataFrame({
+        "FID": ["a", "b", "c"], "IID": ["a", "b", "c"],
+        "C1": [0.0, 1.0, 2.0], "C2": [2.0, 1.0, 0.0], "label": ["EUR"] * 3,
+    })
+    umap_reducer.run_umap(ref_pca=frame, new_pca=frame.copy(), new_labels=frame["label"])
+    assert {width for _, width in _RecordingReducer.widths} == {2}

--- a/tests/unit/test_cli/test_parser.py
+++ b/tests/unit/test_cli/test_parser.py
@@ -1166,3 +1166,111 @@ class TestInvocationRecorded:
             input=InputArgs(pfile=Path("/tmp/geno")),
             output=OutputArgs(out_path=Path("/tmp/out")),
         ).invocation is None
+
+
+class TestAncestryDiagnosticArgs:
+    """The prediction-path controls, at the dataclass layer.
+
+    The interesting cases are the two the validation exists for: a value the
+    preprocessing could not act on, and a flag passed to a run that has no
+    prediction to apply it to.
+    """
+
+    def test_defaults_are_the_measured_path(self) -> None:
+        args = AncestryArgs()
+        assert args.detect_admixed is True
+        assert args.missing_fill == "ref-mean"
+        assert args.max_missing_snps == 0.5
+        assert args.write_plots is False
+        assert args.self_test is False
+        assert args.diagnostic_flags_set() == []
+
+    def test_an_unknown_fill_strategy_names_the_alternatives(self) -> None:
+        with pytest.raises(ValueError, match="ref-mean, constant"):
+            AncestryArgs(missing_fill="zero")
+
+    @pytest.mark.parametrize("value", [-0.1, 1.5])
+    def test_the_missing_snp_limit_must_be_a_fraction(self, value: float) -> None:
+        with pytest.raises(ValueError, match="fraction in \\[0, 1\\]"):
+            AncestryArgs(max_missing_snps=value)
+
+    def test_a_fraction_of_zero_or_one_is_allowed(self) -> None:
+        assert AncestryArgs(max_missing_snps=0.0).max_missing_snps == 0.0
+        assert AncestryArgs(max_missing_snps=1.0).max_missing_snps == 1.0
+
+    def test_each_non_default_setting_is_reported_by_its_flag(self) -> None:
+        assert AncestryArgs(detect_admixed=False).diagnostic_flags_set() == [
+            "--no-admixture-detection"
+        ]
+        assert AncestryArgs(missing_fill="constant").diagnostic_flags_set() == [
+            "--ancestry-missing-fill"
+        ]
+        assert AncestryArgs(self_test=True, write_plots=True).diagnostic_flags_set() == [
+            "--ancestry-plots", "--ancestry-self-test"
+        ]
+
+    def test_a_diagnostic_flag_without_ancestry_is_refused(self) -> None:
+        """The --amr-het rule: refuse a setting rather than ignore it."""
+        with pytest.raises(ValueError, match="--ancestry-plots requires --ancestry"):
+            PipelineArgs(
+                input=InputArgs(pfile=Path("/tmp/geno")),
+                output=OutputArgs(out_path=Path("/tmp/out")),
+                ancestry=AncestryArgs(write_plots=True),
+            )
+
+    def test_the_same_flags_are_fine_alongside_ancestry(self) -> None:
+        args = PipelineArgs(
+            input=InputArgs(pfile=Path("/tmp/geno")),
+            output=OutputArgs(out_path=Path("/tmp/out")),
+            ancestry=AncestryArgs(
+                run_ancestry=True, write_plots=True, detect_admixed=False
+            ),
+        )
+        assert args.ancestry.write_plots is True
+
+
+class TestAncestryDiagnosticFlagsEndToEnd:
+    """The same settings through parse_args, the layer users reach."""
+
+    BASE = [
+        "--pfile", "/data/test",
+        "--out", "/tmp/out",
+        "--ancestry",
+        "--ref-panel", "/tmp/ref",
+        "--ref-labels", "/tmp/lab",
+    ]
+
+    def _ancestry(self, extra: List[str]):
+        return parse_args(self.BASE + extra).ancestry
+
+    def test_defaults_measure_but_change_nothing_the_user_did_not_ask_for(self) -> None:
+        ancestry = self._ancestry([])
+        assert ancestry.detect_admixed is True
+        assert ancestry.write_plots is False
+        assert ancestry.self_test is False
+        assert ancestry.missing_fill == "ref-mean"
+
+    def test_admixture_detection_is_turned_off_by_the_negative_flag(self) -> None:
+        assert self._ancestry(["--no-admixture-detection"]).detect_admixed is False
+
+    def test_the_legacy_fill_is_reachable(self) -> None:
+        assert self._ancestry(["--ancestry-missing-fill", "constant"]).missing_fill == (
+            "constant"
+        )
+
+    def test_an_unknown_fill_is_rejected_by_the_parser(self) -> None:
+        with pytest.raises(SystemExit):
+            self._ancestry(["--ancestry-missing-fill", "zero"])
+
+    def test_the_missing_snp_limit_is_a_float(self) -> None:
+        assert self._ancestry(["--ancestry-max-missing-snps", "0.9"]).max_missing_snps == 0.9
+
+    def test_plots_and_self_test_are_opt_in(self) -> None:
+        ancestry = self._ancestry(["--ancestry-plots", "--ancestry-self-test"])
+        assert (ancestry.write_plots, ancestry.self_test) == (True, True)
+
+    def test_a_diagnostic_flag_without_ancestry_fails_the_whole_parse(self) -> None:
+        with pytest.raises(ValueError, match="requires --ancestry"):
+            parse_args([
+                "--pfile", "/data/test", "--out", "/tmp/out", "--ancestry-self-test",
+            ])

--- a/tests/unit/test_cli/test_runner_regression.py
+++ b/tests/unit/test_cli/test_runner_regression.py
@@ -20,6 +20,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import pandas as pd
 import pytest
 
 from genotools.core.exceptions import QCError, ValidationError
@@ -1957,3 +1958,273 @@ class TestSoftwareProvenance:
             "provenance leaked into the console stream"
         )
         assert "plink2:" in Path(f"{out}_all_logs.log").read_text()
+
+
+# ---------------------------------------------------------------------------
+# Ancestry diagnostics wiring
+# ---------------------------------------------------------------------------
+
+
+class _StubAncestryModel:
+    """Stands in for AncestryModel across both prediction modes.
+
+    Records what the runner asked for, and writes the two files the runner
+    reads back off disk (`_labeled_ref_pca.txt` from `fit`, and
+    `_projected_new_pca.txt` from `predict`).
+    """
+
+    predict_calls: List[Dict[str, Any]] = []
+    self_test_calls: List[Dict[str, Any]] = []
+
+    def __init__(self) -> None:
+        self.best_params = None
+        self.common_snps = ["rs1", "rs2"]
+        self.label_encoder = None
+        self.training_metrics = None
+        self._train_pca = _pc_frame()
+
+    @classmethod
+    def load(cls, path: Path) -> "_StubAncestryModel":
+        return cls()
+
+    def fit(self, ref_data, labels, out_path=None):
+        if out_path is not None:
+            _pc_frame().to_csv(f"{out_path}_labeled_ref_pca.txt", sep="\t", index=False)
+        return self
+
+    def save(self, path: Path) -> Path:
+        return Path(path)
+
+    def predict(self, geno_data, geno_ids, out_path=None, detect_admixed=True,
+                diagnostics=None, diagnostics_prefix=None, collect_diagnostics=True):
+        from genotools.ancestry.results import AncestryPredictions
+
+        type(self).predict_calls.append({
+            "detect_admixed": detect_admixed,
+            "diagnostics": diagnostics,
+            "diagnostics_prefix": diagnostics_prefix,
+        })
+        if out_path is not None:
+            _pc_frame().to_csv(f"{out_path}_projected_new_pca.txt", sep="\t", index=False)
+            Path(f"{out_path}_umap_linearsvc_predicted_labels.txt").write_text(
+                "FID\tIID\tlabel\nF0\tI0\tEUR\n"
+            )
+        predictions = pd.DataFrame({
+            "FID": ["F0"], "IID": ["I0"], "predicted_ancestry": ["EUR"]
+        })
+        if diagnostics is not None:
+            diagnostics.pc_drift = pd.DataFrame([{"pc": "PC1", "shift_sd": 0.1}])
+        return AncestryPredictions(predictions=predictions, decisions=_decision_frame())
+
+    def self_test(self, labeled_ref_data, detect_admixed=True):
+        type(self).self_test_calls.append({"detect_admixed": detect_admixed})
+        return {"n_samples": len(labeled_ref_data), "cah_fraction": 0.0}
+
+
+def _pc_frame() -> "pd.DataFrame":
+    return pd.DataFrame({
+        "FID": ["F0", "F1"], "IID": ["I0", "I1"],
+        "PC1": [0.1, 0.2], "PC2": [0.3, 0.4], "label": ["EUR", "AFR"],
+    })
+
+
+def _decision_frame() -> "pd.DataFrame":
+    return pd.DataFrame({
+        "FID": ["F0"], "IID": ["I0"], "label_pre_admixture": ["EUR"],
+        "label": ["EUR"], "margin_to_all": [1.0],
+    })
+
+
+class TestAncestryDiagnosticsWiring:
+    """The diagnostic settings have to reach preprocessing and prediction in
+    *both* prediction modes.
+
+    Training and inference are separate methods that each call `get_raw_files`
+    and `predict` with their own argument lists, which is the shape that made
+    `--amr-het` inert in production: a setting honoured on one path and
+    forgotten on the other looks like it works right up until the run that
+    matters. Every assertion here is made twice, once per mode.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset(self) -> None:
+        _StubAncestryModel.predict_calls = []
+        _StubAncestryModel.self_test_calls = []
+
+    def _run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        ancestry: AncestryArgs, **stub_overrides: Any,
+    ) -> Dict[str, Any]:
+        import genotools.ancestry.cohort as cohort_mod
+        import genotools.ancestry.plots as plots_mod
+        import genotools.ancestry.preprocessing as prep_mod
+        import genotools.ancestry.reducers.umap_reducer as umap_mod
+
+        geno = tmp_path / "geno"
+        out = tmp_path / "out"
+        _touch_pfiles(geno)
+        work = tmp_path / "tmpwork"
+        work.mkdir(exist_ok=True)
+
+        args = PipelineArgs(
+            input=InputArgs(pfile=geno),
+            output=OutputArgs(out_path=out, full_output=False),
+            ancestry=ancestry,
+        )
+        runner = PipelineRunner(args)
+        runner.state = PipelineState(
+            geno_path=geno, out_path=out, tmp_dir=_StubTmpDir(work)
+        )
+        runner._initialize_modules()
+        runner._new_modules["AncestryModel"] = _StubAncestryModel
+
+        raw_calls: List[Dict[str, Any]] = []
+
+        def fake_get_raw_files(**kwargs: Any) -> Dict[str, Any]:
+            raw_calls.append(kwargs)
+            ref = pd.DataFrame({
+                "FID": ["F0"], "IID": ["I0"], "rs1": [1.0], "label": ["EUR"]
+            })
+            return {
+                "raw_ref": ref,
+                "raw_geno": pd.DataFrame({
+                    "FID": ["F0"], "IID": ["I0"], "rs1": [1.0], "label": ["new"]
+                }),
+                "out_paths": {"common_snps": str(tmp_path / "snps.txt")},
+                "diagnostics": kwargs["diagnostics"],
+            }
+
+        plot_calls: List[Dict[str, Any]] = []
+
+        monkeypatch.setattr(prep_mod, "get_raw_files", fake_get_raw_files)
+        monkeypatch.setattr(prep_mod, "clean_up_files", lambda files: None)
+        monkeypatch.setattr(
+            plots_mod, "plot_ancestry_diagnostics",
+            lambda **kwargs: (plot_calls.append(kwargs), ["/tmp/plot.png"])[1],
+        )
+        monkeypatch.setattr(
+            umap_mod, "run_umap",
+            lambda **kwargs: {"total_umap": None, "ref_umap": None, "new_umap": None},
+        )
+        monkeypatch.setattr(
+            cohort_mod, "split_cohort_by_ancestry",
+            lambda **kwargs: {
+                "labels": ["EUR"], "pruned_samples": pd.DataFrame(), "paths": {}
+            },
+        )
+
+        result = runner._run_ancestry_prediction_new()
+        return {
+            "result": result,
+            "raw_calls": raw_calls,
+            "plot_calls": plot_calls,
+            "out": out,
+        }
+
+    def _ancestry_args(self, tmp_path: Path, mode: str, **kwargs: Any) -> AncestryArgs:
+        model_path = None
+        if mode == "inference":
+            model_path = tmp_path / "model"
+            model_path.mkdir(exist_ok=True)
+        return AncestryArgs(
+            run_ancestry=True,
+            ref_panel=tmp_path / "ref",
+            ref_labels=tmp_path / "labels",
+            model_path=model_path,
+            **kwargs,
+        )
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_fill_settings_reach_preprocessing_in_both_modes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        run = self._run(
+            tmp_path, monkeypatch,
+            self._ancestry_args(
+                tmp_path, mode, missing_fill="constant", max_missing_snps=0.9
+            ),
+        )
+        (call,) = run["raw_calls"]
+        assert call["fill_strategy"] == "constant"
+        assert call["max_missing_fraction"] == 0.9
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_admixture_detection_setting_reaches_predict_in_both_modes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        self._run(
+            tmp_path, monkeypatch,
+            self._ancestry_args(tmp_path, mode, detect_admixed=False),
+        )
+        (call,) = _StubAncestryModel.predict_calls
+        assert call["detect_admixed"] is False
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_diagnostic_artifacts_are_written_outside_the_temp_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        """A partial-output run deletes its temp directory, and with it any
+        evidence written beside the intermediates. The prefix handed to both
+        layers has to be the final output path instead."""
+        run = self._run(tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode))
+        expected = str(run["out"])
+        assert run["raw_calls"][0]["diagnostics_prefix"] == expected
+        assert _StubAncestryModel.predict_calls[0]["diagnostics_prefix"] == expected
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_one_collector_is_shared_by_preprocessing_and_prediction(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        run = self._run(tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode))
+        assert (
+            run["raw_calls"][0]["diagnostics"]
+            is _StubAncestryModel.predict_calls[0]["diagnostics"]
+        )
+        assert run["result"]["diagnostics"]["pc_drift"]["pc"] == ["PC1"]
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_the_self_test_is_opt_in(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        self._run(tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode))
+        assert _StubAncestryModel.self_test_calls == []
+
+        self._run(
+            tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode, self_test=True)
+        )
+        assert len(_StubAncestryModel.self_test_calls) == 1
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_the_self_test_result_reaches_the_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        run = self._run(
+            tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode, self_test=True)
+        )
+        assert run["result"]["diagnostics"]["self_test"]["n_samples"] == 1
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_plots_are_opt_in_and_get_the_decisions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        run = self._run(tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode))
+        assert run["plot_calls"] == []
+
+        run = self._run(
+            tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode, write_plots=True)
+        )
+        (call,) = run["plot_calls"]
+        assert call["out_prefix"] == str(run["out"])
+        assert list(call["decisions"]["label_pre_admixture"]) == ["EUR"]
+        assert run["result"]["diagnostics"]["plots"] == ["/tmp/plot.png"]
+
+    @pytest.mark.parametrize("mode", ["training", "inference"])
+    def test_diagnostics_reach_the_json_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        from genotools.cli.output import PipelineOutput
+
+        run = self._run(tmp_path, monkeypatch, self._ancestry_args(tmp_path, mode))
+        output = PipelineOutput()
+        output._process_ancestry_result(run["result"])
+        assert "ancestry_diagnostics" in output.to_dict()


### PR DESCRIPTION
## Summary

Prompted by a report from outside this repo: a team training an ancestry model
on long-read sequencing got high test accuracy and then `CAH` for **every**
sample in their cohort. Nothing in the run said why. This round makes the
prediction path answer questions about itself, and fixes the silent step that
caused it.

**Where the asymmetry is.** Training accuracy is measured on reference samples
built by the *training* branch of `get_raw_files`. A cohort goes through the
*inference* branch, which has to align itself to a saved model's SNP list —
so only the inference branch can fail at alignment, and nothing downstream
could see that it had:

```
absent model SNP -> filled with dosage 2 for every sample
                 -> identical large offset for every sample after ref-fitted scaling
                 -> cohort collapses to one point off the reference manifold
                 -> nearest centroid is the global one
                 -> CAH, for everybody, from a model with 0.98 test accuracy
```

`missing_cols += [pd.Series(np.repeat(2, ...))]` (1.x, carried into 2.0) was the
first link, and it was **silent** — no count, no warning, no report field.
Dosage 2 is not a neutral filler: it is one end of the range applied
identically to every sample, which produces a shared offset rather than noise.

## Behaviour change: absent model SNPs are no longer filled with dosage 2

**This can change ancestry calls a lot, but only for a cohort that was already
being predicted badly.** Full note in `MIGRATION_2.0.md`.

The fill is now a missing value, which `PCAReducer.transform`'s imputer —
fitted on the reference panel — replaces with that SNP's panel mean. This is
not a new convention: `plink2 --recode A` already writes `NA` for a genuinely
missing call at a SNP the cohort *does* carry, and those NaNs already reached
the same imputer. The old code was inconsistent with the matrix it was filling.

- A cohort that matched the model's SNPs well **barely moves** — the filled
  columns were a small part of the matrix and now sit at the panel mean.
- A cohort that matched badly **may move a great deal.** That is the fix, not a
  regression: the old labels for such a cohort were describing the fill.
- Above 50% filled, prediction is **refused** rather than reported, naming the
  counts and the likely cause (`--ancestry-max-missing-snps`).

`--ancestry-missing-fill constant` restores the old behaviour exactly, int
dtypes included, and is pinned by the legacy golden. **Existing models are not
invalidated** — the model is untouched; this is entirely about the matrix handed
to it at prediction time.

## Eight instruments, in the order a failing run should be read

All on by default, all landing in the log and in the report's new
`ancestry_diagnostics` section.

| Instrument | Question it settles |
|---|---|
| `SnpOverlapReport` | How much of the model's SNP list did the cohort actually carry? >5% filled warns, >50% refuses; filled IDs go to `{out}_filled_snps.txt` |
| `bim_compatibility` | When a match comes back near-empty, do the two files even share a coordinate space? Names `chr1`-vs-`1` and hg19-vs-hg38 outright; zero overlap now raises instead of failing inside `plink2 --extract` |
| `allele_frequency_concordance` | Do matched sites agree with the panel on frequency, or is a swap-signature population sitting near `1 - ref_freq`? |
| `pc_drift` | Where did the cohort land, in reference SD? A centroid 40 SD out, or a spread ratio near zero, is a feature-matrix problem, not ancestry |
| `admixture_summary` | What did the classifier say *before* the `CAH` override replaced it? |
| `--no-admixture-detection` | The same question by experiment |
| `self_test` | Can the model still recover the reference panel's own labels through the prediction path? |
| `--ancestry-plots` | The two pictures worth having once the numbers have narrowed it |

**The override was the other silent step.** `_predict_admixed` overwrote the
classifier's label and discarded it, so an all-`CAH` run was indistinguishable
from a broken classifier. It now returns a per-sample decision frame — both
labels, every centroid distance, and `margin_to_all`, which restates the rule
as one signed number (negative is `CAH`) — written to `{out}_decisions.txt`. A
spread of pre-override labels under a uniform `CAH` result localizes the fault
to the override or the projection in one line of the log.

`self_test` is the measurement that splits the two hypotheses the reporting
team could not. Its accuracy is optimistic by construction — most of those
samples were fitted on — so the load-bearing number is the panel's own `CAH`
rate: the panel *defines* the ancestry centroids, so a panel coming back
largely `CAH` indicts the override or the projection regardless of what the
cohort looks like, and a panel that predicts itself correctly leaves only the
cohort's preprocessing to blame.

### New flags

`--ancestry-missing-fill`, `--ancestry-max-missing-snps`, `--ancestry-plots`,
`--ancestry-self-test`, `--no-admixture-detection`. Documented in
`docs/cli_args.md`; the behaviour change is in `MIGRATION_2.0.md`.

### A trap found on the way in

`run_umap` selected its features by *dropping* `FID`/`IID`/`label`, so anything
else in `_projected_new_pca.txt` became a UMAP feature — silently, since UMAP
accepts any width. Writing per-sample distances into that file, the obvious
first design, would have moved every point in the embedding. Diagnostics went
to their own file instead, and `run_umap` now selects `PC*` by name with a
fallback for frames that name their components otherwise.

Diagnostic artifacts are written to the **final** output prefix rather than
beside the intermediates, because a run without `--full-output` deletes the
directory the intermediates live in — and the evidence is worth more than the
matrix it came from.

## Test plan

- `pytest tests/unit -q` — 786 passing.
- `pytest tests/regression -q` — 77 passing, including the 8 old-vs-new parity
  tests against genotools 1.3.6.
- **Both prediction modes, or neither.** `_run_training_mode` and
  `_run_inference_mode` each call `get_raw_files` and `predict` with their own
  argument lists — the `--amr-het` shape, where a setting honoured on one path
  and forgotten on the other works right up until the run that matters. Every
  wiring test is parameterized over both modes, and the revert-check confirms
  the parameterization is what catches it: dropping the fill settings from the
  inference branch fails only `[inference]`; hardcoding `detect_admixed=True`
  in the training branch fails only `[training]`.
- `tests/scripts/compare_missing_fill.py` — the third single-variable
  comparator after rounds 16 and 17, and the first needing neither a second
  venv nor a second checkout: both strategies are reachable from one tree, so
  it holds the model, the reference PCA and the libraries constant in a single
  process and varies only the value written into the columns the cohort could
  not supply.

**What the fill change costs, measured.** On the 10k GP2 subset with the saved
parity model:

```
  cohort matched 43173/43173 model SNPs (100.00%); 0 filled
  fill: constant -> ref-mean   0 of 10,000 calls moved (0.000%)
```

The exposure is **zero** — this cohort carries the model's entire SNP list — so
the change is provably a no-op here and cannot move a call. Same shape of
argument as round 17's palindrome exclusion: it lands without revalidation
because the data in use is not exposed to it, and the cohort that *is* exposed
is exactly the one whose old labels were describing fill.

**The same run calibrates the thresholds, which is worth more than the parity
result.** A healthy real cohort against this panel looks like:

| Instrument | Healthy value here | Warns at |
|---|---|---|
| SNP overlap | 43,173 / 43,173 (100.00%) | < 95%, refuses > 50% filled |
| Allele-frequency concordance | r = 0.9516, 2 of 43,173 discordant, **0** swap signatures | r < 0.7, > 1% swap |
| PC drift (PC1–PC10) | shift 0.01–0.92 SD, spread ratio 0.25–0.93 | > 5 SD, ratio outside 0.1–10 |
| CAH rate | 135 of 10,000 (**1.35%**) | > 50% |
| Self-test | 4,008 panel samples, balanced accuracy **0.9471** (0.9565 before the override), **0.92%** CAH | accuracy < 0.5, or CAH > 50% |

Every instrument sits an order of magnitude inside its threshold on real data.
End-to-end:

```
genotools --pfile GP2_r12_subset10k --ancestry --model <parity model> \
          --ref-panel <panel> --ref-labels <labels> \
          --ancestry-plots --ancestry-self-test
```

Everything landed: overlap, drift table, self-test and override summary in the
log; `ancestry_diagnostics` in the report; `{out}_decisions.txt` (10,000 rows,
20 columns) and both PNGs at the final prefix, outliving the temp directory. No
diagnostic fired a warning, which is the correct result for this cohort.

The override summary is the line worth showing, because it was previously
impossible to obtain:

```
Admixture detection: 135/10000 labeled CAH; classifier labels before the
override: {'EUR': 6932, 'EAS': 769, 'AFR': 608, 'AJ': 399, 'AMR': 380,
'CAS': 313, 'MDE': 303, 'AAC': 161, 'SAS': 122, 'FIN': 13}
```

On a healthy run it is unremarkable — `AMR` 380 → 344, `CAS` 313 → 271,
`AAC` 161 → 113. On the run that prompted the round it would have read
`{'EUR': ..., 'AFR': ..., 'EAS': ...}` under an all-`CAH` result, which
localizes the fault in one line.

## Notes for reviewers

- **`ancestry_diagnostics` has no golden.** The regression goldens cover no
  ancestry run at all (`tests/scripts/generate_golden.py` has no ancestry
  generator), so the new report section's shape is pinned only by unit tests
  against a hand-built result dict. That is also why this round needed no
  golden regeneration — and why a change to that section's shape would not be
  caught.
- **The thresholds are reasoned, not calibrated.** 5 reference SD of PC shift,
  a 0.1–10× spread ratio, 50% CAH, r < 0.7, 1% swap signature were each derived
  from the mechanism they detect, not from a distribution of real runs. They
  are only warnings — except the 50%-filled refusal, which is the one with
  teeth, and where a false positive on a legitimately unusual cohort costs
  trust in all of them. Worth recalibrating once a handful of real cohorts have
  been through.
- **The self-test measures a floor, not accuracy.** It predicts the whole
  reference panel, most of which the model was fitted on, so its balanced
  accuracy is optimistic by construction and only its *failure* is
  informative. The honest version would push the model's own held-out test
  split through `predict`, which means recording those sample IDs onto the
  model at `fit` time — a model-format change, so deferred.
- **Training mode has no overlap report**, and a width mismatch crashes it
- **Training mode has no overlap report**, and a width mismatch crashes it
  rather than reporting. This round instrumented only the inference branch;
  the training branch does not reindex the cohort matrix to the reference's
  columns at all, assuming two `get_common_snps` calls produced the same
  width. Not observed on real data.
- **Merge order:** this should land *before* `fix/ancestry-fit-determinism`
  (#260, round 19). That branch reserves `REFACTOR.md` items 27–30 for this
  round and its round entry goes 17 → 19, so merging it first leaves a
  permanent hole in the numbering and a dangling cross-reference. The two are
  independent in code — round 19 adds `ancestry/fit_validation.py` and imports
  nothing from `diagnostics.py`.